### PR TITLE
docs: sync README and SKILL.md with v0.2 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Requires Rust 1.85+ (edition 2024).
 Cueward reads local databases that require Full Disk Access:
 
 1. Open **System Settings > Privacy & Security > Full Disk Access**
-2. Add your terminal app (Terminal.app, iTerm2, WezTerm, etc.)
+2. Add your terminal app (Termdock, Terminal.app, iTerm2, WezTerm, etc.)
 
-For Apple Notes capture, also allow automation:
-- **System Settings > Privacy & Security > Automation** > allow your terminal to control Notes
+For Apple Notes and Reminders operations, also allow automation:
+- **System Settings > Privacy & Security > Automation** > allow your terminal to control Notes and Reminders
 
 ## Usage
 
@@ -97,6 +97,55 @@ Query the local index:
 cueward search "rust concurrency" --limit 5
 ```
 
+### Send
+
+Create a digest note in Apple Notes and optionally trigger a macOS notification:
+
+```bash
+# Create a note
+cueward send --title "Daily Digest" --body "Today's summary..." --folder Cueward
+
+# With notification
+cueward send --title "Daily Digest" --body "Summary" --notify
+
+# Pipe from capture
+cueward capture --source all --since 24h | cueward send --title "2026-04-07 Digest"
+```
+
+### Plan
+
+Create a reminder in Apple Reminders:
+
+```bash
+cueward plan --title "Review PR" --notes "Check bot comments" --list Cueward
+```
+
+### OCR
+
+Extract text from images or PDFs via Apple Vision Framework:
+
+```bash
+cueward ocr ~/Desktop/screenshot.png
+cueward ocr ~/Documents/paper.pdf
+```
+
+Supports PNG, JPG, PDF. Languages: zh-Hant, zh-Hans, en-US, ja.
+
+### Notes Management
+
+Update, delete, or move Apple Notes:
+
+```bash
+# Update a note's body
+cueward notes update --title "Note Title" --body "New content" --folder Cueward
+
+# Delete a note
+cueward notes delete --title "Note Title" --folder Cueward
+
+# Move between folders
+cueward notes move --title "Note Title" --from Cueward --to Archive
+```
+
 ## Agent Integration
 
 Cueward outputs structured JSON — it does not call any LLM. The LLM layer is your Agent's responsibility.
@@ -124,13 +173,14 @@ mkdir -p ~/.claude/skills/ && cp -r skills/cueward-agent ~/.claude/skills/
 ```
 crates/
 ├── core/            Cue struct, PlatformAdapter trait, BM25 index, auto-tagger
-├── cli/             clap CLI (capture, triage, search)
-├── adapter-macos/   Safari (SQLite), Notes (AppleScript), Messages (SQLite)
+├── cli/             clap CLI (capture, triage, search, send, plan, ocr, notes)
+├── adapter-macos/   Safari (SQLite), Notes (AppleScript), Messages (SQLite),
+│                    Reminders (AppleScript), Vision OCR (Swift)
 └── adapter-windows/ Reserved for future cross-platform support
 ```
 
 - **Core Engine + Adapter Pattern**: Platform-specific code is isolated in adapters. Core logic is platform-agnostic.
-- **Native First**: Direct SQLite reads and AppleScript. No web scraping, no browser automation.
+- **Native First**: Direct SQLite reads, AppleScript, and Vision Framework. No web scraping, no browser automation.
 - **Privacy**: All data extraction happens locally. Nothing leaves your machine.
 
 ## Data Storage

--- a/skills/cueward-agent/SKILL.md
+++ b/skills/cueward-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cueward-agent
-description: Use Cueward CLI to capture, triage, and search the user's scattered knowledge from Safari, Apple Notes, and iMessage. Trigger when the user asks about their browsing history, recent notes, messages, or wants to organize/search their daily knowledge intake. Also use when the user says things like "what did I read today", "find that article I saw", "summarize my knowledge intake", or "help me organize what I've been looking at".
+description: Use Cueward CLI to capture, triage, search, and manage the user's scattered knowledge from Safari, Apple Notes, and iMessage. Also supports OCR (images/PDFs), creating Notes and Reminders, and managing notes (update/delete/move). Trigger when the user asks about their browsing history, recent notes, messages, wants to organize knowledge, create a digest, set reminders from captured content, extract text from images/PDFs, or manage Apple Notes. Also use when the user says things like "what did I read today", "find that article I saw", "summarize my knowledge intake", "help me organize what I've been looking at", "create a reminder for this", "write a summary note", or "OCR this screenshot".
 ---
 
 # Cueward Agent Skill


### PR DESCRIPTION
## Summary

- **README**: Add send, plan, ocr, notes management usage sections
- **README**: List Termdock first in terminal app permission examples
- **README**: Update architecture section to reflect Vision OCR and Reminders
- **SKILL.md**: Update description trigger to include all 9 commands (send, plan, ocr, notes update/delete/move)

## Changes

No code changes, docs only.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
