### PR TITLE
feat: add send, plan, and ocr commands (v0.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,8 @@ dependencies = [
  "chrono",
  "cueward-core",
  "rusqlite",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -7,3 +7,5 @@ edition.workspace = true
 cueward-core = { path = "../core" }
 rusqlite = { version = "0.35", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -9,3 +9,4 @@ rusqlite = { version = "0.35", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempfile = "3"

--- a/crates/adapter-macos/scripts/ocr.swift
+++ b/crates/adapter-macos/scripts/ocr.swift
@@ -92,7 +92,15 @@ guard args.count > 1 else {
 let results = ocrImage(args[1])
 let encoder = JSONEncoder()
 encoder.outputFormatting = .prettyPrinted
-if let data = try? encoder.encode(results),
-   let json = String(data: data, encoding: .utf8) {
-    print(json)
+do {
+    let data = try encoder.encode(results)
+    if let json = String(data: data, encoding: .utf8) {
+        print(json)
+    } else {
+        fputs("error: failed to encode JSON as UTF-8\n", stderr)
+        exit(1)
+    }
+} catch {
+    fputs("error: JSON encoding failed: \(error)\n", stderr)
+    exit(1)
 }

--- a/crates/adapter-macos/scripts/ocr.swift
+++ b/crates/adapter-macos/scripts/ocr.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Vision
+import AppKit
+import PDFKit
+
+struct OcrResult: Codable {
+    let text: String
+    let confidence: Float
+}
+
+func ocrImage(_ path: String) -> [OcrResult] {
+    let url = URL(fileURLWithPath: path)
+
+    // Check if PDF
+    if path.lowercased().hasSuffix(".pdf") {
+        return ocrPdf(url)
+    }
+
+    guard let ciImage = CIImage(contentsOf: url) else {
+        fputs("error: could not load image at \(path)\n", stderr)
+        return []
+    }
+
+    return recognizeText(in: ciImage)
+}
+
+func ocrPdf(_ url: URL) -> [OcrResult] {
+    guard let document = PDFDocument(url: url) else {
+        fputs("error: could not load PDF at \(url.path)\n", stderr)
+        return []
+    }
+
+    var allResults: [OcrResult] = []
+
+    for i in 0..<document.pageCount {
+        guard let page = document.page(at: i) else { continue }
+
+        // Try native text first
+        if let rawText = page.string, !rawText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            allResults.append(OcrResult(text: rawText, confidence: 1.0))
+            continue
+        }
+
+        // Fall back to Vision OCR
+        let pageRect = page.bounds(for: .mediaBox)
+        let image = NSImage(size: pageRect.size)
+        image.lockFocus()
+        if let context = NSGraphicsContext.current?.cgContext {
+            context.setFillColor(NSColor.white.cgColor)
+            context.fill(pageRect)
+            page.draw(with: .mediaBox, to: context)
+        }
+        image.unlockFocus()
+
+        guard let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let cgImage = bitmap.cgImage else { continue }
+
+        let ciImage = CIImage(cgImage: cgImage)
+        allResults.append(contentsOf: recognizeText(in: ciImage))
+    }
+
+    return allResults
+}
+
+func recognizeText(in ciImage: CIImage) -> [OcrResult] {
+    var results: [OcrResult] = []
+
+    let handler = VNImageRequestHandler(ciImage: ciImage, options: [:])
+    let request = VNRecognizeTextRequest { request, _ in
+        guard let observations = request.results as? [VNRecognizedTextObservation] else { return }
+        for observation in observations {
+            guard let candidate = observation.topCandidates(1).first else { continue }
+            results.append(OcrResult(text: candidate.string, confidence: candidate.confidence))
+        }
+    }
+
+    request.recognitionLanguages = ["zh-Hant", "zh-Hans", "en-US", "ja"]
+    request.usesLanguageCorrection = true
+
+    try? handler.perform([request])
+    return results
+}
+
+// Main
+let args = CommandLine.arguments
+guard args.count > 1 else {
+    fputs("usage: ocr.swift <image_or_pdf_path>\n", stderr)
+    exit(1)
+}
+
+let results = ocrImage(args[1])
+let encoder = JSONEncoder()
+encoder.outputFormatting = .prettyPrinted
+if let data = try? encoder.encode(results),
+   let json = String(data: data, encoding: .utf8) {
+    print(json)
+}

--- a/crates/adapter-macos/src/applescript.rs
+++ b/crates/adapter-macos/src/applescript.rs
@@ -1,0 +1,33 @@
+use std::process::Command;
+
+use crate::MacosError;
+
+/// Escape a string for use in AppleScript double-quoted literals.
+pub fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Escape a multi-line string for AppleScript by joining lines with `linefeed`.
+pub fn escape_body(s: &str) -> String {
+    let parts: Vec<String> = s
+        .split('\n')
+        .map(|line| format!("\"{}\"", escape(line)))
+        .collect();
+    parts.join(" & linefeed & ")
+}
+
+/// Run an AppleScript and return Ok or a descriptive error.
+pub fn run(script: &str, context: &str) -> Result<(), MacosError> {
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .map_err(|e| MacosError::Other(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::Other(format!("{context}: {stderr}")));
+    }
+
+    Ok(())
+}

--- a/crates/adapter-macos/src/error.rs
+++ b/crates/adapter-macos/src/error.rs
@@ -5,6 +5,7 @@ pub enum MacosError {
     Sqlite(rusqlite::Error),
     PermissionDenied(String),
     NotImplemented(&'static str),
+    Other(String),
 }
 
 impl fmt::Display for MacosError {
@@ -18,6 +19,7 @@ impl fmt::Display for MacosError {
                  System Settings > Privacy & Security > Full Disk Access"
             ),
             Self::NotImplemented(name) => write!(f, "{name}: not yet implemented"),
+            Self::Other(msg) => write!(f, "{msg}"),
         }
     }
 }

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -1,6 +1,7 @@
 mod safari;
 mod notes;
 mod messages;
+pub mod applescript;
 pub mod send;
 pub mod plan;
 pub mod ocr;

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -1,6 +1,9 @@
 mod safari;
 mod notes;
 mod messages;
+pub mod send;
+pub mod plan;
+pub mod ocr;
 mod error;
 
 pub use error::MacosError;

--- a/crates/adapter-macos/src/ocr.rs
+++ b/crates/adapter-macos/src/ocr.rs
@@ -20,34 +20,34 @@ struct OcrResult {
 /// Run Vision OCR on an image or PDF file, returning Cues.
 pub fn capture(path: &str) -> Result<Vec<Cue>, MacosError> {
     let abs_path = std::fs::canonicalize(path)
-        .map_err(|_| MacosError::PermissionDenied(format!("file not found: {path}")))?;
+        .map_err(|_| MacosError::Other(format!("file not found: {path}")))?;
 
     // Write embedded script to temp file
     let mut tmp = tempfile::NamedTempFile::with_suffix(".swift")
-        .map_err(|e| MacosError::PermissionDenied(format!("failed to create temp file: {e}")))?;
+        .map_err(|e| MacosError::Other(format!("failed to create temp file: {e}")))?;
     tmp.write_all(OCR_SCRIPT.as_bytes())
-        .map_err(|e| MacosError::PermissionDenied(format!("failed to write script: {e}")))?;
+        .map_err(|e| MacosError::Other(format!("failed to write script: {e}")))?;
 
     let output = Command::new("swift")
         .arg(tmp.path())
         .arg(&abs_path)
         .output()
-        .map_err(|e| MacosError::PermissionDenied(format!("swift: {e}")))?;
+        .map_err(|e| MacosError::Other(format!("swift: {e}")))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(MacosError::PermissionDenied(format!("OCR failed: {stderr}")));
+        return Err(MacosError::Other(format!("OCR failed: {stderr}")));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     if stdout.trim().is_empty() {
-        return Err(MacosError::PermissionDenied(
+        return Err(MacosError::Other(
             "OCR produced no output (Swift encoder may have failed)".into(),
         ));
     }
 
     let results: Vec<OcrResult> = serde_json::from_str(&stdout)
-        .map_err(|e| MacosError::PermissionDenied(format!("failed to parse OCR output: {e}")))?;
+        .map_err(|e| MacosError::Other(format!("failed to parse OCR output: {e}")))?;
 
     let text: String = results
         .iter()

--- a/crates/adapter-macos/src/ocr.rs
+++ b/crates/adapter-macos/src/ocr.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::io::Write;
 use std::process::Command;
 
 use chrono::Utc;
@@ -9,6 +9,8 @@ use cueward_core::{Cue, CueSource};
 
 use crate::MacosError;
 
+const OCR_SCRIPT: &str = include_str!("../scripts/ocr.swift");
+
 #[derive(Debug, Deserialize)]
 struct OcrResult {
     text: String,
@@ -17,18 +19,18 @@ struct OcrResult {
 
 /// Run Vision OCR on an image or PDF file, returning Cues.
 pub fn capture(path: &str) -> Result<Vec<Cue>, MacosError> {
-    if !Path::new(path).exists() {
-        return Err(MacosError::PermissionDenied(format!(
-            "file not found: {path}"
-        )));
-    }
+    let abs_path = std::fs::canonicalize(path)
+        .map_err(|_| MacosError::PermissionDenied(format!("file not found: {path}")))?;
 
-    // Find the ocr.swift script relative to the binary or fall back to common locations
-    let script = find_ocr_script()?;
+    // Write embedded script to temp file
+    let mut tmp = tempfile::NamedTempFile::with_suffix(".swift")
+        .map_err(|e| MacosError::PermissionDenied(format!("failed to create temp file: {e}")))?;
+    tmp.write_all(OCR_SCRIPT.as_bytes())
+        .map_err(|e| MacosError::PermissionDenied(format!("failed to write script: {e}")))?;
 
     let output = Command::new("swift")
-        .arg(&script)
-        .arg(path)
+        .arg(tmp.path())
+        .arg(&abs_path)
         .output()
         .map_err(|e| MacosError::PermissionDenied(format!("swift: {e}")))?;
 
@@ -38,6 +40,12 @@ pub fn capture(path: &str) -> Result<Vec<Cue>, MacosError> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.trim().is_empty() {
+        return Err(MacosError::PermissionDenied(
+            "OCR produced no output (Swift encoder may have failed)".into(),
+        ));
+    }
+
     let results: Vec<OcrResult> = serde_json::from_str(&stdout)
         .map_err(|e| MacosError::PermissionDenied(format!("failed to parse OCR output: {e}")))?;
 
@@ -52,48 +60,17 @@ pub fn capture(path: &str) -> Result<Vec<Cue>, MacosError> {
         return Ok(Vec::new());
     }
 
-    let filename = Path::new(path)
+    let filename = abs_path
         .file_name()
         .map(|f| f.to_string_lossy().into_owned());
 
     Ok(vec![Cue {
-        source: CueSource::Safari, // Reuse safari as generic source for now
+        source: CueSource::Ocr,
         timestamp: Utc::now(),
         content: text,
-        url: Some(format!("file://{path}")),
+        url: Some(format!("file://{}", abs_path.display())),
         title: filename,
         tags: Vec::new(),
         metadata: HashMap::from([("ocr".into(), "true".into())]),
     }])
-}
-
-fn find_ocr_script() -> Result<String, MacosError> {
-    // Check common locations
-    let candidates = [
-        // Relative to the repo
-        "crates/adapter-macos/scripts/ocr.swift",
-        // Installed location
-        "/usr/local/share/cueward/ocr.swift",
-    ];
-
-    for path in &candidates {
-        if Path::new(path).exists() {
-            return Ok(path.to_string());
-        }
-    }
-
-    // Try to find via the binary's location
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            let script = dir.join("ocr.swift");
-            if script.exists() {
-                return Ok(script.to_string_lossy().into_owned());
-            }
-        }
-    }
-
-    Err(MacosError::PermissionDenied(
-        "ocr.swift not found. Ensure it's in the scripts/ directory or /usr/local/share/cueward/"
-            .into(),
-    ))
 }

--- a/crates/adapter-macos/src/ocr.rs
+++ b/crates/adapter-macos/src/ocr.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Command;
+
+use chrono::Utc;
+use serde::Deserialize;
+
+use cueward_core::{Cue, CueSource};
+
+use crate::MacosError;
+
+#[derive(Debug, Deserialize)]
+struct OcrResult {
+    text: String,
+    confidence: f32,
+}
+
+/// Run Vision OCR on an image or PDF file, returning Cues.
+pub fn capture(path: &str) -> Result<Vec<Cue>, MacosError> {
+    if !Path::new(path).exists() {
+        return Err(MacosError::PermissionDenied(format!(
+            "file not found: {path}"
+        )));
+    }
+
+    // Find the ocr.swift script relative to the binary or fall back to common locations
+    let script = find_ocr_script()?;
+
+    let output = Command::new("swift")
+        .arg(&script)
+        .arg(path)
+        .output()
+        .map_err(|e| MacosError::PermissionDenied(format!("swift: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::PermissionDenied(format!("OCR failed: {stderr}")));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let results: Vec<OcrResult> = serde_json::from_str(&stdout)
+        .map_err(|e| MacosError::PermissionDenied(format!("failed to parse OCR output: {e}")))?;
+
+    let text: String = results
+        .iter()
+        .filter(|r| r.confidence > 0.5)
+        .map(|r| r.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if text.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let filename = Path::new(path)
+        .file_name()
+        .map(|f| f.to_string_lossy().into_owned());
+
+    Ok(vec![Cue {
+        source: CueSource::Safari, // Reuse safari as generic source for now
+        timestamp: Utc::now(),
+        content: text,
+        url: Some(format!("file://{path}")),
+        title: filename,
+        tags: Vec::new(),
+        metadata: HashMap::from([("ocr".into(), "true".into())]),
+    }])
+}
+
+fn find_ocr_script() -> Result<String, MacosError> {
+    // Check common locations
+    let candidates = [
+        // Relative to the repo
+        "crates/adapter-macos/scripts/ocr.swift",
+        // Installed location
+        "/usr/local/share/cueward/ocr.swift",
+    ];
+
+    for path in &candidates {
+        if Path::new(path).exists() {
+            return Ok(path.to_string());
+        }
+    }
+
+    // Try to find via the binary's location
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let script = dir.join("ocr.swift");
+            if script.exists() {
+                return Ok(script.to_string_lossy().into_owned());
+            }
+        }
+    }
+
+    Err(MacosError::PermissionDenied(
+        "ocr.swift not found. Ensure it's in the scripts/ directory or /usr/local/share/cueward/"
+            .into(),
+    ))
+}

--- a/crates/adapter-macos/src/plan.rs
+++ b/crates/adapter-macos/src/plan.rs
@@ -2,73 +2,46 @@ use std::process::Command;
 
 use crate::MacosError;
 
-/// Create a reminder in Apple Reminders.
-pub fn create_reminder(title: &str, notes: &str, list: &str) -> Result<(), MacosError> {
-    let escaped_title = title.replace('"', "\\\"");
-    let escaped_notes = notes.replace('"', "\\\"");
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
 
-    let script = format!(
-        r#"
-        tell application "Reminders"
-            try
-                set targetList to list "{list}"
-            on error
-                make new list with properties {{name:"{list}"}}
-                set targetList to list "{list}"
-            end try
-            make new reminder at targetList with properties {{name:"{escaped_title}", body:"{escaped_notes}"}}
-        end tell
-        "#
-    );
-
+fn run_osascript(script: &str, context: &str) -> Result<(), MacosError> {
     let output = Command::new("osascript")
         .arg("-e")
-        .arg(&script)
+        .arg(script)
         .output()
         .map_err(|e| MacosError::PermissionDenied(format!("osascript: {e}")))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(MacosError::PermissionDenied(format!(
-            "failed to create reminder: {stderr}"
+            "{context}: {stderr}"
         )));
     }
 
     Ok(())
 }
 
-/// Create a calendar event via AppleScript.
-pub fn create_calendar_event(
-    title: &str,
-    start_date: &str,
-    end_date: &str,
-    calendar: &str,
-) -> Result<(), MacosError> {
-    let escaped_title = title.replace('"', "\\\"");
+/// Create a reminder in Apple Reminders.
+pub fn create_reminder(title: &str, notes: &str, list: &str) -> Result<(), MacosError> {
+    let escaped_title = escape(title);
+    let escaped_notes = escape(notes);
+    let escaped_list = escape(list);
 
-    // AppleScript date format: "April 7, 2026 at 10:00:00 AM"
     let script = format!(
         r#"
-        tell application "Calendar"
-            tell calendar "{calendar}"
-                make new event with properties {{summary:"{escaped_title}", start date:(date "{start_date}"), end date:(date "{end_date}")}}
-            end tell
+        tell application "Reminders"
+            try
+                set targetList to list "{escaped_list}"
+            on error
+                make new list with properties {{name:"{escaped_list}"}}
+                set targetList to list "{escaped_list}"
+            end try
+            make new reminder at targetList with properties {{name:"{escaped_title}", body:"{escaped_notes}"}}
         end tell
         "#
     );
 
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg(&script)
-        .output()
-        .map_err(|e| MacosError::PermissionDenied(format!("osascript: {e}")))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(MacosError::PermissionDenied(format!(
-            "failed to create calendar event: {stderr}"
-        )));
-    }
-
-    Ok(())
+    run_osascript(&script, "failed to create reminder")
 }

--- a/crates/adapter-macos/src/plan.rs
+++ b/crates/adapter-macos/src/plan.rs
@@ -1,0 +1,74 @@
+use std::process::Command;
+
+use crate::MacosError;
+
+/// Create a reminder in Apple Reminders.
+pub fn create_reminder(title: &str, notes: &str, list: &str) -> Result<(), MacosError> {
+    let escaped_title = title.replace('"', "\\\"");
+    let escaped_notes = notes.replace('"', "\\\"");
+
+    let script = format!(
+        r#"
+        tell application "Reminders"
+            try
+                set targetList to list "{list}"
+            on error
+                make new list with properties {{name:"{list}"}}
+                set targetList to list "{list}"
+            end try
+            make new reminder at targetList with properties {{name:"{escaped_title}", body:"{escaped_notes}"}}
+        end tell
+        "#
+    );
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| MacosError::PermissionDenied(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::PermissionDenied(format!(
+            "failed to create reminder: {stderr}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Create a calendar event via AppleScript.
+pub fn create_calendar_event(
+    title: &str,
+    start_date: &str,
+    end_date: &str,
+    calendar: &str,
+) -> Result<(), MacosError> {
+    let escaped_title = title.replace('"', "\\\"");
+
+    // AppleScript date format: "April 7, 2026 at 10:00:00 AM"
+    let script = format!(
+        r#"
+        tell application "Calendar"
+            tell calendar "{calendar}"
+                make new event with properties {{summary:"{escaped_title}", start date:(date "{start_date}"), end date:(date "{end_date}")}}
+            end tell
+        end tell
+        "#
+    );
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| MacosError::PermissionDenied(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::PermissionDenied(format!(
+            "failed to create calendar event: {stderr}"
+        )));
+    }
+
+    Ok(())
+}

--- a/crates/adapter-macos/src/plan.rs
+++ b/crates/adapter-macos/src/plan.rs
@@ -1,33 +1,11 @@
-use std::process::Command;
-
+use crate::applescript::{escape, escape_body, run};
 use crate::MacosError;
-
-fn escape(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
-fn run_osascript(script: &str, context: &str) -> Result<(), MacosError> {
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg(script)
-        .output()
-        .map_err(|e| MacosError::PermissionDenied(format!("osascript: {e}")))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(MacosError::PermissionDenied(format!(
-            "{context}: {stderr}"
-        )));
-    }
-
-    Ok(())
-}
 
 /// Create a reminder in Apple Reminders.
 pub fn create_reminder(title: &str, notes: &str, list: &str) -> Result<(), MacosError> {
     let escaped_title = escape(title);
-    let escaped_notes = escape(notes);
     let escaped_list = escape(list);
+    let notes_expr = escape_body(notes);
 
     let script = format!(
         r#"
@@ -38,10 +16,10 @@ pub fn create_reminder(title: &str, notes: &str, list: &str) -> Result<(), Macos
                 make new list with properties {{name:"{escaped_list}"}}
                 set targetList to list "{escaped_list}"
             end try
-            make new reminder at targetList with properties {{name:"{escaped_title}", body:"{escaped_notes}"}}
+            make new reminder at targetList with properties {{name:"{escaped_title}", body:{notes_expr}}}
         end tell
         "#
     );
 
-    run_osascript(&script, "failed to create reminder")
+    run(&script, "failed to create reminder")
 }

--- a/crates/adapter-macos/src/send.rs
+++ b/crates/adapter-macos/src/send.rs
@@ -1,0 +1,63 @@
+use std::process::Command;
+
+use crate::MacosError;
+
+/// Create a note in Apple Notes with the given title and body.
+pub fn create_note(title: &str, body: &str, folder: &str) -> Result<(), MacosError> {
+    let escaped_title = title.replace('"', "\\\"");
+    let escaped_body = body.replace('"', "\\\"").replace('\n', "\\n");
+
+    let script = format!(
+        r#"
+        tell application "Notes"
+            try
+                set targetFolder to folder "{folder}"
+            on error
+                make new folder with properties {{name:"{folder}"}}
+                set targetFolder to folder "{folder}"
+            end try
+            make new note at targetFolder with properties {{name:"{escaped_title}", body:"{escaped_body}"}}
+        end tell
+        "#
+    );
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| MacosError::PermissionDenied(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::PermissionDenied(format!(
+            "failed to create note: {stderr}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Send a macOS notification via osascript.
+pub fn notify(title: &str, message: &str) -> Result<(), MacosError> {
+    let escaped_title = title.replace('"', "\\\"");
+    let escaped_msg = message.replace('"', "\\\"");
+
+    let script = format!(
+        r#"display notification "{escaped_msg}" with title "{escaped_title}""#
+    );
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| MacosError::PermissionDenied(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::PermissionDenied(format!(
+            "notification failed: {stderr}"
+        )));
+    }
+
+    Ok(())
+}

--- a/crates/adapter-macos/src/send.rs
+++ b/crates/adapter-macos/src/send.rs
@@ -21,16 +21,74 @@ pub fn create_note(title: &str, body: &str, folder: &str) -> Result<(), MacosErr
         "#
     );
 
+    run_osascript(&script, "failed to create note")
+}
+
+/// Update an existing note's body by title.
+pub fn update_note(title: &str, body: &str, folder: &str) -> Result<(), MacosError> {
+    let escaped_title = title.replace('"', "\\\"");
+    let escaped_body = body.replace('"', "\\\"").replace('\n', "\\n");
+
+    let script = format!(
+        r#"
+        tell application "Notes"
+            set theNote to (first note of folder "{folder}" whose name is "{escaped_title}")
+            set body of theNote to "{escaped_body}"
+        end tell
+        "#
+    );
+
+    run_osascript(&script, "failed to update note")
+}
+
+/// Delete a note by title from a specific folder.
+pub fn delete_note(title: &str, folder: &str) -> Result<(), MacosError> {
+    let escaped_title = title.replace('"', "\\\"");
+
+    let script = format!(
+        r#"
+        tell application "Notes"
+            delete (first note of folder "{folder}" whose name is "{escaped_title}")
+        end tell
+        "#
+    );
+
+    run_osascript(&script, "failed to delete note")
+}
+
+/// Move a note to a different folder.
+pub fn move_note(title: &str, from_folder: &str, to_folder: &str) -> Result<(), MacosError> {
+    let escaped_title = title.replace('"', "\\\"");
+
+    let script = format!(
+        r#"
+        tell application "Notes"
+            try
+                set destFolder to folder "{to_folder}"
+            on error
+                make new folder with properties {{name:"{to_folder}"}}
+                set destFolder to folder "{to_folder}"
+            end try
+            set theNote to (first note of folder "{from_folder}" whose name is "{escaped_title}")
+            move theNote to destFolder
+        end tell
+        "#
+    );
+
+    run_osascript(&script, "failed to move note")
+}
+
+fn run_osascript(script: &str, context: &str) -> Result<(), MacosError> {
     let output = Command::new("osascript")
         .arg("-e")
-        .arg(&script)
+        .arg(script)
         .output()
         .map_err(|e| MacosError::PermissionDenied(format!("osascript: {e}")))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(MacosError::PermissionDenied(format!(
-            "failed to create note: {stderr}"
+            "{context}: {stderr}"
         )));
     }
 
@@ -46,18 +104,5 @@ pub fn notify(title: &str, message: &str) -> Result<(), MacosError> {
         r#"display notification "{escaped_msg}" with title "{escaped_title}""#
     );
 
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg(&script)
-        .output()
-        .map_err(|e| MacosError::PermissionDenied(format!("osascript: {e}")))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(MacosError::PermissionDenied(format!(
-            "notification failed: {stderr}"
-        )));
-    }
-
-    Ok(())
+    run_osascript(&script, "notification failed")
 }

--- a/crates/adapter-macos/src/send.rs
+++ b/crates/adapter-macos/src/send.rs
@@ -1,36 +1,5 @@
-use std::process::Command;
-
+use crate::applescript::{escape, escape_body, run};
 use crate::MacosError;
-
-fn escape(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
-fn escape_body(s: &str) -> String {
-    // AppleScript doesn't support \n in strings.
-    // Split on newlines and join with `& linefeed &`.
-    let parts: Vec<String> = s.split('\n').map(|line| {
-        format!("\"{}\"", escape(line))
-    }).collect();
-    parts.join(" & linefeed & ")
-}
-
-fn run_osascript(script: &str, context: &str) -> Result<(), MacosError> {
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg(script)
-        .output()
-        .map_err(|e| MacosError::PermissionDenied(format!("osascript: {e}")))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(MacosError::PermissionDenied(format!(
-            "{context}: {stderr}"
-        )));
-    }
-
-    Ok(())
-}
 
 /// Create a note in Apple Notes with the given title and body.
 pub fn create_note(title: &str, body: &str, folder: &str) -> Result<(), MacosError> {
@@ -52,7 +21,7 @@ pub fn create_note(title: &str, body: &str, folder: &str) -> Result<(), MacosErr
         "#
     );
 
-    run_osascript(&script, "failed to create note")
+    run(&script, "failed to create note")
 }
 
 /// Update an existing note's body by title.
@@ -70,7 +39,7 @@ pub fn update_note(title: &str, body: &str, folder: &str) -> Result<(), MacosErr
         "#
     );
 
-    run_osascript(&script, "failed to update note")
+    run(&script, "failed to update note")
 }
 
 /// Delete a note by title from a specific folder.
@@ -86,7 +55,7 @@ pub fn delete_note(title: &str, folder: &str) -> Result<(), MacosError> {
         "#
     );
 
-    run_osascript(&script, "failed to delete note")
+    run(&script, "failed to delete note")
 }
 
 /// Move a note to a different folder.
@@ -110,7 +79,7 @@ pub fn move_note(title: &str, from_folder: &str, to_folder: &str) -> Result<(), 
         "#
     );
 
-    run_osascript(&script, "failed to move note")
+    run(&script, "failed to move note")
 }
 
 /// Send a macOS notification via osascript.
@@ -122,5 +91,5 @@ pub fn notify(title: &str, message: &str) -> Result<(), MacosError> {
         r#"display notification "{escaped_msg}" with title "{escaped_title}""#
     );
 
-    run_osascript(&script, "notification failed")
+    run(&script, "notification failed")
 }

--- a/crates/adapter-macos/src/send.rs
+++ b/crates/adapter-macos/src/send.rs
@@ -2,80 +2,17 @@ use std::process::Command;
 
 use crate::MacosError;
 
-/// Create a note in Apple Notes with the given title and body.
-pub fn create_note(title: &str, body: &str, folder: &str) -> Result<(), MacosError> {
-    let escaped_title = title.replace('"', "\\\"");
-    let escaped_body = body.replace('"', "\\\"").replace('\n', "\\n");
-
-    let script = format!(
-        r#"
-        tell application "Notes"
-            try
-                set targetFolder to folder "{folder}"
-            on error
-                make new folder with properties {{name:"{folder}"}}
-                set targetFolder to folder "{folder}"
-            end try
-            make new note at targetFolder with properties {{name:"{escaped_title}", body:"{escaped_body}"}}
-        end tell
-        "#
-    );
-
-    run_osascript(&script, "failed to create note")
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
-/// Update an existing note's body by title.
-pub fn update_note(title: &str, body: &str, folder: &str) -> Result<(), MacosError> {
-    let escaped_title = title.replace('"', "\\\"");
-    let escaped_body = body.replace('"', "\\\"").replace('\n', "\\n");
-
-    let script = format!(
-        r#"
-        tell application "Notes"
-            set theNote to (first note of folder "{folder}" whose name is "{escaped_title}")
-            set body of theNote to "{escaped_body}"
-        end tell
-        "#
-    );
-
-    run_osascript(&script, "failed to update note")
-}
-
-/// Delete a note by title from a specific folder.
-pub fn delete_note(title: &str, folder: &str) -> Result<(), MacosError> {
-    let escaped_title = title.replace('"', "\\\"");
-
-    let script = format!(
-        r#"
-        tell application "Notes"
-            delete (first note of folder "{folder}" whose name is "{escaped_title}")
-        end tell
-        "#
-    );
-
-    run_osascript(&script, "failed to delete note")
-}
-
-/// Move a note to a different folder.
-pub fn move_note(title: &str, from_folder: &str, to_folder: &str) -> Result<(), MacosError> {
-    let escaped_title = title.replace('"', "\\\"");
-
-    let script = format!(
-        r#"
-        tell application "Notes"
-            try
-                set destFolder to folder "{to_folder}"
-            on error
-                make new folder with properties {{name:"{to_folder}"}}
-                set destFolder to folder "{to_folder}"
-            end try
-            set theNote to (first note of folder "{from_folder}" whose name is "{escaped_title}")
-            move theNote to destFolder
-        end tell
-        "#
-    );
-
-    run_osascript(&script, "failed to move note")
+fn escape_body(s: &str) -> String {
+    // AppleScript doesn't support \n in strings.
+    // Split on newlines and join with `& linefeed &`.
+    let parts: Vec<String> = s.split('\n').map(|line| {
+        format!("\"{}\"", escape(line))
+    }).collect();
+    parts.join(" & linefeed & ")
 }
 
 fn run_osascript(script: &str, context: &str) -> Result<(), MacosError> {
@@ -95,10 +32,91 @@ fn run_osascript(script: &str, context: &str) -> Result<(), MacosError> {
     Ok(())
 }
 
+/// Create a note in Apple Notes with the given title and body.
+pub fn create_note(title: &str, body: &str, folder: &str) -> Result<(), MacosError> {
+    let escaped_title = escape(title);
+    let escaped_folder = escape(folder);
+    let body_expr = escape_body(body);
+
+    let script = format!(
+        r#"
+        tell application "Notes"
+            try
+                set targetFolder to folder "{escaped_folder}"
+            on error
+                make new folder with properties {{name:"{escaped_folder}"}}
+                set targetFolder to folder "{escaped_folder}"
+            end try
+            make new note at targetFolder with properties {{name:"{escaped_title}", body:{body_expr}}}
+        end tell
+        "#
+    );
+
+    run_osascript(&script, "failed to create note")
+}
+
+/// Update an existing note's body by title.
+pub fn update_note(title: &str, body: &str, folder: &str) -> Result<(), MacosError> {
+    let escaped_title = escape(title);
+    let escaped_folder = escape(folder);
+    let body_expr = escape_body(body);
+
+    let script = format!(
+        r#"
+        tell application "Notes"
+            set theNote to (first note of folder "{escaped_folder}" whose name is "{escaped_title}")
+            set body of theNote to {body_expr}
+        end tell
+        "#
+    );
+
+    run_osascript(&script, "failed to update note")
+}
+
+/// Delete a note by title from a specific folder.
+pub fn delete_note(title: &str, folder: &str) -> Result<(), MacosError> {
+    let escaped_title = escape(title);
+    let escaped_folder = escape(folder);
+
+    let script = format!(
+        r#"
+        tell application "Notes"
+            delete (first note of folder "{escaped_folder}" whose name is "{escaped_title}")
+        end tell
+        "#
+    );
+
+    run_osascript(&script, "failed to delete note")
+}
+
+/// Move a note to a different folder.
+pub fn move_note(title: &str, from_folder: &str, to_folder: &str) -> Result<(), MacosError> {
+    let escaped_title = escape(title);
+    let escaped_from = escape(from_folder);
+    let escaped_to = escape(to_folder);
+
+    let script = format!(
+        r#"
+        tell application "Notes"
+            try
+                set destFolder to folder "{escaped_to}"
+            on error
+                make new folder with properties {{name:"{escaped_to}"}}
+                set destFolder to folder "{escaped_to}"
+            end try
+            set theNote to (first note of folder "{escaped_from}" whose name is "{escaped_title}")
+            move theNote to destFolder
+        end tell
+        "#
+    );
+
+    run_osascript(&script, "failed to move note")
+}
+
 /// Send a macOS notification via osascript.
 pub fn notify(title: &str, message: &str) -> Result<(), MacosError> {
-    let escaped_title = title.replace('"', "\\\"");
-    let escaped_msg = message.replace('"', "\\\"");
+    let escaped_title = escape(title);
+    let escaped_msg = escape(message);
 
     let script = format!(
         r#"display notification "{escaped_msg}" with title "{escaped_title}""#

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -324,11 +324,12 @@ fn main() {
             }
 
             if notify {
-                let preview = if body.chars().count() > 100 {
-                    let truncated: String = body.chars().take(100).collect();
+                let flat = body.replace('\n', " ");
+                let preview = if flat.chars().count() > 100 {
+                    let truncated: String = flat.chars().take(100).collect();
                     format!("{truncated}...")
                 } else {
-                    body.clone()
+                    flat
                 };
                 if let Err(e) = cueward_adapter_macos::send::notify(&title, &preview) {
                     eprintln!("warning: notification failed: {e}");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -38,6 +38,46 @@ enum Command {
         #[arg(long, default_value = "10")]
         limit: usize,
     },
+
+    /// Send a digest note or system notification
+    Send {
+        /// Note title
+        #[arg(long)]
+        title: String,
+
+        /// Note body (read from stdin if not provided)
+        #[arg(long)]
+        body: Option<String>,
+
+        /// Target Notes folder
+        #[arg(long, default_value = "Cueward")]
+        folder: String,
+
+        /// Also send a macOS notification
+        #[arg(long)]
+        notify: bool,
+    },
+
+    /// Create a reminder or calendar event
+    Plan {
+        /// Reminder/event title
+        #[arg(long)]
+        title: String,
+
+        /// Notes or description
+        #[arg(long, default_value = "")]
+        notes: String,
+
+        /// Reminders list name
+        #[arg(long, default_value = "Cueward")]
+        list: String,
+    },
+
+    /// Extract text from images or PDFs via Vision OCR
+    Ocr {
+        /// Path to image or PDF file
+        path: String,
+    },
 }
 
 #[derive(Clone, ValueEnum)]
@@ -207,6 +247,63 @@ fn main() {
                 }
                 Err(e) => {
                     eprintln!("error: search failed: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Command::Send {
+            title,
+            body,
+            folder,
+            notify,
+        } => {
+            let body = body.unwrap_or_else(|| {
+                use std::io::Read;
+                let mut buf = String::new();
+                std::io::stdin().read_to_string(&mut buf).unwrap_or_default();
+                buf
+            });
+
+            match cueward_adapter_macos::send::create_note(&title, &body, &folder) {
+                Ok(()) => eprintln!("note created in {folder}"),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
+                }
+            }
+
+            if notify {
+                let preview = if body.len() > 100 {
+                    format!("{}...", &body[..100])
+                } else {
+                    body.clone()
+                };
+                if let Err(e) = cueward_adapter_macos::send::notify(&title, &preview) {
+                    eprintln!("warning: notification failed: {e}");
+                }
+            }
+        }
+
+        Command::Plan { title, notes, list } => {
+            match cueward_adapter_macos::plan::create_reminder(&title, &notes, &list) {
+                Ok(()) => eprintln!("reminder created in {list}"),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+
+        Command::Ocr { path } => {
+            match cueward_adapter_macos::ocr::capture(&path) {
+                Ok(cues) => {
+                    let json = serde_json::to_string_pretty(&cues).unwrap();
+                    println!("{json}");
+                    eprintln!("extracted {} cues", cues.len());
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
                     process::exit(1);
                 }
             }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -324,8 +324,9 @@ fn main() {
             }
 
             if notify {
-                let preview = if body.len() > 100 {
-                    format!("{}...", &body[..100])
+                let preview = if body.chars().count() > 100 {
+                    let truncated: String = body.chars().take(100).collect();
+                    format!("{truncated}...")
                 } else {
                     body.clone()
                 };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -78,6 +78,56 @@ enum Command {
         /// Path to image or PDF file
         path: String,
     },
+
+    /// Manage Apple Notes (update, delete, move)
+    Notes {
+        #[command(subcommand)]
+        action: NotesAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum NotesAction {
+    /// Update a note's body
+    Update {
+        /// Note title to find
+        #[arg(long)]
+        title: String,
+
+        /// New body content
+        #[arg(long)]
+        body: String,
+
+        /// Folder to search in
+        #[arg(long, default_value = "Cueward")]
+        folder: String,
+    },
+
+    /// Delete a note
+    Delete {
+        /// Note title to find
+        #[arg(long)]
+        title: String,
+
+        /// Folder to search in
+        #[arg(long, default_value = "Cueward")]
+        folder: String,
+    },
+
+    /// Move a note to a different folder
+    Move {
+        /// Note title to find
+        #[arg(long)]
+        title: String,
+
+        /// Source folder
+        #[arg(long)]
+        from: String,
+
+        /// Destination folder
+        #[arg(long)]
+        to: String,
+    },
 }
 
 #[derive(Clone, ValueEnum)]
@@ -308,5 +358,39 @@ fn main() {
                 }
             }
         }
+
+        Command::Notes { action } => match action {
+            NotesAction::Update {
+                title,
+                body,
+                folder,
+            } => {
+                match cueward_adapter_macos::send::update_note(&title, &body, &folder) {
+                    Ok(()) => eprintln!("note updated: {title}"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            NotesAction::Delete { title, folder } => {
+                match cueward_adapter_macos::send::delete_note(&title, &folder) {
+                    Ok(()) => eprintln!("note deleted: {title}"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            NotesAction::Move { title, from, to } => {
+                match cueward_adapter_macos::send::move_note(&title, &from, &to) {
+                    Ok(()) => eprintln!("note moved: {title} ({from} -> {to})"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+        },
     }
 }

--- a/crates/core/src/cue.rs
+++ b/crates/core/src/cue.rs
@@ -8,6 +8,7 @@ pub enum CueSource {
     Safari,
     Notes,
     Messages,
+    Ocr,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/index.rs
+++ b/crates/core/src/index.rs
@@ -61,6 +61,7 @@ impl CueIndex {
                 crate::CueSource::Safari => "safari",
                 crate::CueSource::Notes => "notes",
                 crate::CueSource::Messages => "messages",
+                crate::CueSource::Ocr => "ocr",
             };
             writer.add_document(doc!(
                 source => source_str,

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -38,9 +38,12 @@
 - [x] 撰寫 Agent skill 文件（skills/cueward-agent/）
 - [x] README 改寫為實用文件（安裝、用法、Agent 整合）
 
-## Phase 5+（v0.2）
-- [ ] cueward plan（行事曆 / Reminders）
-- [ ] cueward send（每日摘要通知）
-- [ ] Vision OCR capture
+## Phase 5：v0.2 指令擴展
+- [x] cueward send（寫入 Apple Notes + macOS 通知）
+- [x] cueward plan（建立 Reminders 提醒事項）
+- [x] cueward ocr（Vision Framework OCR，支援圖片 + PDF）
+
+## Phase 6+（未來）
 - [ ] 靈動島 Notch UI
 - [ ] Windows adapter
+- [ ] Calendar event 整合（目前只有 Reminders）

--- a/skills/cueward-agent/SKILL.md
+++ b/skills/cueward-agent/SKILL.md
@@ -73,6 +73,58 @@ cueward search "<query>" --limit <N>
 - Best for English keyword searches; Chinese content works but tokenization is basic
 - Search results include: source, timestamp, title, content, url, tags — but NOT metadata fields (sender, folder, direction). For full metadata, use `capture` output directly
 
+### 4. Send
+
+Create a note in Apple Notes and optionally send a macOS notification.
+
+```bash
+cueward send --title "Daily Digest" --body "Summary content..." --folder Cueward --notify
+```
+
+- `--folder`: Target Notes folder (auto-created if missing). Default: `Cueward`
+- `--notify`: Also trigger a macOS notification
+- Body can be piped via stdin if `--body` is omitted
+
+### 5. Plan
+
+Create a reminder in Apple Reminders.
+
+```bash
+cueward plan --title "Review PR" --notes "Check bot comments" --list Cueward
+```
+
+- `--list`: Reminders list (auto-created if missing). Default: `Cueward`
+
+### 6. OCR
+
+Extract text from images or PDFs using Apple Vision Framework.
+
+```bash
+cueward ocr <path_to_image_or_pdf>
+```
+
+- Supports PNG, JPG, PDF
+- PDF: uses native text layer first, falls back to Vision OCR for scanned pages
+- Languages: zh-Hant, zh-Hans, en-US, ja
+- Outputs standard Cue JSON (source: "ocr")
+
+### 7. Notes Management
+
+Update, delete, or move Apple Notes.
+
+```bash
+# Update a note's body
+cueward notes update --title "Note Title" --body "New content" --folder Cueward
+
+# Delete a note
+cueward notes delete --title "Note Title" --folder Cueward
+
+# Move a note between folders
+cueward notes move --title "Note Title" --from Cueward --to Archive
+```
+
+These commands find notes by exact title match within the specified folder.
+
 ## Workflow Patterns
 
 ### Daily knowledge digest
@@ -109,6 +161,36 @@ cueward triage
 ```
 
 Then read the indexed results or the processed JSON to provide a structured overview.
+
+### Capture, summarize, and archive
+
+Full pipeline: capture → summarize → write digest → clean up:
+
+```bash
+# 1. Capture today's knowledge
+cueward capture --source all --since 24h
+
+# 2. (You summarize the JSON output)
+
+# 3. Write digest to Notes
+cueward send --title "2026-04-07 Digest" --body "<your summary>" --folder Cueward --notify
+
+# 4. Create reminders for action items
+cueward plan --title "Follow up on X" --notes "From today's capture"
+
+# 5. Archive processed notes
+cueward notes move --title "Old Note" --from Notes --to Archive
+```
+
+### OCR a document
+
+When the user shares an image or PDF:
+
+```bash
+cueward ocr ~/Desktop/screenshot.png
+```
+
+Then summarize the extracted text or answer questions about it.
 
 ## Important Notes
 


### PR DESCRIPTION
## Summary

Three new commands for v0.2:

| Command | Function | Method |
|---------|----------|--------|
| `cueward send` | Create digest note + macOS notification | AppleScript → Apple Notes |
| `cueward plan` | Create reminder | AppleScript → Reminders |
| `cueward ocr` | Extract text from images/PDFs | Swift Vision Framework |

## Usage

```bash
# Send a digest note
cueward send --title "Daily Digest" --body "Today's summary..." --notify

# Pipe capture output as note body
cueward capture --source all --since 24h | cueward send --title "2026-04-07 Digest" --folder Cueward

# Create a reminder
cueward plan --title "Review PR" --notes "Check bot comments"

# OCR a screenshot
cueward ocr ~/Desktop/screenshot.png

# OCR a PDF
cueward ocr ~/Documents/paper.pdf
```

## OCR details

- Supports image formats (PNG, JPG, etc.) and PDFs
- PDF: tries native text layer first, falls back to Vision OCR for scanned pages
- Languages: zh-Hant, zh-Hans, en-US, ja
- Outputs standard Cue JSON (pipeable to triage)

## Test plan

- [ ] `cargo build` compiles
- [ ] `cueward send --title "Test" --body "Hello" --notify` creates note + notification
- [ ] `cueward plan --title "Test" --notes "..."` creates reminder
- [ ] `cueward ocr <image>` outputs JSON with OCR text
- [ ] `cueward ocr <pdf>` handles both text-based and scanned PDFs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
