### PR TITLE
feat: add quick-notes command for Quick Notes (快速備忘錄)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,75 @@ Query the local index:
 cueward search "rust concurrency" --limit 5
 ```
 
+### Send
+
+Create a digest note in Apple Notes and optionally trigger a macOS notification:
+
+```bash
+# Create a note
+cueward send --title "Daily Digest" --body "Today's summary..." --folder Cueward
+
+# With notification
+cueward send --title "Daily Digest" --body "Summary" --notify
+
+# Pipe from capture
+cueward capture --source all --since 24h | cueward send --title "2026-04-07 Digest"
+```
+
+### Plan
+
+Create a reminder in Apple Reminders:
+
+```bash
+cueward plan --title "Review PR" --notes "Check bot comments" --list Cueward
+```
+
+### OCR
+
+Extract text from images or PDFs via Apple Vision Framework:
+
+```bash
+cueward ocr ~/Desktop/screenshot.png
+cueward ocr ~/Documents/paper.pdf
+```
+
+Supports PNG, JPG, PDF. Languages: zh-Hant, zh-Hans, en-US, ja.
+
+### Notes Management
+
+Update, delete, or move Apple Notes:
+
+```bash
+# Update a note's body
+cueward notes update --title "Note Title" --body "New content" --folder Cueward
+
+# Delete a note
+cueward notes delete --title "Note Title" --folder Cueward
+
+# Move between folders
+cueward notes move --title "Note Title" --from Cueward --to Archive
+```
+
+### Quick Notes
+
+List, update, and delete system Quick Notes (快速備忘錄):
+
+```bash
+# List all Quick Notes
+cueward quick-notes list
+
+# Update a Quick Note's body
+cueward quick-notes update --title "Note Title" --body "New content"
+
+# Delete a Quick Note
+cueward quick-notes delete --title "Note Title"
+
+# Create a note in the Quick Notes folder
+cueward quick-notes create --title "Title" --body "Content"
+```
+
+Quick Notes are identified by the system `ZISSYSTEMPAPER` flag — notes created via the macOS Quick Note gesture (hot corner, Apple Pencil, etc.). `list`, `update`, and `delete` operate on these system-tagged notes regardless of which folder they reside in. `create` places a regular note in the "Quick Notes" folder but does not mark it as a system Quick Note.
+
 ## Agent Integration
 
 Cueward outputs structured JSON — it does not call any LLM. The LLM layer is your Agent's responsibility.
@@ -124,8 +193,9 @@ mkdir -p ~/.claude/skills/ && cp -r skills/cueward-agent ~/.claude/skills/
 ```
 crates/
 ├── core/            Cue struct, PlatformAdapter trait, BM25 index, auto-tagger
-├── cli/             clap CLI (capture, triage, search)
-├── adapter-macos/   Safari (SQLite), Notes (AppleScript), Messages (SQLite)
+├── cli/             clap CLI (capture, triage, search, send, plan, ocr, notes, quick-notes)
+├── adapter-macos/   Safari (SQLite), Notes (AppleScript), Messages (SQLite),
+│                    Reminders (AppleScript), Vision OCR (Swift)
 └── adapter-windows/ Reserved for future cross-platform support
 ```
 

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -5,6 +5,7 @@ pub mod applescript;
 pub mod send;
 pub mod plan;
 pub mod ocr;
+pub mod quick_notes;
 mod error;
 
 pub use error::MacosError;

--- a/crates/adapter-macos/src/quick_notes.rs
+++ b/crates/adapter-macos/src/quick_notes.rs
@@ -100,7 +100,8 @@ pub fn update(title: &str, body: &str) -> Result<(), MacosError> {
     let folder = find_folder(title)?;
     let escaped_title = escape(title);
     let escaped_folder = escape(&folder);
-    let body_expr = escape_body(&format!("<h1>{title}</h1><br>{body}"));
+    let html_title = title.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;");
+    let body_expr = escape_body(&format!("<h1>{html_title}</h1><br>{body}"));
 
     let script = format!(
         r#"

--- a/crates/adapter-macos/src/quick_notes.rs
+++ b/crates/adapter-macos/src/quick_notes.rs
@@ -1,0 +1,131 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::applescript::escape;
+use crate::send;
+use crate::MacosError;
+
+pub struct QuickNote {
+    pub title: String,
+    pub folder: String,
+}
+
+fn db_path() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_default();
+    PathBuf::from(home)
+        .join("Library/Group Containers/group.com.apple.notes/NoteStore.sqlite")
+}
+
+/// Run a read-only SQLite query via the sqlite3 CLI to get consistent WAL reads.
+fn query_db(sql: &str) -> Result<String, MacosError> {
+    let path = db_path();
+    let output = Command::new("/usr/bin/sqlite3")
+        .arg(path)
+        .arg(sql)
+        .output()
+        .map_err(|e| MacosError::Other(format!("sqlite3: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::Other(format!("sqlite3 error: {stderr}")));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// List all Quick Notes (notes with ZISSYSTEMPAPER = 1).
+pub fn list() -> Result<Vec<QuickNote>, MacosError> {
+    let raw = query_db(
+        "SELECT n.ZTITLE1, f.ZTITLE2
+         FROM ZICCLOUDSYNCINGOBJECT n
+         LEFT JOIN ZICCLOUDSYNCINGOBJECT f ON n.ZFOLDER = f.Z_PK
+         WHERE n.Z_ENT = 11
+           AND n.ZISSYSTEMPAPER = 1
+           AND n.ZMARKEDFORDELETION != 1
+           AND f.ZTITLE2 != 'Recently Deleted'",
+    )?;
+
+    let notes = raw
+        .lines()
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let mut parts = line.splitn(2, '|');
+            let title = parts.next()?.to_string();
+            let folder = parts.next().unwrap_or("").to_string();
+            if title.is_empty() {
+                return None;
+            }
+            Some(QuickNote { title, folder })
+        })
+        .collect();
+
+    Ok(notes)
+}
+
+/// Find a Quick Note's folder by title.
+fn find_folder(title: &str) -> Result<String, MacosError> {
+    let escaped = title.replace('\'', "''");
+    let raw = query_db(&format!(
+        "SELECT f.ZTITLE2
+         FROM ZICCLOUDSYNCINGOBJECT n
+         JOIN ZICCLOUDSYNCINGOBJECT f ON n.ZFOLDER = f.Z_PK
+         WHERE n.Z_ENT = 11
+           AND n.ZISSYSTEMPAPER = 1
+           AND n.ZMARKEDFORDELETION != 1
+           AND f.ZTITLE2 != 'Recently Deleted'
+           AND n.ZTITLE1 = '{escaped}'
+         LIMIT 1"
+    ))?;
+
+    raw.lines()
+        .next()
+        .map(|s| s.to_string())
+        .ok_or_else(|| MacosError::Other(format!("quick note not found: {title}")))
+}
+
+/// Create a note in the Quick Notes folder.
+///
+/// Note: this creates a regular note in the "Quick Notes" folder.
+/// It will NOT appear in the system Quick Notes smart folder (快速備忘錄)
+/// — that requires creating via the macOS Quick Note gesture.
+pub fn create(title: &str, body: &str) -> Result<(), MacosError> {
+    send::create_note(title, body, "Quick Notes")
+}
+
+/// Update a Quick Note's body (preserves title).
+pub fn update(title: &str, body: &str) -> Result<(), MacosError> {
+    let folder = find_folder(title)?;
+    let escaped_title = escape(title);
+    let escaped_folder = escape(&folder);
+    let escaped_body = escape(body);
+
+    let script = format!(
+        r#"
+        tell application "Notes"
+            set theNote to (first note of folder "{escaped_folder}" whose name is "{escaped_title}")
+            set body of theNote to "<h1>{escaped_title}</h1><br>{escaped_body}"
+        end tell
+        "#
+    );
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| MacosError::Other(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::Other(format!(
+            "failed to update quick note: {stderr}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Delete a Quick Note.
+pub fn delete(title: &str) -> Result<(), MacosError> {
+    let folder = find_folder(title)?;
+    send::delete_note(title, &folder)
+}

--- a/crates/adapter-macos/src/quick_notes.rs
+++ b/crates/adapter-macos/src/quick_notes.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-use crate::applescript::escape;
+use crate::applescript::{escape, escape_body, run};
 use crate::send;
 use crate::MacosError;
 
@@ -10,15 +10,16 @@ pub struct QuickNote {
     pub folder: String,
 }
 
-fn db_path() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_default();
-    PathBuf::from(home)
-        .join("Library/Group Containers/group.com.apple.notes/NoteStore.sqlite")
+fn db_path() -> Result<PathBuf, MacosError> {
+    let home = std::env::var("HOME")
+        .map_err(|_| MacosError::Other("HOME environment variable not set".to_string()))?;
+    Ok(PathBuf::from(home)
+        .join("Library/Group Containers/group.com.apple.notes/NoteStore.sqlite"))
 }
 
 /// Run a read-only SQLite query via the sqlite3 CLI to get consistent WAL reads.
 fn query_db(sql: &str) -> Result<String, MacosError> {
-    let path = db_path();
+    let path = db_path()?;
     let output = Command::new("/usr/bin/sqlite3")
         .arg(path)
         .arg(sql)
@@ -97,31 +98,18 @@ pub fn update(title: &str, body: &str) -> Result<(), MacosError> {
     let folder = find_folder(title)?;
     let escaped_title = escape(title);
     let escaped_folder = escape(&folder);
-    let escaped_body = escape(body);
+    let body_expr = escape_body(&format!("<h1>{title}</h1><br>{body}"));
 
     let script = format!(
         r#"
         tell application "Notes"
             set theNote to (first note of folder "{escaped_folder}" whose name is "{escaped_title}")
-            set body of theNote to "<h1>{escaped_title}</h1><br>{escaped_body}"
+            set body of theNote to {body_expr}
         end tell
         "#
     );
 
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg(&script)
-        .output()
-        .map_err(|e| MacosError::Other(format!("osascript: {e}")))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(MacosError::Other(format!(
-            "failed to update quick note: {stderr}"
-        )));
-    }
-
-    Ok(())
+    run(&script, "failed to update quick note")
 }
 
 /// Delete a Quick Note.

--- a/crates/adapter-macos/src/quick_notes.rs
+++ b/crates/adapter-macos/src/quick_notes.rs
@@ -5,6 +5,7 @@ use crate::applescript::{escape, escape_body, run};
 use crate::send;
 use crate::MacosError;
 
+#[derive(serde::Serialize)]
 pub struct QuickNote {
     pub title: String,
     pub folder: String,
@@ -21,6 +22,7 @@ fn db_path() -> Result<PathBuf, MacosError> {
 fn query_db(sql: &str) -> Result<String, MacosError> {
     let path = db_path()?;
     let output = Command::new("/usr/bin/sqlite3")
+        .arg("-readonly")
         .arg("-separator")
         .arg("\t")
         .arg(path)
@@ -44,8 +46,8 @@ pub fn list() -> Result<Vec<QuickNote>, MacosError> {
          LEFT JOIN ZICCLOUDSYNCINGOBJECT f ON n.ZFOLDER = f.Z_PK
          WHERE n.Z_ENT = 11
            AND n.ZISSYSTEMPAPER = 1
-           AND n.ZMARKEDFORDELETION != 1
-           AND f.ZTITLE2 != 'Recently Deleted'",
+           AND COALESCE(n.ZMARKEDFORDELETION, 0) != 1
+           AND (f.ZTITLE2 IS NULL OR f.ZTITLE2 != 'Recently Deleted')",
     )?;
 
     let notes = raw
@@ -74,7 +76,7 @@ fn find_folder(title: &str) -> Result<String, MacosError> {
          JOIN ZICCLOUDSYNCINGOBJECT f ON n.ZFOLDER = f.Z_PK
          WHERE n.Z_ENT = 11
            AND n.ZISSYSTEMPAPER = 1
-           AND n.ZMARKEDFORDELETION != 1
+           AND COALESCE(n.ZMARKEDFORDELETION, 0) != 1
            AND f.ZTITLE2 != 'Recently Deleted'
            AND n.ZTITLE1 = '{escaped}'
          LIMIT 1"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -84,6 +84,12 @@ enum Command {
         #[command(subcommand)]
         action: NotesAction,
     },
+
+    /// Manage Quick Notes (快速備忘錄)
+    QuickNotes {
+        #[command(subcommand)]
+        action: QuickNotesAction,
+    },
 }
 
 #[derive(Subcommand)]
@@ -127,6 +133,41 @@ enum NotesAction {
         /// Destination folder
         #[arg(long)]
         to: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum QuickNotesAction {
+    /// List all Quick Notes
+    List,
+
+    /// Create a new Quick Note
+    Create {
+        /// Note title
+        #[arg(long)]
+        title: String,
+
+        /// Note body
+        #[arg(long)]
+        body: String,
+    },
+
+    /// Update a Quick Note's body
+    Update {
+        /// Note title to find
+        #[arg(long)]
+        title: String,
+
+        /// New body content
+        #[arg(long)]
+        body: String,
+    },
+
+    /// Delete a Quick Note
+    Delete {
+        /// Note title to find
+        #[arg(long)]
+        title: String,
     },
 }
 
@@ -387,6 +428,54 @@ fn main() {
             NotesAction::Move { title, from, to } => {
                 match cueward_adapter_macos::send::move_note(&title, &from, &to) {
                     Ok(()) => eprintln!("note moved: {title} ({from} -> {to})"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+        },
+
+        Command::QuickNotes { action } => match action {
+            QuickNotesAction::List => {
+                match cueward_adapter_macos::quick_notes::list() {
+                    Ok(notes) => {
+                        if notes.is_empty() {
+                            eprintln!("no quick notes found");
+                        } else {
+                            for n in &notes {
+                                println!("[{}] {}", n.folder, n.title);
+                            }
+                            eprintln!("{} quick note(s)", notes.len());
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            QuickNotesAction::Create { title, body } => {
+                match cueward_adapter_macos::quick_notes::create(&title, &body) {
+                    Ok(()) => eprintln!("quick note created: {title}"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            QuickNotesAction::Update { title, body } => {
+                match cueward_adapter_macos::quick_notes::update(&title, &body) {
+                    Ok(()) => eprintln!("quick note updated: {title}"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            QuickNotesAction::Delete { title } => {
+                match cueward_adapter_macos::quick_notes::delete(&title) {
+                    Ok(()) => eprintln!("quick note deleted: {title}"),
                     Err(e) => {
                         eprintln!("error: {e}");
                         process::exit(1);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -443,10 +443,9 @@ fn main() {
                         if notes.is_empty() {
                             eprintln!("no quick notes found");
                         } else {
-                            for n in &notes {
-                                println!("[{}] {}", n.folder, n.title);
-                            }
-                            eprintln!("{} quick note(s)", notes.len());
+                            let count = notes.len();
+                            println!("{}", serde_json::to_string_pretty(&notes).unwrap());
+                            eprintln!("{count} quick note(s)");
                         }
                     }
                     Err(e) => {

--- a/skills/cueward-agent/SKILL.md
+++ b/skills/cueward-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cueward-agent
-description: Use Cueward CLI to capture, triage, and search the user's scattered knowledge from Safari, Apple Notes, and iMessage. Trigger when the user asks about their browsing history, recent notes, messages, or wants to organize/search their daily knowledge intake. Also use when the user says things like "what did I read today", "find that article I saw", "summarize my knowledge intake", or "help me organize what I've been looking at".
+description: Use Cueward CLI to capture, triage, search, and manage the user's scattered knowledge from Safari, Apple Notes, and iMessage. Also supports OCR (images/PDFs), creating Notes and Reminders, managing notes (update/delete/move), and Quick Notes (快速備忘錄) operations. Trigger when the user asks about their browsing history, recent notes, messages, Quick Notes, wants to organize knowledge, create a digest, set reminders from captured content, extract text from images/PDFs, or manage Apple Notes. Also use when the user says things like "what did I read today", "find that article I saw", "summarize my knowledge intake", "help me organize what I've been looking at", "create a reminder for this", "write a summary note", "OCR this screenshot", "list my quick notes", or "what's in my quick notes".
 ---
 
 # Cueward Agent Skill
@@ -125,6 +125,28 @@ cueward notes move --title "Note Title" --from Cueward --to Archive
 
 These commands find notes by exact title match within the specified folder.
 
+### 8. Quick Notes
+
+List, update, and delete system Quick Notes (快速備忘錄). Quick Notes are notes created via the macOS Quick Note gesture and tagged with a system flag — they may reside in any folder.
+
+```bash
+# List all Quick Notes
+cueward quick-notes list
+
+# Update a Quick Note's body (finds by title across all folders)
+cueward quick-notes update --title "Note Title" --body "New content"
+
+# Delete a Quick Note
+cueward quick-notes delete --title "Note Title"
+
+# Create a note in the Quick Notes folder (not a system Quick Note)
+cueward quick-notes create --title "Title" --body "Content"
+```
+
+- `list` outputs one line per note: `[folder] title`
+- `update` and `delete` locate the note by title using the system Quick Note flag — no folder needed
+- `create` places a regular note in the "Quick Notes" folder; it will NOT appear in the system Quick Notes smart folder (快速備忘錄) unless created via macOS gesture
+
 ## Workflow Patterns
 
 ### Daily knowledge digest
@@ -191,6 +213,16 @@ cueward ocr ~/Desktop/screenshot.png
 ```
 
 Then summarize the extracted text or answer questions about it.
+
+### Quick Notes review
+
+When the user asks about their Quick Notes or wants to review jotted-down ideas:
+
+```bash
+cueward quick-notes list
+```
+
+Then summarize the Quick Notes, group by folder, or help the user decide what to keep, archive, or delete.
 
 ## Important Notes
 

--- a/skills/cueward-agent/SKILL.md
+++ b/skills/cueward-agent/SKILL.md
@@ -143,7 +143,7 @@ cueward quick-notes delete --title "Note Title"
 cueward quick-notes create --title "Title" --body "Content"
 ```
 
-- `list` outputs one line per note: `[folder] title`
+- `list` outputs a JSON array of `{"title": "...", "folder": "..."}` objects to stdout
 - `update` and `delete` locate the note by title using the system Quick Note flag — no folder needed
 - `create` places a regular note in the "Quick Notes" folder; it will NOT appear in the system Quick Notes smart folder (快速備忘錄) unless created via macOS gesture
 


### PR DESCRIPTION
## Summary

- Add `cueward quick-notes` subcommand with list, create, update, and delete operations
- Quick Notes are identified via the macOS `ZISSYSTEMPAPER` SQLite flag — a virtual smart folder, not a physical one
- Uses `/usr/bin/sqlite3` CLI for WAL-consistent reads, AppleScript for write operations
- `create` places notes in the Quick Notes folder (content syncs via iCloud, but system flag requires macOS gesture)

## Changes

- **New**: `crates/adapter-macos/src/quick_notes.rs` — list/create/update/delete logic
- **Modified**: `crates/adapter-macos/src/lib.rs` — export `quick_notes` module
- **Modified**: `crates/cli/src/main.rs` — `QuickNotes` command + `QuickNotesAction` enum
- **Modified**: `README.md` — Quick Notes usage section
- **Modified**: `skills/cueward-agent/SKILL.md` — command docs + workflow pattern

## Test plan

- [ ] `cueward quick-notes list` — lists system Quick Notes with folder
- [ ] `cueward quick-notes create --title "Test" --body "Content"` — creates note in Quick Notes folder
- [ ] `cueward quick-notes update --title "<existing>" --body "Updated"` — updates body, preserves title
- [ ] `cueward quick-notes delete --title "<existing>"` — deletes note
- [ ] Verify no compilation warnings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
