### PR TITLE
docs: rewrite README and add Agent skill reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,149 @@
 # Cueward
 
-> **Cue**: A signal, hint, or piece of information waiting to be processed (from browsing history, notes, messages, etc.).
-> **Ward**: To guard, manage, and watch over. 
-> Cueward captures these scattered signals and hands them over to an Agent to determine the next actionable step.
+A CLI tool that captures scattered knowledge from macOS native sources and makes it searchable.
 
-## Vision
+Cueward reads Safari history, Apple Notes, and iMessage locally — no cloud APIs, no web scraping, no third-party dependencies. It auto-tags content using keyword rules and indexes everything for fast BM25 search.
 
-Modern knowledge workers suffer from information fragmentation. Insights are scattered across devices and applications—Safari bookmarks, Apple Notes drafts, iMessage links, and Calendar events. 
+Designed as a Unix-style tool: it outputs structured JSON for AI Agents to consume.
 
-**Cueward** is not another note-taking app. It is a CLI-based Agent tool focused strictly on **Capture** and **Triage**. 
+## Install
 
-Its core mission is to **converge daily knowledge accumulation**. By utilizing native system APIs (e.g., macOS AppleScript, local SQLite databases, Vision Framework), Cueward silently gathers the raw materials of your day, passes them to an AI Agent for summarization and tagging, and transforms digital clutter into structured, actionable intelligence.
+```bash
+git clone https://github.com/HCYT/cueward.git
+cd cueward
+cargo install --path crates/cli
+```
 
-## Core Commands
+Requires Rust 1.85+ (edition 2024).
 
-Cueward focuses on turning captured cues into tangible next steps:
+### macOS Permissions
 
-*   `cueward capture`: Proactively scans and extracts knowledge fragments from targeted applications (browser history, notes, messages) within a specific timeframe.
-*   `cueward triage`: Categorizes, summarizes, and automatically tags captured cues, routing them back into designated smart folders or archives.
-*   `cueward plan`: Analyzes cues for time-sensitive tasks or events, automatically scheduling them in Calendar or creating Reminders.
-*   `cueward send`: Dispatches the processed knowledge or actions (e.g., compiling a daily digest note, or triggering a native GUI notification like a Dynamic Island pop-up).
+Cueward reads local databases that require Full Disk Access:
+
+1. Open **System Settings > Privacy & Security > Full Disk Access**
+2. Add your terminal app (Terminal.app, iTerm2, WezTerm, etc.)
+
+For Apple Notes capture, also allow automation:
+- **System Settings > Privacy & Security > Automation** > allow your terminal to control Notes
+
+## Usage
+
+### Capture
+
+Extract knowledge fragments from local sources:
+
+```bash
+# Everything from the last 24 hours
+cueward capture --source all --since 24h
+
+# Safari only, last 7 days
+cueward capture --source safari --since 7d
+
+# Apple Notes, last 3 hours
+cueward capture --source notes --since 3h
+```
+
+Outputs JSON to stdout:
+
+```json
+[
+  {
+    "source": "safari",
+    "timestamp": "2026-04-07T03:14:16Z",
+    "content": "Rust Concurrency Patterns - Blog",
+    "url": "https://example.com/rust-concurrency",
+    "title": "Rust Concurrency Patterns - Blog"
+  },
+  {
+    "source": "notes",
+    "timestamp": "2026-04-07T01:16:16Z",
+    "content": "Meeting notes from product sync...",
+    "title": "Product Sync 2026-04-07",
+    "metadata": {
+      "folder": "Work"
+    }
+  }
+]
+```
+
+### Triage
+
+Auto-tag and index captured cues:
+
+```bash
+cueward triage
+```
+
+Reads from `~/.cueward/inbox/`, applies keyword-based auto-tagging, and writes to a local BM25 index.
+
+Configure auto-tagging in `~/.cueward/tags.toml`:
+
+```toml
+[rust]
+keywords = ["Rust", "cargo", "crate", "rustc"]
+
+[ai]
+keywords = ["AI", "LLM", "ChatGPT", "Claude", "GPT"]
+
+[finance]
+keywords = ["stock", "ETF", "investment"]
+```
+
+### Search
+
+Query the local index:
+
+```bash
+cueward search "rust concurrency" --limit 5
+```
+
+## Agent Integration
+
+Cueward outputs structured JSON — it does not call any LLM. The LLM layer is your Agent's responsibility.
+
+### Pipe to an Agent
+
+```bash
+# Claude Code
+cueward capture --source all --since 24h | claude --print "Summarize my knowledge intake today"
+
+# Gemini CLI
+cueward capture --source all --since 24h | gemini "Group these by topic and highlight action items"
+```
+
+### As a Skill
+
+A reference skill for Claude Code is included in `skills/cueward-agent/`. Copy it to your skills directory to teach Claude how to use Cueward automatically:
+
+```bash
+cp -r skills/cueward-agent ~/.claude/skills/
+```
 
 ## Architecture
 
-To ensure long-term viability and potential cross-platform support (e.g., future Windows integration with Edge/Chrome and To Do), Cueward adopts a **Core Engine + Adapter Pattern** architecture:
+```
+crates/
+├── core/            Cue struct, PlatformAdapter trait, BM25 index, auto-tagger
+├── cli/             clap CLI (capture, triage, search)
+├── adapter-macos/   Safari (SQLite), Notes (AppleScript), Messages (SQLite)
+└── adapter-windows/ Reserved for future cross-platform support
+```
 
-1.  **Core Engine (Rust)**: Handles CLI parsing, defines the unified `Cue` data structure, and manages LLM (Agent) interaction logic.
-2.  **Platform Adapters**:
-    *   **`macos-adapter` (MVP)**: Deeply integrates with the Apple ecosystem using native capabilities (AppleScript, `History.db`, `chat.db`, Vision OCR).
-    *   **`windows-adapter` (Future)**: Provides interfaces for future Windows support via native APIs.
+- **Core Engine + Adapter Pattern**: Platform-specific code is isolated in adapters. Core logic is platform-agnostic.
+- **Native First**: Direct SQLite reads and AppleScript. No web scraping, no browser automation.
+- **Privacy**: All data extraction happens locally. Nothing leaves your machine.
 
-## Technical Taste
+## Data Storage
 
--   **Native First**: Zero reliance on bloated third-party libraries or fragile web scrapers. If SQLite is accessible, read it. If not, use AppleScript. If the window is opaque, use native OCR.
--   **Privacy Centric**: All data extraction (including Safari history and iMessages) is performed entirely on the local machine.
--   **Elegant Feedback**: Goes beyond terminal standard output. Background tasks can trigger low-level macOS GUI components (like a borderless notch animation) for tasteful, non-intrusive visual feedback.
+```
+~/.cueward/
+├── inbox/        Captured cues awaiting triage
+├── processed/    Triaged cues (moved from inbox)
+├── index/        Tantivy BM25 search index
+├── state.json    High watermark timestamps per source
+└── tags.toml     Auto-tagging keyword rules (user-created)
+```
 
----
+## License
 
-# Cueward (中文版)
-
-> **Cue (線索、提示)**: 捕捉來自瀏覽紀錄、備忘錄、訊息等各處的待處理訊號。
-> **Ward (守望、代管)**: 像管家一樣，將這些混亂的線索妥善收斂，交給 Agent 轉化為具體的下一步。
-
-## 專案願景
-
-現代知識工作者深受資訊碎片化所苦。靈感與資料散落在各個裝置與應用程式中——Safari 的瀏覽紀錄、Apple Notes 的草稿、iMessage 裡的連結，以及行事曆的排程。
-
-**Cueward** 不是另一個筆記軟體，而是一個專注於 **「捕捉 (Capture)」與「收斂 (Triage)」** 的 CLI Agent 工具。
-
-它的核心任務是：**每天幫忙收斂知識累積**。
-透過呼叫本地原生 API（如 macOS 的 AppleScript、SQLite 資料庫、Vision Framework），Cueward 能在背景匯集你一整天的資訊碎片，交由 AI Agent 進行摘要、打標籤與建立待辦，讓知識不再淪為數位垃圾。
-
-## 核心指令
-
-Cueward 強調「將捕捉到的 Cue 轉化為行動」的實際行為：
-
-*   `cueward capture`：主動掃描並捕捉指定時間範圍內，散落在各應用程式（瀏覽器、備忘錄、訊息）中的知識碎片與訊號。
-*   `cueward triage`：對捕捉到的 Cue 進行分類、摘要，並自動打上標籤，歸檔回對應的智慧型資料夾或知識庫。
-*   `cueward plan`：分析 Cue 中的待辦事項與時間點，自動在行事曆排程或新增提醒事項。
-*   `cueward send`：將收斂完成的知識或行動結果發送出去（例如：建立一則統整筆記，或透過系統原生的浮動 UI 給予通知）。
-
-## 系統架構
-
-為了長期的跨平台發展潛力（例如未來支援 Windows 系統），Cueward 採用 **「核心引擎 + 平台適配器 (Adapter Pattern)」** 的架構設計：
-
-1.  **Core Engine (Rust)**：負責指令解析 (CLI)、統一定義 `Cue` 資料結構，以及與 LLM (Agent) 的交互邏輯。
-2.  **Platform Adapters**：
-    *   **`macos-adapter` (MVP)**：深耕 Apple 生態系，利用系統原生能力（AppleScript、`History.db`、`chat.db`、原生 Vision OCR）。
-    *   **`windows-adapter` (未來規劃)**：預留介面，未來可透過實作 Windows 原生 API 來支援跨平台知識收斂。
-
-## 技術品味
-
--   **原生優先**：拒絕臃腫的第三方依賴與不穩定的網頁爬蟲。能讀 SQLite 就直讀，不能讀就用 AppleScript，遇到封閉介面就呼叫原生 OCR 截圖辨識。
--   **隱私安全**：所有的資料提取（包含 Safari 瀏覽紀錄、iMessage）皆嚴格在本地設備完成。
--   **優雅回饋**：不侷限於終端機的純文字輸出。Agent 在背景執行完任務後，可透過呼叫 macOS 底層 GUI（例如繪製無邊框的靈動島動畫），給予極簡且優雅的視覺回饋。
+MIT

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cueward capture --source all --since 24h | gemini "Group these by topic and high
 A reference skill for Claude Code is included in `skills/cueward-agent/`. Copy it to your skills directory to teach Claude how to use Cueward automatically:
 
 ```bash
-cp -r skills/cueward-agent ~/.claude/skills/
+mkdir -p ~/.claude/skills/ && cp -r skills/cueward-agent ~/.claude/skills/
 ```
 
 ## Architecture

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -33,10 +33,10 @@
 - [x] inbox 持久化機制（capture → inbox → triage → processed）
 - [x] cueward search 指令
 
-## Phase 4：Triage — LLM 摘要
-- [ ] LLM 整合介面（Anthropic / OpenAI API）
-- [ ] Prompt 模板與結構化 JSON 輸出
-- [ ] 僅對無法本地分類的 Cue 呼叫 LLM
+## Phase 4：Agent 整合（設計變更）
+- [x] 決策：Cueward 不內建 LLM，保持純 tool 定位
+- [x] 撰寫 Agent skill 文件（skills/cueward-agent/）
+- [x] README 改寫為實用文件（安裝、用法、Agent 整合）
 
 ## Phase 5+（v0.2）
 - [ ] cueward plan（行事曆 / Reminders）

--- a/skills/cueward-agent/SKILL.md
+++ b/skills/cueward-agent/SKILL.md
@@ -71,6 +71,7 @@ cueward search "<query>" --limit <N>
 
 - Returns JSON objects to stdout, one per line
 - Best for English keyword searches; Chinese content works but tokenization is basic
+- Search results include: source, timestamp, title, content, url, tags — but NOT metadata fields (sender, folder, direction). For full metadata, use `capture` output directly
 
 ## Workflow Patterns
 

--- a/skills/cueward-agent/SKILL.md
+++ b/skills/cueward-agent/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: cueward-agent
+description: Use Cueward CLI to capture, triage, and search the user's scattered knowledge from Safari, Apple Notes, and iMessage. Trigger when the user asks about their browsing history, recent notes, messages, or wants to organize/search their daily knowledge intake. Also use when the user says things like "what did I read today", "find that article I saw", "summarize my knowledge intake", or "help me organize what I've been looking at".
+---
+
+# Cueward Agent Skill
+
+Cueward is a local CLI tool that extracts knowledge fragments from macOS native sources (Safari, Apple Notes, iMessage), auto-tags them, indexes them for search, and outputs structured JSON for you to process.
+
+Your role as the Agent is to call Cueward commands, interpret the JSON output, and provide the user with summaries, insights, or answers based on their captured knowledge.
+
+## Commands
+
+### 1. Capture
+
+Extracts raw knowledge fragments from local sources.
+
+```bash
+cueward capture --source <safari|notes|messages|all> --since <duration>
+```
+
+- `--source`: Which source to capture from. Default: `all`
+- `--since`: Time window. Supports `h` (hours), `d` (days), `m` (minutes). Default: `24h`
+- Outputs JSON to stdout, status messages to stderr
+- Also saves to `~/.cueward/inbox/` for later triage
+
+**Output format** (JSON array of Cue objects):
+```json
+[
+  {
+    "source": "safari",
+    "timestamp": "2026-04-07T03:14:16Z",
+    "content": "Page title or note body",
+    "url": "https://...",
+    "title": "Page title",
+    "tags": ["ai", "rust"],
+    "metadata": {
+      "folder": "Notes",
+      "direction": "received",
+      "sender": "+886..."
+    }
+  }
+]
+```
+
+Fields vary by source:
+- **Safari**: always has `url` and `title`
+- **Notes**: has `title`, `metadata.folder`, no `url`
+- **Messages**: has `metadata.sender`, `metadata.direction`, no `url` or `title`
+
+### 2. Triage
+
+Processes inbox cues: auto-tags with keyword rules and indexes for search.
+
+```bash
+cueward triage
+```
+
+- Reads from `~/.cueward/inbox/`
+- Auto-tags using `~/.cueward/tags.toml` (if present)
+- Indexes into local BM25 search index
+- Moves processed files to `~/.cueward/processed/`
+
+### 3. Search
+
+Queries the local BM25 index.
+
+```bash
+cueward search "<query>" --limit <N>
+```
+
+- Returns JSON objects to stdout, one per line
+- Best for English keyword searches; Chinese content works but tokenization is basic
+
+## Workflow Patterns
+
+### Daily knowledge digest
+
+When the user asks "what did I look at today" or "summarize my day":
+
+```bash
+cueward capture --source all --since 24h
+```
+
+Then summarize the JSON output, grouping by source and topic. Deduplicate similar URLs. Highlight anything with action items.
+
+### Find something the user saw before
+
+When the user asks "I saw an article about X" or "find that link about Y":
+
+1. First try search (fast, uses index):
+   ```bash
+   cueward search "X" --limit 5
+   ```
+2. If search returns nothing, capture fresh and grep:
+   ```bash
+   cueward capture --source safari --since 7d
+   ```
+   Then filter the JSON output for relevant content.
+
+### Triage and organize
+
+When the user wants to organize their knowledge:
+
+```bash
+cueward capture --source all --since 7d
+cueward triage
+```
+
+Then read the indexed results or the processed JSON to provide a structured overview.
+
+## Important Notes
+
+- **First run**: The user may need to grant Full Disk Access to their terminal app (System Settings > Privacy & Security > Full Disk Access). If you see permission errors, guide them through this.
+- **Automation permission**: Apple Notes capture requires allowing terminal automation (System Settings > Privacy & Security > Automation).
+- **JSON on stdout**: Cueward outputs clean JSON to stdout and status/warnings to stderr. Always parse stdout for data.
+- **You are the LLM layer**: Cueward intentionally does not call any LLM. It captures and pre-processes locally. Summarization, insight extraction, and action item generation are your job as the Agent.
+- **Auto-tagging config**: If the user wants custom tags, help them create `~/.cueward/tags.toml`:
+  ```toml
+  [rust]
+  keywords = ["Rust", "cargo", "crate"]
+
+  [ai]
+  keywords = ["AI", "LLM", "ChatGPT", "Claude"]
+  ```


### PR DESCRIPTION
## Summary

- **README rewrite**: from philosophy manifesto to practical documentation
  - Install instructions
  - Usage examples with actual CLI output
  - Agent integration patterns (pipe to claude/gemini)
  - Architecture overview
  - Data storage layout
- **Agent skill**: `skills/cueward-agent/SKILL.md` — best-practice reference for teaching AI Agents how to use Cueward
- **Phase 4 design change**: Cueward stays as pure tool, no embedded LLM

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Skill file is discoverable at `skills/cueward-agent/`
- [ ] All CLI examples in README are accurate
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
