### PR TITLE
feat: calendar, screenshot, clipboard integrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +241,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +299,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "cueward-adapter-macos"
 version = "0.1.0"
 dependencies = [
@@ -289,6 +317,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
 ]
 
@@ -330,6 +359,16 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -410,6 +449,16 @@ checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
 dependencies = [
  "rustix 0.38.44",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1026,6 +1075,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1376,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1422,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Cueward reads local databases that require Full Disk Access:
 1. Open **System Settings > Privacy & Security > Full Disk Access**
 2. Add your terminal app (Termdock, Terminal.app, iTerm2, WezTerm, etc.)
 
-For Apple Notes and Reminders operations, also allow automation:
-- **System Settings > Privacy & Security > Automation** > allow your terminal to control Notes and Reminders
+For Apple Notes, Reminders, and Calendar operations, also allow automation:
+- **System Settings > Privacy & Security > Automation** > allow your terminal to control Notes, Reminders, and Calendar
 
 ## Usage
 
@@ -146,6 +146,64 @@ cueward notes delete --title "Note Title" --folder Cueward
 cueward notes move --title "Note Title" --from Cueward --to Archive
 ```
 
+### Calendar
+
+Query and manage Apple Calendar events:
+
+```bash
+# Today's events
+cueward calendar today
+
+# Events in a time range
+cueward calendar list --from "2026-04-11 09:00" --to "2026-04-11 18:00"
+
+# Filter by calendar
+cueward calendar list --calendar Work
+
+# Create an event
+cueward calendar create --title "Team Sync" --start "2026-04-12 14:00" --end "2026-04-12 15:00" --calendar Work --location "Google Meet" --notes "Weekly sync"
+
+# Delete an event (matches by title + start time)
+cueward calendar delete --title "Team Sync" --start "2026-04-12 14:00"
+```
+
+Datetime format: ISO 8601 (`2026-04-11T14:00:00`) or `YYYY-MM-DD HH:MM`.
+
+### Screenshot
+
+Capture a screenshot, optionally with OCR:
+
+```bash
+# Capture main screen
+cueward screenshot
+
+# With OCR text extraction
+cueward screenshot --ocr
+
+# Specific display (1=main, 2=secondary, 3=third)
+cueward screenshot --display 2
+
+# Custom output path
+cueward screenshot --output ~/Desktop/shot.png --ocr
+```
+
+### Clipboard
+
+Read and write the system clipboard:
+
+```bash
+# Read clipboard (text or image)
+cueward clipboard get
+
+# Save clipboard image to a specific path
+cueward clipboard get --save-image ~/Desktop/clip.png
+
+# Write text to clipboard
+cueward clipboard set "Hello from cueward"
+```
+
+Text content returns JSON with `"type": "text"`. Image content is saved as PNG and returns `"type": "image"` with the file path.
+
 ### Quick Notes
 
 List, update, archive, and delete system Quick Notes (快速備忘錄):
@@ -199,9 +257,11 @@ mkdir -p ~/.claude/skills/ && cp -r skills/cueward-agent ~/.claude/skills/
 ```
 crates/
 ├── core/            Cue struct, PlatformAdapter trait, BM25 index, auto-tagger
-├── cli/             clap CLI (capture, triage, search, send, plan, ocr, notes, quick-notes)
+├── cli/             clap CLI (capture, triage, search, send, plan, ocr, notes, quick-notes,
+│                    calendar, screenshot, clipboard)
 ├── adapter-macos/   Safari (SQLite), Notes (AppleScript), Messages (SQLite),
-│                    Reminders (AppleScript), Vision OCR (Swift)
+│                    Reminders (AppleScript), Calendar (AppleScript),
+│                    Vision OCR (Swift), Screenshot (screencapture), Clipboard (pbpaste/pbcopy)
 └── adapter-windows/ Reserved for future cross-platform support
 ```
 
@@ -216,6 +276,10 @@ crates/
 ├── inbox/        Captured cues awaiting triage
 ├── processed/    Triaged cues (moved from inbox)
 ├── index/        Tantivy BM25 search index
+├── cache/
+│   ├── ocr/          OCR result cache (by SHA256)
+│   ├── screenshots/  Screenshot captures
+│   └── clipboard/    Clipboard image captures
 ├── state.json    High watermark timestamps per source
 └── tags.toml     Auto-tagging keyword rules (user-created)
 ```

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -2,11 +2,18 @@
 name = "cueward-adapter-macos"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+rust-version.workspace = true
+description = "macOS adapter for Cueward with Safari, Notes, Messages, Reminders, and OCR integrations."
 
 [dependencies]
-cueward-core = { path = "../core" }
+cueward-core = { version = "0.1.0", path = "../core" }
 rusqlite = { version = "0.35", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
+sha2 = "0.10"

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 readme.workspace = true
 rust-version.workspace = true
-description = "macOS adapter for Cueward with Safari, Notes, Messages, Reminders, and OCR integrations."
+description = "macOS adapter for Cueward with Safari, Notes, Messages, Reminders, Calendar, Screenshot, Clipboard, and OCR integrations."
 
 [dependencies]
 cueward-core = { version = "0.1.0", path = "../core" }

--- a/crates/adapter-macos/src/applescript.rs
+++ b/crates/adapter-macos/src/applescript.rs
@@ -16,6 +16,22 @@ pub fn escape_body(s: &str) -> String {
     parts.join(" & linefeed & ")
 }
 
+/// Run an AppleScript and return its stdout on success.
+pub fn run_capture(script: &str, context: &str) -> Result<String, MacosError> {
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .map_err(|e| MacosError::Other(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::Other(format!("{context}: {stderr}")));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
 /// Run an AppleScript and return Ok or a descriptive error.
 pub fn run(script: &str, context: &str) -> Result<(), MacosError> {
     let output = Command::new("osascript")

--- a/crates/adapter-macos/src/calendar.rs
+++ b/crates/adapter-macos/src/calendar.rs
@@ -1,10 +1,8 @@
-use std::process::Command;
-
 use chrono::{DateTime, Local};
 use serde::Serialize;
 
 use crate::MacosError;
-use crate::applescript::{escape, run};
+use crate::applescript::{escape, run, run_capture};
 
 const EVENT_SEPARATOR: &str = "---EVENT_SEP---";
 
@@ -154,18 +152,7 @@ pub fn list_events(
         "#
     );
 
-    let raw = Command::new("osascript")
-        .arg("-e")
-        .arg(&script)
-        .output()
-        .map_err(|e| MacosError::Other(format!("osascript: {e}")))?;
-
-    if !raw.status.success() {
-        let stderr = String::from_utf8_lossy(&raw.stderr);
-        return Err(MacosError::Other(format!("list_events: {stderr}")));
-    }
-
-    let stdout = String::from_utf8_lossy(&raw.stdout);
+    let stdout = run_capture(&script, "list_events")?;
     let events = parse_events_output(&stdout);
 
     Ok(events)

--- a/crates/adapter-macos/src/calendar.rs
+++ b/crates/adapter-macos/src/calendar.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Local};
 use serde::Serialize;
 
 use crate::MacosError;
-use crate::applescript::{escape, run, run_capture};
+use crate::applescript::{escape, escape_body, run, run_capture};
 
 const EVENT_SEPARATOR: &str = "---EVENT_SEP---";
 
@@ -49,8 +49,8 @@ fn decode_field(value: &str) -> String {
 /// Parse a tab-separated event line from the AppleScript output.
 /// Fields: title \t start \t end \t calendar \t location \t notes \t all_day
 pub fn parse_event_line(line: &str) -> Option<CalendarEvent> {
-    let parts: Vec<&str> = line.splitn(7, '\t').collect();
-    if parts.len() < 7 {
+    let parts: Vec<&str> = line.split('\t').collect();
+    if parts.len() != 7 {
         return None;
     }
     let title = decode_field(parts[0]);
@@ -128,7 +128,7 @@ pub fn list_events(
             {cal_filter_block}
             repeat with aCal in targetCals
                 set calName to my encode_field(name of aCal)
-                set evts to (events of aCal whose start date >= fromDate and start date <= toDate)
+                set evts to (events of aCal whose (start date < toDate) and (end date > fromDate))
                 repeat with evt in evts
                     set evtTitle to my encode_field(summary of evt)
                     set evtStart to (start date of evt) as «class isot» as string
@@ -172,10 +172,10 @@ pub fn create_event(
     let end_str = format_for_applescript(&end);
 
     let notes_prop = notes
-        .map(|n| format!(r#", description:"{}""#, escape(n)))
+        .map(|n| format!(r#", description:{}"#, escape_body(n)))
         .unwrap_or_default();
     let location_prop = location
-        .map(|l| format!(r#", location:"{}""#, escape(l)))
+        .map(|l| format!(r#", location:{}"#, escape_body(l)))
         .unwrap_or_default();
 
     let target_cal_block = match calendar_name {
@@ -255,5 +255,12 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].notes, "Line 1\nLine 2");
+    }
+
+    #[test]
+    fn create_event_script_uses_escape_body_for_multiline_fields() {
+        let escaped = crate::applescript::escape_body("Line 1\nLine 2");
+
+        assert_eq!(escaped, "\"Line 1\" & linefeed & \"Line 2\"");
     }
 }

--- a/crates/adapter-macos/src/calendar.rs
+++ b/crates/adapter-macos/src/calendar.rs
@@ -3,8 +3,10 @@ use std::process::Command;
 use chrono::{DateTime, Local};
 use serde::Serialize;
 
-use crate::applescript::{escape, run};
 use crate::MacosError;
+use crate::applescript::{escape, run};
+
+const EVENT_SEPARATOR: &str = "---EVENT_SEP---";
 
 #[derive(Serialize)]
 pub struct CalendarEvent {
@@ -22,6 +24,30 @@ fn format_for_applescript(dt: &DateTime<Local>) -> String {
     dt.format("%Y-%m-%d %H:%M:%S").to_string()
 }
 
+fn decode_field(value: &str) -> String {
+    let mut decoded = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            decoded.push(ch);
+            continue;
+        }
+
+        match chars.next() {
+            Some('n') => decoded.push('\n'),
+            Some('r') => decoded.push('\r'),
+            Some('t') => decoded.push('\t'),
+            Some('\\') => decoded.push('\\'),
+            Some(other) => {
+                decoded.push('\\');
+                decoded.push(other);
+            }
+            None => decoded.push('\\'),
+        }
+    }
+    decoded
+}
+
 /// Parse a tab-separated event line from the AppleScript output.
 /// Fields: title \t start \t end \t calendar \t location \t notes \t all_day
 pub fn parse_event_line(line: &str) -> Option<CalendarEvent> {
@@ -29,7 +55,7 @@ pub fn parse_event_line(line: &str) -> Option<CalendarEvent> {
     if parts.len() < 7 {
         return None;
     }
-    let title = parts[0].to_string();
+    let title = decode_field(parts[0]);
     if title.is_empty() {
         return None;
     }
@@ -37,11 +63,19 @@ pub fn parse_event_line(line: &str) -> Option<CalendarEvent> {
         title,
         start: parts[1].to_string(),
         end: parts[2].to_string(),
-        calendar: parts[3].to_string(),
-        location: parts[4].to_string(),
-        notes: parts[5].to_string(),
+        calendar: decode_field(parts[3]),
+        location: decode_field(parts[4]),
+        notes: decode_field(parts[5]),
         all_day: parts[6].trim() == "true",
     })
+}
+
+fn parse_events_output(stdout: &str) -> Vec<CalendarEvent> {
+    stdout
+        .split(EVENT_SEPARATOR)
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(parse_event_line)
+        .collect()
 }
 
 /// List calendar events in the given time range, optionally filtered by calendar name.
@@ -68,30 +102,51 @@ pub fn list_events(
 
     let script = format!(
         r#"
+        on replace_text(find_text, replace_text, source_text)
+            set previous_delimiters to AppleScript's text item delimiters
+            set AppleScript's text item delimiters to find_text
+            set chunks to every text item of source_text
+            set AppleScript's text item delimiters to replace_text
+            set replaced_text to chunks as text
+            set AppleScript's text item delimiters to previous_delimiters
+            return replaced_text
+        end replace_text
+
+        on encode_field(source_text)
+            if source_text is missing value then
+                return ""
+            end if
+            set escaped_text to my replace_text("\\", "\\\\", source_text)
+            set escaped_text to my replace_text(tab, "\\t", escaped_text)
+            set escaped_text to my replace_text(return, "\\r", escaped_text)
+            set escaped_text to my replace_text(linefeed, "\\n", escaped_text)
+            return escaped_text
+        end encode_field
+
         tell application "Calendar"
             set fromDate to date "{from_str}"
             set toDate to date "{to_str}"
             set output to ""
             {cal_filter_block}
             repeat with aCal in targetCals
-                set calName to name of aCal
+                set calName to my encode_field(name of aCal)
                 set evts to (events of aCal whose start date >= fromDate and start date <= toDate)
                 repeat with evt in evts
-                    set evtTitle to summary of evt
+                    set evtTitle to my encode_field(summary of evt)
                     set evtStart to (start date of evt) as «class isot» as string
                     set evtEnd to (end date of evt) as «class isot» as string
                     if location of evt is missing value then
                         set evtLoc to ""
                     else
-                        set evtLoc to location of evt
+                        set evtLoc to my encode_field(location of evt)
                     end if
                     if description of evt is missing value then
                         set evtNotes to ""
                     else
-                        set evtNotes to description of evt
+                        set evtNotes to my encode_field(description of evt)
                     end if
                     set evtAllDay to allday event of evt
-                    set output to output & evtTitle & tab & evtStart & tab & evtEnd & tab & calName & tab & evtLoc & tab & evtNotes & tab & evtAllDay & linefeed
+                    set output to output & evtTitle & tab & evtStart & tab & evtEnd & tab & calName & tab & evtLoc & tab & evtNotes & tab & evtAllDay & "{EVENT_SEPARATOR}"
                 end repeat
             end repeat
             return output
@@ -111,11 +166,7 @@ pub fn list_events(
     }
 
     let stdout = String::from_utf8_lossy(&raw.stdout);
-    let events = stdout
-        .lines()
-        .filter(|l| !l.is_empty())
-        .filter_map(parse_event_line)
-        .collect();
+    let events = parse_events_output(&stdout);
 
     Ok(events)
 }
@@ -187,4 +238,35 @@ pub fn delete_event(
     );
 
     run(&script, "failed to delete calendar event")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_event_line, parse_events_output};
+
+    #[test]
+    fn parse_event_line_unescapes_sanitized_fields() {
+        let line = "Team\\tSync\t2026-04-11T09:00:00Z\t2026-04-11T10:00:00Z\tWork\\nCal\tRoom\\rA\tLine 1\\nLine 2\ttrue";
+
+        let event = parse_event_line(line).expect("event");
+
+        assert_eq!(event.title, "Team\tSync");
+        assert_eq!(event.calendar, "Work\nCal");
+        assert_eq!(event.location, "Room\rA");
+        assert_eq!(event.notes, "Line 1\nLine 2");
+        assert!(event.all_day);
+    }
+
+    #[test]
+    fn parse_events_output_keeps_multiline_notes() {
+        let raw = concat!(
+            "Title\t2026-04-11T09:00:00Z\t2026-04-11T10:00:00Z\tWork\tDesk\tLine 1\\nLine 2\tfalse",
+            "---EVENT_SEP---"
+        );
+
+        let events = parse_events_output(raw);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].notes, "Line 1\nLine 2");
+    }
 }

--- a/crates/adapter-macos/src/calendar.rs
+++ b/crates/adapter-macos/src/calendar.rs
@@ -1,0 +1,190 @@
+use std::process::Command;
+
+use chrono::{DateTime, Local};
+use serde::Serialize;
+
+use crate::applescript::{escape, run};
+use crate::MacosError;
+
+#[derive(Serialize)]
+pub struct CalendarEvent {
+    pub title: String,
+    pub start: String,
+    pub end: String,
+    pub calendar: String,
+    pub location: String,
+    pub notes: String,
+    pub all_day: bool,
+}
+
+/// Format a local datetime as "YYYY-MM-DD HH:MM:SS" for AppleScript date parsing.
+fn format_for_applescript(dt: &DateTime<Local>) -> String {
+    dt.format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+/// Parse a tab-separated event line from the AppleScript output.
+/// Fields: title \t start \t end \t calendar \t location \t notes \t all_day
+pub fn parse_event_line(line: &str) -> Option<CalendarEvent> {
+    let parts: Vec<&str> = line.splitn(7, '\t').collect();
+    if parts.len() < 7 {
+        return None;
+    }
+    let title = parts[0].to_string();
+    if title.is_empty() {
+        return None;
+    }
+    Some(CalendarEvent {
+        title,
+        start: parts[1].to_string(),
+        end: parts[2].to_string(),
+        calendar: parts[3].to_string(),
+        location: parts[4].to_string(),
+        notes: parts[5].to_string(),
+        all_day: parts[6].trim() == "true",
+    })
+}
+
+/// List calendar events in the given time range, optionally filtered by calendar name.
+pub fn list_events(
+    from: DateTime<Local>,
+    to: DateTime<Local>,
+    calendar_filter: Option<&str>,
+) -> Result<Vec<CalendarEvent>, MacosError> {
+    let from_str = format_for_applescript(&from);
+    let to_str = format_for_applescript(&to);
+
+    let cal_filter_block = match calendar_filter {
+        Some(name) => {
+            let escaped = escape(name);
+            format!(
+                r#"set targetCals to (calendars whose name is "{escaped}")
+            if targetCals is {{}} then
+                return ""
+            end if"#
+            )
+        }
+        None => "set targetCals to calendars".to_string(),
+    };
+
+    let script = format!(
+        r#"
+        tell application "Calendar"
+            set fromDate to date "{from_str}"
+            set toDate to date "{to_str}"
+            set output to ""
+            {cal_filter_block}
+            repeat with aCal in targetCals
+                set calName to name of aCal
+                set evts to (events of aCal whose start date >= fromDate and start date <= toDate)
+                repeat with evt in evts
+                    set evtTitle to summary of evt
+                    set evtStart to (start date of evt) as «class isot» as string
+                    set evtEnd to (end date of evt) as «class isot» as string
+                    if location of evt is missing value then
+                        set evtLoc to ""
+                    else
+                        set evtLoc to location of evt
+                    end if
+                    if description of evt is missing value then
+                        set evtNotes to ""
+                    else
+                        set evtNotes to description of evt
+                    end if
+                    set evtAllDay to allday event of evt
+                    set output to output & evtTitle & tab & evtStart & tab & evtEnd & tab & calName & tab & evtLoc & tab & evtNotes & tab & evtAllDay & linefeed
+                end repeat
+            end repeat
+            return output
+        end tell
+        "#
+    );
+
+    let raw = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| MacosError::Other(format!("osascript: {e}")))?;
+
+    if !raw.status.success() {
+        let stderr = String::from_utf8_lossy(&raw.stderr);
+        return Err(MacosError::Other(format!("list_events: {stderr}")));
+    }
+
+    let stdout = String::from_utf8_lossy(&raw.stdout);
+    let events = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .filter_map(parse_event_line)
+        .collect();
+
+    Ok(events)
+}
+
+/// Create a calendar event.
+pub fn create_event(
+    title: &str,
+    start: DateTime<Local>,
+    end: DateTime<Local>,
+    calendar_name: Option<&str>,
+    notes: Option<&str>,
+    location: Option<&str>,
+) -> Result<(), MacosError> {
+    let escaped_title = escape(title);
+    let start_str = format_for_applescript(&start);
+    let end_str = format_for_applescript(&end);
+
+    let notes_prop = notes
+        .map(|n| format!(r#", description:"{}""#, escape(n)))
+        .unwrap_or_default();
+    let location_prop = location
+        .map(|l| format!(r#", location:"{}""#, escape(l)))
+        .unwrap_or_default();
+
+    let target_cal_block = match calendar_name {
+        Some(name) => {
+            let escaped = escape(name);
+            format!(r#"set targetCal to calendar "{escaped}""#)
+        }
+        None => "set targetCal to default calendar".to_string(),
+    };
+
+    let script = format!(
+        r#"
+        tell application "Calendar"
+            {target_cal_block}
+            make new event at end of events of targetCal with properties {{summary:"{escaped_title}", start date:date "{start_str}", end date:date "{end_str}"{notes_prop}{location_prop}}}
+        end tell
+        "#
+    );
+
+    run(&script, "failed to create calendar event")
+}
+
+/// Delete a calendar event matched by title and start date.
+pub fn delete_event(
+    title: &str,
+    start: DateTime<Local>,
+    calendar_name: &str,
+) -> Result<(), MacosError> {
+    let escaped_title = escape(title);
+    let escaped_cal = escape(calendar_name);
+    let start_str = format_for_applescript(&start);
+
+    let script = format!(
+        r#"
+        tell application "Calendar"
+            set targetCal to calendar "{escaped_cal}"
+            set startDate to date "{start_str}"
+            set matchingEvts to (events of targetCal whose summary is "{escaped_title}" and start date is startDate)
+            if matchingEvts is {{}} then
+                error "event not found: {escaped_title}"
+            end if
+            repeat with evt in matchingEvts
+                delete evt
+            end repeat
+        end tell
+        "#
+    );
+
+    run(&script, "failed to delete calendar event")
+}

--- a/crates/adapter-macos/src/clipboard.rs
+++ b/crates/adapter-macos/src/clipboard.rs
@@ -1,0 +1,136 @@
+use std::fs;
+use std::process::Command;
+
+use chrono::Local;
+use serde::Serialize;
+
+use crate::MacosError;
+
+#[derive(Debug, Serialize)]
+pub struct ClipboardContent {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+const CACHE_DIR: &str = ".cueward/cache/clipboard";
+
+fn ensure_cache_dir() -> Result<String, MacosError> {
+    let home = std::env::var("HOME")
+        .map_err(|_| MacosError::Other("HOME not set".into()))?;
+    let dir = format!("{home}/{CACHE_DIR}");
+    fs::create_dir_all(&dir)
+        .map_err(|e| MacosError::Other(format!("failed to create {dir}: {e}")))?;
+    Ok(dir)
+}
+
+/// Check if clipboard contains an image.
+fn has_image() -> bool {
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg("clipboard info")
+        .output();
+    match output {
+        Ok(o) => {
+            let info = String::from_utf8_lossy(&o.stdout);
+            info.contains("«class PNGf»") || info.contains("«class TIFF»")
+        }
+        Err(_) => false,
+    }
+}
+
+/// Save clipboard image to PNG using AppleScript with Cocoa bridge.
+fn save_clipboard_image(save_path: &str) -> Result<(), MacosError> {
+    let script = format!(
+        r#"
+        use framework "AppKit"
+        set pb to current application's NSPasteboard's generalPasteboard()
+        set imgData to pb's dataForType:(current application's NSPasteboardTypePNG)
+        if imgData is missing value then
+            set tiffData to pb's dataForType:(current application's NSPasteboardTypeTIFF)
+            if tiffData is missing value then error "no image in clipboard"
+            set bitmapRep to current application's NSBitmapImageRep's imageRepWithData:tiffData
+            set imgData to bitmapRep's representationUsingType:(current application's NSBitmapImageFileTypePNG) properties:(missing value)
+        end if
+        imgData's writeToFile:"{save_path}" atomically:true
+        "#,
+        save_path = save_path.replace('"', "\\\""),
+    );
+
+    let output = Command::new("osascript")
+        .arg("-l")
+        .arg("AppleScript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| MacosError::Other(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::Other(format!("failed to save clipboard image: {stderr}")));
+    }
+
+    Ok(())
+}
+
+/// Read clipboard content. Returns text or saves image and returns path.
+pub fn get(save_image_path: Option<&str>) -> Result<ClipboardContent, MacosError> {
+    if has_image() {
+        let path = match save_image_path {
+            Some(p) => p.to_string(),
+            None => {
+                let dir = ensure_cache_dir()?;
+                let ts = Local::now().format("%Y%m%d-%H%M%S").to_string();
+                format!("{dir}/{ts}.png")
+            }
+        };
+
+        save_clipboard_image(&path)?;
+
+        return Ok(ClipboardContent {
+            content_type: "image".into(),
+            content: None,
+            path: Some(path),
+        });
+    }
+
+    let output = Command::new("pbpaste")
+        .output()
+        .map_err(|e| MacosError::Other(format!("pbpaste: {e}")))?;
+
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    Ok(ClipboardContent {
+        content_type: "text".into(),
+        content: Some(text),
+        path: None,
+    })
+}
+
+/// Write text to clipboard via pbcopy (stdin pipe, no shell injection).
+pub fn set(text: &str) -> Result<(), MacosError> {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = Command::new("pbcopy")
+        .stdin(Stdio::piped())
+        .spawn()
+        .map_err(|e| MacosError::Other(format!("pbcopy: {e}")))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(text.as_bytes())
+            .map_err(|e| MacosError::Other(format!("failed to write to pbcopy: {e}")))?;
+    }
+
+    let status = child.wait()
+        .map_err(|e| MacosError::Other(format!("pbcopy: {e}")))?;
+
+    if !status.success() {
+        return Err(MacosError::Other("pbcopy failed".into()));
+    }
+
+    Ok(())
+}

--- a/crates/adapter-macos/src/clipboard.rs
+++ b/crates/adapter-macos/src/clipboard.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::{Component, Path};
 use std::process::Command;
 
 use chrono::Local;
@@ -18,9 +19,19 @@ pub struct ClipboardContent {
 
 const CACHE_DIR: &str = ".cueward/cache/clipboard";
 
+fn validate_user_output_path(path: &str) -> Result<&Path, String> {
+    let candidate = Path::new(path);
+    if candidate
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err("path must not contain parent directory components".into());
+    }
+    Ok(candidate)
+}
+
 fn ensure_cache_dir() -> Result<String, MacosError> {
-    let home = std::env::var("HOME")
-        .map_err(|_| MacosError::Other("HOME not set".into()))?;
+    let home = std::env::var("HOME").map_err(|_| MacosError::Other("HOME not set".into()))?;
     let dir = format!("{home}/{CACHE_DIR}");
     fs::create_dir_all(&dir)
         .map_err(|e| MacosError::Other(format!("failed to create {dir}: {e}")))?;
@@ -44,6 +55,8 @@ fn has_image() -> bool {
 
 /// Save clipboard image to PNG using AppleScript with Cocoa bridge.
 fn save_clipboard_image(save_path: &str) -> Result<(), MacosError> {
+    validate_user_output_path(save_path).map_err(MacosError::Other)?;
+
     let script = format!(
         r#"
         use framework "AppKit"
@@ -57,7 +70,7 @@ fn save_clipboard_image(save_path: &str) -> Result<(), MacosError> {
         end if
         imgData's writeToFile:"{save_path}" atomically:true
         "#,
-        save_path = save_path.replace('"', "\\\""),
+        save_path = save_path.replace('\\', "\\\\").replace('"', "\\\""),
     );
 
     let output = Command::new("osascript")
@@ -70,7 +83,9 @@ fn save_clipboard_image(save_path: &str) -> Result<(), MacosError> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(MacosError::Other(format!("failed to save clipboard image: {stderr}")));
+        return Err(MacosError::Other(format!(
+            "failed to save clipboard image: {stderr}"
+        )));
     }
 
     Ok(())
@@ -120,12 +135,16 @@ pub fn set(text: &str) -> Result<(), MacosError> {
         .spawn()
         .map_err(|e| MacosError::Other(format!("pbcopy: {e}")))?;
 
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin.write_all(text.as_bytes())
-            .map_err(|e| MacosError::Other(format!("failed to write to pbcopy: {e}")))?;
-    }
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| MacosError::Other("failed to open stdin for pbcopy".into()))?;
+    stdin
+        .write_all(text.as_bytes())
+        .map_err(|e| MacosError::Other(format!("failed to write to pbcopy: {e}")))?;
 
-    let status = child.wait()
+    let status = child
+        .wait()
         .map_err(|e| MacosError::Other(format!("pbcopy: {e}")))?;
 
     if !status.success() {
@@ -133,4 +152,25 @@ pub fn set(text: &str) -> Result<(), MacosError> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::validate_user_output_path;
+
+    #[test]
+    fn validate_user_output_path_rejects_parent_components() {
+        let err = validate_user_output_path("../../etc/passwd").expect_err("should reject");
+
+        assert!(err.contains("parent directory"));
+    }
+
+    #[test]
+    fn validate_user_output_path_accepts_normal_relative_paths() {
+        let path = validate_user_output_path("screenshots/out.png").expect("path");
+
+        assert_eq!(path, Path::new("screenshots/out.png"));
+    }
 }

--- a/crates/adapter-macos/src/clipboard.rs
+++ b/crates/adapter-macos/src/clipboard.rs
@@ -21,6 +21,9 @@ const CACHE_DIR: &str = ".cueward/cache/clipboard";
 
 fn validate_user_output_path(path: &str) -> Result<&Path, String> {
     let candidate = Path::new(path);
+    if path.contains('\n') || path.contains('\r') {
+        return Err("path must not contain control characters".into());
+    }
     if candidate
         .components()
         .any(|component| matches!(component, Component::ParentDir))
@@ -95,7 +98,10 @@ fn save_clipboard_image(save_path: &str) -> Result<(), MacosError> {
 pub fn get(save_image_path: Option<&str>) -> Result<ClipboardContent, MacosError> {
     if has_image() {
         let path = match save_image_path {
-            Some(p) => p.to_string(),
+            Some(p) => {
+                validate_user_output_path(p).map_err(MacosError::Other)?;
+                p.to_string()
+            }
             None => {
                 let dir = ensure_cache_dir()?;
                 let ts = Local::now().format("%Y%m%d-%H%M%S").to_string();
@@ -142,6 +148,7 @@ pub fn set(text: &str) -> Result<(), MacosError> {
     stdin
         .write_all(text.as_bytes())
         .map_err(|e| MacosError::Other(format!("failed to write to pbcopy: {e}")))?;
+    drop(stdin);
 
     let status = child
         .wait()
@@ -165,6 +172,13 @@ mod tests {
         let err = validate_user_output_path("../../etc/passwd").expect_err("should reject");
 
         assert!(err.contains("parent directory"));
+    }
+
+    #[test]
+    fn validate_user_output_path_rejects_control_characters() {
+        let err = validate_user_output_path("bad\npath.png").expect_err("should reject");
+
+        assert!(err.contains("control characters"));
     }
 
     #[test]

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -2,6 +2,7 @@ mod safari;
 mod notes;
 mod messages;
 pub mod applescript;
+pub mod calendar;
 pub mod send;
 pub mod plan;
 pub mod ocr;

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -3,6 +3,7 @@ mod notes;
 mod messages;
 pub mod applescript;
 pub mod calendar;
+pub mod clipboard;
 pub mod send;
 pub mod plan;
 pub mod ocr;

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -7,6 +7,7 @@ pub mod send;
 pub mod plan;
 pub mod ocr;
 pub mod quick_notes;
+pub mod screenshot;
 mod error;
 
 pub use error::MacosError;

--- a/crates/adapter-macos/src/messages.rs
+++ b/crates/adapter-macos/src/messages.rs
@@ -86,6 +86,7 @@ pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
                 url: None,
                 title: None,
                 tags: Vec::new(),
+                attachment_segments: Vec::new(),
                 metadata,
             }
         })

--- a/crates/adapter-macos/src/notes.rs
+++ b/crates/adapter-macos/src/notes.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use chrono::{DateTime, TimeZone, Utc};
-use rusqlite::Connection;
+use rusqlite::{Connection, OpenFlags};
 use sha2::{Digest, Sha256};
 
 use cueward_core::{AttachmentSegment, Cue, CueSource};
@@ -17,6 +17,8 @@ const ATTACHMENT_PLACEHOLDER: char = '\u{fffc}';
 const ATTACHMENT_LABEL: &str = "[Attachment]";
 const MEDIA_MATCH_WINDOW_SECS: i64 = 5;
 const APPLE_EPOCH_OFFSET: f64 = 978_307_200.0;
+const MAX_MEDIA_SEARCH_DEPTH: usize = 10;
+const OCR_EMPTY_SENTINEL: &str = "__CUEWARD_OCR_EMPTY__";
 
 pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
     let seconds_ago = (Utc::now() - since).num_seconds().max(0);
@@ -67,7 +69,9 @@ pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
                 "Apple Notes access denied. Allow automation in System Settings > Privacy & Security > Automation".into(),
             ));
         }
-        return Err(MacosError::PermissionDenied(format!("osascript error: {stderr}")));
+        return Err(MacosError::PermissionDenied(format!(
+            "osascript error: {stderr}"
+        )));
     }
 
     let raw = String::from_utf8_lossy(&output.stdout);
@@ -100,16 +104,24 @@ pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
         })
         .collect();
 
-    if let Ok(media_notes) = load_media_notes() {
-        enrich_cues_with_media(&mut cues, &media_notes);
-        enrich_cues_with_attachment_ocr(&mut cues, &media_notes);
+    let has_attachment_placeholders = cues.iter().any(|cue| {
+        matches!(cue.source, CueSource::Notes) && attachment_placeholder_count(&cue.content) > 0
+    });
+
+    if has_attachment_placeholders {
+        if let Ok(media_notes) = load_media_notes(since) {
+            enrich_cues_with_attachments(&mut cues, &media_notes);
+        }
     }
 
     Ok(cues)
 }
 
 fn normalize_plaintext(body: &str) -> (String, usize) {
-    let attachment_placeholders = body.chars().filter(|c| *c == ATTACHMENT_PLACEHOLDER).count();
+    let attachment_placeholders = body
+        .chars()
+        .filter(|c| *c == ATTACHMENT_PLACEHOLDER)
+        .count();
     if attachment_placeholders == 0 {
         return (body.to_string(), 0);
     }
@@ -134,6 +146,7 @@ struct MediaNote {
     attachments: Vec<MediaAttachment>,
 }
 
+#[cfg(test)]
 fn enrich_cues_with_media(cues: &mut [Cue], media_notes: &[MediaNote]) {
     for cue in cues.iter_mut() {
         if !matches!(cue.source, CueSource::Notes) {
@@ -153,14 +166,47 @@ fn enrich_cues_with_media(cues: &mut [Cue], media_notes: &[MediaNote]) {
             continue;
         }
 
-        cue.content = replace_attachment_labels(
-            &cue.content,
-            &media_note.attachments,
-            placeholder_count,
-        );
+        cue.content =
+            replace_attachment_labels(&cue.content, &media_note.attachments, placeholder_count);
 
         cue.attachment_segments =
             build_attachment_segments(&media_note.attachments, placeholder_count, None);
+    }
+}
+
+fn enrich_cues_with_attachments(cues: &mut [Cue], media_notes: &[MediaNote]) {
+    for cue in cues.iter_mut() {
+        if !matches!(cue.source, CueSource::Notes) {
+            continue;
+        }
+
+        let placeholder_count = attachment_placeholder_count(&cue.content);
+        if placeholder_count == 0 {
+            continue;
+        }
+
+        let Some(media_note) = match_media_note(cue, media_notes) else {
+            continue;
+        };
+
+        if media_note.attachments.is_empty() {
+            continue;
+        }
+
+        let attachments = materialize_attachments(&media_note.attachments, placeholder_count);
+        if attachments.is_empty() {
+            continue;
+        }
+
+        cue.content = replace_attachment_labels(&cue.content, &attachments, placeholder_count);
+
+        let ocr_blocks = collect_attachment_ocr_blocks(&attachments, placeholder_count);
+        if !ocr_blocks.is_empty() {
+            cue.content = append_attachment_ocr(&cue.content, &ocr_blocks);
+        }
+
+        cue.attachment_segments =
+            build_attachment_segments(&attachments, placeholder_count, Some(&ocr_blocks));
     }
 }
 
@@ -201,35 +247,6 @@ fn replace_attachment_labels(
     }
 
     result
-}
-
-fn enrich_cues_with_attachment_ocr(cues: &mut [Cue], media_notes: &[MediaNote]) {
-    for cue in cues.iter_mut() {
-        if !matches!(cue.source, CueSource::Notes) {
-            continue;
-        }
-
-        let placeholder_count = cue.attachment_segments.len();
-        if placeholder_count == 0 {
-            continue;
-        }
-
-        let Some(media_note) = match_media_note(cue, media_notes) else {
-            continue;
-        };
-
-        let ocr_blocks = collect_attachment_ocr_blocks(&media_note.attachments, placeholder_count);
-        if ocr_blocks.is_empty() {
-            continue;
-        }
-
-        cue.content = append_attachment_ocr(&cue.content, &ocr_blocks);
-        cue.attachment_segments = build_attachment_segments(
-            &media_note.attachments,
-            placeholder_count,
-            Some(&ocr_blocks),
-        );
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -289,10 +306,15 @@ fn build_attachment_segments(
     placeholder_count: usize,
     ocr_blocks: Option<&[AttachmentOcrBlock]>,
 ) -> Vec<AttachmentSegment> {
-    let ocr_by_filename: HashMap<&str, &AttachmentOcrBlock> = ocr_blocks
+    let ocr_by_attachment: HashMap<String, &AttachmentOcrBlock> = ocr_blocks
         .unwrap_or(&[])
         .iter()
-        .map(|block| (block.filename.as_str(), block))
+        .map(|block| {
+            (
+                attachment_lookup_key(block.sha256.as_deref(), &block.filename),
+                block,
+            )
+        })
         .collect();
 
     attachments
@@ -300,7 +322,8 @@ fn build_attachment_segments(
         .take(placeholder_count)
         .enumerate()
         .map(|(idx, attachment)| {
-            let ocr = ocr_by_filename.get(attachment.filename.as_str());
+            let key = attachment_lookup_key(attachment.sha256.as_deref(), &attachment.filename);
+            let ocr = ocr_by_attachment.get(&key);
             AttachmentSegment {
                 index: idx + 1,
                 filename: attachment.filename.clone(),
@@ -313,21 +336,25 @@ fn build_attachment_segments(
         .collect()
 }
 
+fn attachment_lookup_key(sha256: Option<&str>, filename: &str) -> String {
+    sha256.unwrap_or(filename).to_string()
+}
+
 fn load_or_run_attachment_ocr(attachment: &MediaAttachment) -> Result<Option<String>, MacosError> {
-    let cache_path = attachment
-        .sha256
-        .as_deref()
-        .map(ocr_cache_file_path)
-        .unwrap_or_else(|| {
-            let sanitized = attachment.filename.replace('/', "_");
-            ocr_cache_dir().join(format!("name-{sanitized}.txt"))
-        });
+    let cache_path = if let Some(hash) = attachment.sha256.as_deref() {
+        ocr_cache_file_path(hash)?
+    } else {
+        let sanitized = attachment.filename.replace('/', "_");
+        ocr_cache_dir()?.join(format!("name-{sanitized}.txt"))
+    };
 
     if let Ok(cached) = fs::read_to_string(&cache_path) {
-        if cached.is_empty() {
-            return Ok(None);
+        if let Some(cached_text) = cached_ocr_text(&cached) {
+            if cached_text.is_empty() {
+                return Ok(None);
+            }
+            return Ok(Some(cached_text));
         }
-        return Ok(Some(cached));
     }
 
     let cues = ocr::capture(&attachment.path.to_string_lossy())?;
@@ -338,9 +365,16 @@ fn load_or_run_attachment_ocr(attachment: &MediaAttachment) -> Result<Option<Str
         .collect::<Vec<_>>()
         .join("\n");
 
-    fs::create_dir_all(ocr_cache_dir())
+    fs::create_dir_all(ocr_cache_dir()?)
         .map_err(|err| MacosError::Other(format!("failed to create OCR cache dir: {err}")))?;
-    fs::write(&cache_path, &text)
+
+    let cached_value = if text.is_empty() {
+        OCR_EMPTY_SENTINEL.to_string()
+    } else {
+        text.clone()
+    };
+
+    fs::write(&cache_path, cached_value)
         .map_err(|err| MacosError::Other(format!("failed to write OCR cache: {err}")))?;
 
     if text.is_empty() {
@@ -350,23 +384,42 @@ fn load_or_run_attachment_ocr(attachment: &MediaAttachment) -> Result<Option<Str
     }
 }
 
-fn ocr_cache_dir() -> PathBuf {
-    PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/Users/unknown".into()))
-        .join(".cueward/cache/ocr")
+fn cached_ocr_text(cached: &str) -> Option<String> {
+    if cached.is_empty() {
+        return None;
+    }
+    if cached.trim() == OCR_EMPTY_SENTINEL {
+        return Some(String::new());
+    }
+    Some(cached.to_string())
 }
 
-fn ocr_cache_file_path(hash: &str) -> PathBuf {
-    ocr_cache_dir().join(format!("{hash}.txt"))
+fn home_dir() -> Result<PathBuf, MacosError> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| MacosError::Other("HOME environment variable must be set".into()))
 }
 
-fn load_media_notes() -> Result<Vec<MediaNote>, MacosError> {
-    let note_store = notes_group_container_path().join("NoteStore.sqlite");
-    let media_root = notes_group_container_path().join("Accounts");
-    let conn = Connection::open(note_store)
-        .map_err(|err| MacosError::Other(format!("failed to open NoteStore.sqlite: {err}")))?;
+fn ocr_cache_dir() -> Result<PathBuf, MacosError> {
+    Ok(home_dir()?.join(".cueward/cache/ocr"))
+}
 
-    let mut stmt = conn.prepare(
-        r#"
+fn ocr_cache_file_path(hash: &str) -> Result<PathBuf, MacosError> {
+    Ok(ocr_cache_dir()?.join(format!("{hash}.txt")))
+}
+
+fn load_media_notes(since: DateTime<Utc>) -> Result<Vec<MediaNote>, MacosError> {
+    let note_store = notes_group_container_path()?.join("NoteStore.sqlite");
+    let media_root = notes_group_container_path()?.join("Accounts");
+    let conn = Connection::open_with_flags(
+        note_store,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|err| MacosError::Other(format!("failed to open NoteStore.sqlite: {err}")))?;
+
+    let mut stmt = conn
+        .prepare(
+            r#"
         SELECT
             note.ZMODIFICATIONDATE,
             note.ZTITLE,
@@ -379,12 +432,14 @@ fn load_media_notes() -> Result<Vec<MediaNote>, MacosError> {
           AND note.ZMEDIA != 0
           AND media.ZFILENAME IS NOT NULL
           AND media.ZIDENTIFIER IS NOT NULL
+          AND note.ZMODIFICATIONDATE > ?
         "#,
-    )
-    .map_err(|err| MacosError::Other(format!("failed to prepare media query: {err}")))?;
+        )
+        .map_err(|err| MacosError::Other(format!("failed to prepare media query: {err}")))?;
 
+    let since_apple_epoch = since.timestamp() as f64 - APPLE_EPOCH_OFFSET;
     let mut rows = stmt
-        .query([])
+        .query([since_apple_epoch])
         .map_err(|err| MacosError::Other(format!("failed to query note media: {err}")))?;
 
     let mut grouped: HashMap<(i64, Option<String>), Vec<MediaAttachment>> = HashMap::new();
@@ -392,23 +447,22 @@ fn load_media_notes() -> Result<Vec<MediaNote>, MacosError> {
         .next()
         .map_err(|err| MacosError::Other(format!("failed to read media row: {err}")))?
     {
-        let modification_date: f64 = row
-            .get(0)
-            .map_err(|err| MacosError::Other(format!("failed to decode modification date: {err}")))?;
+        let modification_date: f64 = row.get(0).map_err(|err| {
+            MacosError::Other(format!("failed to decode modification date: {err}"))
+        })?;
         let title: Option<String> = row
             .get(1)
             .map_err(|err| MacosError::Other(format!("failed to decode note title: {err}")))?;
-        let filename: String = row
-            .get(2)
-            .map_err(|err| MacosError::Other(format!("failed to decode attachment filename: {err}")))?;
-        let identifier: String = row
-            .get(3)
-            .map_err(|err| MacosError::Other(format!("failed to decode attachment identifier: {err}")))?;
+        let filename: String = row.get(2).map_err(|err| {
+            MacosError::Other(format!("failed to decode attachment filename: {err}"))
+        })?;
+        let identifier: String = row.get(3).map_err(|err| {
+            MacosError::Other(format!("failed to decode attachment identifier: {err}"))
+        })?;
 
         let Some(path) = resolve_media_path(&media_root, &identifier, &filename) else {
             continue;
         };
-        let sha256 = compute_sha256(&path);
 
         let timestamp = (modification_date + APPLE_EPOCH_OFFSET).round() as i64;
         grouped
@@ -417,7 +471,7 @@ fn load_media_notes() -> Result<Vec<MediaNote>, MacosError> {
             .push(MediaAttachment {
                 filename,
                 path,
-                sha256,
+                sha256: None,
             });
     }
 
@@ -431,6 +485,23 @@ fn load_media_notes() -> Result<Vec<MediaNote>, MacosError> {
         .collect())
 }
 
+fn materialize_attachments(
+    attachments: &[MediaAttachment],
+    placeholder_count: usize,
+) -> Vec<MediaAttachment> {
+    attachments
+        .iter()
+        .take(placeholder_count)
+        .cloned()
+        .map(|mut attachment| {
+            if attachment.sha256.is_none() {
+                attachment.sha256 = compute_sha256(&attachment.path);
+            }
+            attachment
+        })
+        .collect()
+}
+
 fn normalize_media_title(title: Option<String>) -> Option<String> {
     title.and_then(|value| {
         let trimmed = value.trim();
@@ -442,9 +513,8 @@ fn normalize_media_title(title: Option<String>) -> Option<String> {
     })
 }
 
-fn notes_group_container_path() -> PathBuf {
-    PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/Users/unknown".into()))
-        .join("Library/Group Containers/group.com.apple.notes")
+fn notes_group_container_path() -> Result<PathBuf, MacosError> {
+    Ok(home_dir()?.join("Library/Group Containers/group.com.apple.notes"))
 }
 
 fn resolve_media_path(media_root: &Path, identifier: &str, filename: &str) -> Option<PathBuf> {
@@ -464,14 +534,27 @@ fn resolve_media_path(media_root: &Path, identifier: &str, filename: &str) -> Op
 }
 
 fn find_named_file(root: &Path, filename: &str) -> Option<PathBuf> {
+    find_named_file_impl(root, filename, 0)
+}
+
+fn find_named_file_impl(root: &Path, filename: &str, depth: usize) -> Option<PathBuf> {
+    if depth > MAX_MEDIA_SEARCH_DEPTH {
+        return None;
+    }
+
     let entries = fs::read_dir(root).ok()?;
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.is_file() && path.file_name().and_then(|name| name.to_str()) == Some(filename) {
+        let file_type = entry.file_type().ok()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_file() && path.file_name().and_then(|name| name.to_str()) == Some(filename)
+        {
             return Some(path);
         }
-        if path.is_dir() {
-            if let Some(found) = find_named_file(&path, filename) {
+        if file_type.is_dir() {
+            if let Some(found) = find_named_file_impl(&path, filename, depth + 1) {
                 return Some(found);
             }
         }
@@ -497,18 +580,18 @@ fn compute_sha256(path: &Path) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use std::collections::HashMap;
+    use std::fs;
     use std::path::PathBuf;
 
     use chrono::{TimeZone, Utc};
     use cueward_core::{Cue, CueSource};
 
     use super::{
-        append_attachment_ocr, attachment_placeholder_count, build_attachment_segments, compute_sha256,
-        enrich_cues_with_media, find_named_file, normalize_plaintext, ocr_cache_file_path,
-        replace_attachment_labels, AttachmentOcrBlock, MediaAttachment, MediaNote,
-        ATTACHMENT_LABEL,
+        ATTACHMENT_LABEL, AttachmentOcrBlock, MediaAttachment, MediaNote, OCR_EMPTY_SENTINEL,
+        append_attachment_ocr, attachment_placeholder_count, build_attachment_segments,
+        cached_ocr_text, compute_sha256, enrich_cues_with_media, find_named_file,
+        normalize_plaintext, ocr_cache_file_path, replace_attachment_labels,
     };
 
     #[test]
@@ -579,7 +662,10 @@ mod tests {
         assert_eq!(cues[0].attachment_segments.len(), 1);
         assert_eq!(cues[0].attachment_segments[0].filename, "scan.jpg");
         assert_eq!(cues[0].attachment_segments[0].path, "/tmp/scan.jpg");
-        assert_eq!(cues[0].attachment_segments[0].sha256.as_deref(), Some("abc123"));
+        assert_eq!(
+            cues[0].attachment_segments[0].sha256.as_deref(),
+            Some("abc123")
+        );
         assert!(!cues[0].attachment_segments[0].has_ocr);
     }
 
@@ -629,14 +715,17 @@ mod tests {
 
     #[test]
     fn ocr_cache_file_path_uses_hash_name() {
-        let path = ocr_cache_file_path("abc123");
+        let path = ocr_cache_file_path("abc123").expect("cache path");
 
         assert!(path.ends_with(".cueward/cache/ocr/abc123.txt"));
     }
 
     #[test]
     fn attachment_placeholder_count_counts_remaining_plain_labels() {
-        assert_eq!(attachment_placeholder_count("[Attachment]\n[Attachment]"), 2);
+        assert_eq!(
+            attachment_placeholder_count("[Attachment]\n[Attachment]"),
+            2
+        );
         assert_eq!(attachment_placeholder_count("[Attachment 1: image.png]"), 0);
     }
 
@@ -662,5 +751,60 @@ mod tests {
         assert_eq!(segments[0].sha256.as_deref(), Some("hash1"));
         assert_eq!(segments[0].ocr_text.as_deref(), Some("detected text"));
         assert!(segments[0].has_ocr);
+    }
+
+    #[test]
+    fn build_attachment_segments_prefers_sha256_over_filename() {
+        let attachments = vec![
+            MediaAttachment {
+                filename: "image.png".into(),
+                path: PathBuf::from("/tmp/one.png"),
+                sha256: Some("hash-a".into()),
+            },
+            MediaAttachment {
+                filename: "image.png".into(),
+                path: PathBuf::from("/tmp/two.png"),
+                sha256: Some("hash-b".into()),
+            },
+        ];
+        let blocks = vec![
+            AttachmentOcrBlock {
+                filename: "image.png".into(),
+                sha256: Some("hash-a".into()),
+                text: "first".into(),
+            },
+            AttachmentOcrBlock {
+                filename: "image.png".into(),
+                sha256: Some("hash-b".into()),
+                text: "second".into(),
+            },
+        ];
+
+        let segments = build_attachment_segments(&attachments, 2, Some(&blocks));
+
+        assert_eq!(segments[0].ocr_text.as_deref(), Some("first"));
+        assert_eq!(segments[1].ocr_text.as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn find_named_file_respects_max_depth() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut current = temp.path().to_path_buf();
+        for idx in 0..12 {
+            current = current.join(format!("d{idx}"));
+        }
+        fs::create_dir_all(&current).expect("create nested dirs");
+        let target = current.join("image.png");
+        fs::write(&target, b"png").expect("write media file");
+
+        let found = find_named_file(temp.path(), "image.png");
+
+        assert_eq!(found, None);
+    }
+
+    #[test]
+    fn cached_ocr_text_treats_empty_files_as_cache_miss() {
+        assert_eq!(cached_ocr_text(""), None);
+        assert_eq!(cached_ocr_text(OCR_EMPTY_SENTINEL), Some(String::new()));
     }
 }

--- a/crates/adapter-macos/src/notes.rs
+++ b/crates/adapter-macos/src/notes.rs
@@ -251,6 +251,7 @@ fn replace_attachment_labels(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AttachmentOcrBlock {
+    index: usize,
     filename: String,
     sha256: Option<String>,
     text: String,
@@ -263,7 +264,8 @@ fn collect_attachment_ocr_blocks(
     attachments
         .iter()
         .take(placeholder_count)
-        .filter_map(|attachment| {
+        .enumerate()
+        .filter_map(|(idx, attachment)| {
             let text = load_or_run_attachment_ocr(attachment).ok().flatten()?;
             let trimmed = text.trim();
             if trimmed.is_empty() {
@@ -271,6 +273,7 @@ fn collect_attachment_ocr_blocks(
             }
 
             Some(AttachmentOcrBlock {
+                index: idx + 1,
                 filename: attachment.filename.clone(),
                 sha256: attachment.sha256.clone(),
                 text: trimmed.to_string(),
@@ -285,12 +288,10 @@ fn append_attachment_ocr(content: &str, blocks: &[AttachmentOcrBlock]) -> String
     }
 
     let mut sections = Vec::with_capacity(blocks.len());
-    for (idx, block) in blocks.iter().enumerate() {
+    for block in blocks {
         sections.push(format!(
             "[Attachment {} OCR: {}]\n{}",
-            idx + 1,
-            block.filename,
-            block.text
+            block.index, block.filename, block.text
         ));
     }
 
@@ -700,6 +701,7 @@ mod tests {
     fn append_attachment_ocr_adds_readable_sections() {
         let content = "[Attachment 1: image.png]";
         let blocks = vec![AttachmentOcrBlock {
+            index: 1,
             filename: "image.png".into(),
             sha256: Some("hash1".into()),
             text: "detected text".into(),
@@ -737,6 +739,7 @@ mod tests {
             sha256: Some("hash1".into()),
         }];
         let blocks = vec![AttachmentOcrBlock {
+            index: 1,
             filename: "image.png".into(),
             sha256: Some("hash1".into()),
             text: "detected text".into(),
@@ -769,11 +772,13 @@ mod tests {
         ];
         let blocks = vec![
             AttachmentOcrBlock {
+                index: 1,
                 filename: "image.png".into(),
                 sha256: Some("hash-a".into()),
                 text: "first".into(),
             },
             AttachmentOcrBlock {
+                index: 2,
                 filename: "image.png".into(),
                 sha256: Some("hash-b".into()),
                 text: "second".into(),
@@ -806,5 +811,20 @@ mod tests {
     fn cached_ocr_text_treats_empty_files_as_cache_miss() {
         assert_eq!(cached_ocr_text(""), None);
         assert_eq!(cached_ocr_text(OCR_EMPTY_SENTINEL), Some(String::new()));
+    }
+
+    #[test]
+    fn append_attachment_ocr_keeps_original_attachment_indices() {
+        let content = "[Attachment 1: one.png]\n[Attachment 2: two.png]";
+        let blocks = vec![AttachmentOcrBlock {
+            index: 2,
+            filename: "two.png".into(),
+            sha256: Some("hash2".into()),
+            text: "detected text".into(),
+        }];
+
+        let combined = append_attachment_ocr(content, &blocks);
+
+        assert!(combined.contains("[Attachment 2 OCR: two.png]"));
     }
 }

--- a/crates/adapter-macos/src/notes.rs
+++ b/crates/adapter-macos/src/notes.rs
@@ -1,11 +1,22 @@
 use std::collections::HashMap;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use chrono::{DateTime, TimeZone, Utc};
+use rusqlite::Connection;
+use sha2::{Digest, Sha256};
 
-use cueward_core::{Cue, CueSource};
+use cueward_core::{AttachmentSegment, Cue, CueSource};
 
 use crate::MacosError;
+use crate::ocr;
+
+const ATTACHMENT_PLACEHOLDER: char = '\u{fffc}';
+const ATTACHMENT_LABEL: &str = "[Attachment]";
+const MEDIA_MATCH_WINDOW_SECS: i64 = 5;
+const APPLE_EPOCH_OFFSET: f64 = 978_307_200.0;
 
 pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
     let seconds_ago = (Utc::now() - since).num_seconds().max(0);
@@ -60,7 +71,7 @@ pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
     }
 
     let raw = String::from_utf8_lossy(&output.stdout);
-    let cues = raw
+    let mut cues: Vec<Cue> = raw
         .split("---CUE_SEP---")
         .filter(|s| !s.trim().is_empty())
         .filter_map(|entry| {
@@ -72,7 +83,9 @@ pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
             let timestamp = Utc.timestamp_opt(unix_ts, 0).single()?;
             let title = fields[1].trim().to_string();
             let folder = fields[2].trim().to_string();
-            let body = fields[3].trim().to_string();
+            let (body, _) = normalize_plaintext(fields[3].trim());
+
+            let metadata = HashMap::from([("folder".into(), folder)]);
 
             Some(Cue {
                 source: CueSource::Notes,
@@ -81,10 +94,573 @@ pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
                 url: None,
                 title: Some(title),
                 tags: Vec::new(),
-                metadata: HashMap::from([("folder".into(), folder)]),
+                attachment_segments: Vec::new(),
+                metadata,
             })
         })
         .collect();
 
+    if let Ok(media_notes) = load_media_notes() {
+        enrich_cues_with_media(&mut cues, &media_notes);
+        enrich_cues_with_attachment_ocr(&mut cues, &media_notes);
+    }
+
     Ok(cues)
+}
+
+fn normalize_plaintext(body: &str) -> (String, usize) {
+    let attachment_placeholders = body.chars().filter(|c| *c == ATTACHMENT_PLACEHOLDER).count();
+    if attachment_placeholders == 0 {
+        return (body.to_string(), 0);
+    }
+
+    (
+        body.replace(ATTACHMENT_PLACEHOLDER, ATTACHMENT_LABEL),
+        attachment_placeholders,
+    )
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MediaAttachment {
+    filename: String,
+    path: PathBuf,
+    sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MediaNote {
+    timestamp: i64,
+    title: Option<String>,
+    attachments: Vec<MediaAttachment>,
+}
+
+fn enrich_cues_with_media(cues: &mut [Cue], media_notes: &[MediaNote]) {
+    for cue in cues.iter_mut() {
+        if !matches!(cue.source, CueSource::Notes) {
+            continue;
+        }
+
+        let placeholder_count = attachment_placeholder_count(&cue.content);
+        if placeholder_count == 0 {
+            continue;
+        }
+
+        let Some(media_note) = match_media_note(cue, media_notes) else {
+            continue;
+        };
+
+        if media_note.attachments.is_empty() {
+            continue;
+        }
+
+        cue.content = replace_attachment_labels(
+            &cue.content,
+            &media_note.attachments,
+            placeholder_count,
+        );
+
+        cue.attachment_segments =
+            build_attachment_segments(&media_note.attachments, placeholder_count, None);
+    }
+}
+
+fn match_media_note<'a>(cue: &Cue, media_notes: &'a [MediaNote]) -> Option<&'a MediaNote> {
+    let cue_ts = cue.timestamp.timestamp();
+    let cue_title = cue.title.as_deref();
+
+    media_notes
+        .iter()
+        .filter(|note| (note.timestamp - cue_ts).abs() <= MEDIA_MATCH_WINDOW_SECS)
+        .min_by_key(|note| {
+            let title_penalty = match (cue_title, note.title.as_deref()) {
+                (Some(cue_title), Some(note_title)) if cue_title == note_title => 0,
+                (Some(_), Some(_)) => 1,
+                _ => 2,
+            };
+            (title_penalty, (note.timestamp - cue_ts).abs())
+        })
+}
+
+fn replace_attachment_labels(
+    body: &str,
+    attachments: &[MediaAttachment],
+    placeholder_count: usize,
+) -> String {
+    if placeholder_count == 0 {
+        return body.to_string();
+    }
+
+    let mut result = body.to_string();
+    for (idx, attachment) in attachments.iter().enumerate() {
+        if idx >= placeholder_count {
+            break;
+        }
+
+        let replacement = format!("[Attachment {}: {}]", idx + 1, attachment.filename);
+        result = result.replacen(ATTACHMENT_LABEL, &replacement, 1);
+    }
+
+    result
+}
+
+fn enrich_cues_with_attachment_ocr(cues: &mut [Cue], media_notes: &[MediaNote]) {
+    for cue in cues.iter_mut() {
+        if !matches!(cue.source, CueSource::Notes) {
+            continue;
+        }
+
+        let placeholder_count = cue.attachment_segments.len();
+        if placeholder_count == 0 {
+            continue;
+        }
+
+        let Some(media_note) = match_media_note(cue, media_notes) else {
+            continue;
+        };
+
+        let ocr_blocks = collect_attachment_ocr_blocks(&media_note.attachments, placeholder_count);
+        if ocr_blocks.is_empty() {
+            continue;
+        }
+
+        cue.content = append_attachment_ocr(&cue.content, &ocr_blocks);
+        cue.attachment_segments = build_attachment_segments(
+            &media_note.attachments,
+            placeholder_count,
+            Some(&ocr_blocks),
+        );
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AttachmentOcrBlock {
+    filename: String,
+    sha256: Option<String>,
+    text: String,
+}
+
+fn collect_attachment_ocr_blocks(
+    attachments: &[MediaAttachment],
+    placeholder_count: usize,
+) -> Vec<AttachmentOcrBlock> {
+    attachments
+        .iter()
+        .take(placeholder_count)
+        .filter_map(|attachment| {
+            let text = load_or_run_attachment_ocr(attachment).ok().flatten()?;
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+
+            Some(AttachmentOcrBlock {
+                filename: attachment.filename.clone(),
+                sha256: attachment.sha256.clone(),
+                text: trimmed.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn append_attachment_ocr(content: &str, blocks: &[AttachmentOcrBlock]) -> String {
+    if blocks.is_empty() {
+        return content.to_string();
+    }
+
+    let mut sections = Vec::with_capacity(blocks.len());
+    for (idx, block) in blocks.iter().enumerate() {
+        sections.push(format!(
+            "[Attachment {} OCR: {}]\n{}",
+            idx + 1,
+            block.filename,
+            block.text
+        ));
+    }
+
+    format!("{content}\n\n{}", sections.join("\n\n"))
+}
+
+fn attachment_placeholder_count(content: &str) -> usize {
+    content.matches(ATTACHMENT_LABEL).count()
+}
+
+fn build_attachment_segments(
+    attachments: &[MediaAttachment],
+    placeholder_count: usize,
+    ocr_blocks: Option<&[AttachmentOcrBlock]>,
+) -> Vec<AttachmentSegment> {
+    let ocr_by_filename: HashMap<&str, &AttachmentOcrBlock> = ocr_blocks
+        .unwrap_or(&[])
+        .iter()
+        .map(|block| (block.filename.as_str(), block))
+        .collect();
+
+    attachments
+        .iter()
+        .take(placeholder_count)
+        .enumerate()
+        .map(|(idx, attachment)| {
+            let ocr = ocr_by_filename.get(attachment.filename.as_str());
+            AttachmentSegment {
+                index: idx + 1,
+                filename: attachment.filename.clone(),
+                path: attachment.path.display().to_string(),
+                sha256: attachment.sha256.clone(),
+                ocr_text: ocr.map(|block| block.text.clone()),
+                has_ocr: ocr.is_some(),
+            }
+        })
+        .collect()
+}
+
+fn load_or_run_attachment_ocr(attachment: &MediaAttachment) -> Result<Option<String>, MacosError> {
+    let cache_path = attachment
+        .sha256
+        .as_deref()
+        .map(ocr_cache_file_path)
+        .unwrap_or_else(|| {
+            let sanitized = attachment.filename.replace('/', "_");
+            ocr_cache_dir().join(format!("name-{sanitized}.txt"))
+        });
+
+    if let Ok(cached) = fs::read_to_string(&cache_path) {
+        if cached.is_empty() {
+            return Ok(None);
+        }
+        return Ok(Some(cached));
+    }
+
+    let cues = ocr::capture(&attachment.path.to_string_lossy())?;
+    let text = cues
+        .iter()
+        .map(|cue| cue.content.trim())
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    fs::create_dir_all(ocr_cache_dir())
+        .map_err(|err| MacosError::Other(format!("failed to create OCR cache dir: {err}")))?;
+    fs::write(&cache_path, &text)
+        .map_err(|err| MacosError::Other(format!("failed to write OCR cache: {err}")))?;
+
+    if text.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(text))
+    }
+}
+
+fn ocr_cache_dir() -> PathBuf {
+    PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/Users/unknown".into()))
+        .join(".cueward/cache/ocr")
+}
+
+fn ocr_cache_file_path(hash: &str) -> PathBuf {
+    ocr_cache_dir().join(format!("{hash}.txt"))
+}
+
+fn load_media_notes() -> Result<Vec<MediaNote>, MacosError> {
+    let note_store = notes_group_container_path().join("NoteStore.sqlite");
+    let media_root = notes_group_container_path().join("Accounts");
+    let conn = Connection::open(note_store)
+        .map_err(|err| MacosError::Other(format!("failed to open NoteStore.sqlite: {err}")))?;
+
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT
+            note.ZMODIFICATIONDATE,
+            note.ZTITLE,
+            media.ZFILENAME,
+            media.ZIDENTIFIER
+        FROM ZICCLOUDSYNCINGOBJECT AS note
+        JOIN ZICCLOUDSYNCINGOBJECT AS media
+            ON note.ZMEDIA = media.Z_PK
+        WHERE note.ZMEDIA IS NOT NULL
+          AND note.ZMEDIA != 0
+          AND media.ZFILENAME IS NOT NULL
+          AND media.ZIDENTIFIER IS NOT NULL
+        "#,
+    )
+    .map_err(|err| MacosError::Other(format!("failed to prepare media query: {err}")))?;
+
+    let mut rows = stmt
+        .query([])
+        .map_err(|err| MacosError::Other(format!("failed to query note media: {err}")))?;
+
+    let mut grouped: HashMap<(i64, Option<String>), Vec<MediaAttachment>> = HashMap::new();
+    while let Some(row) = rows
+        .next()
+        .map_err(|err| MacosError::Other(format!("failed to read media row: {err}")))?
+    {
+        let modification_date: f64 = row
+            .get(0)
+            .map_err(|err| MacosError::Other(format!("failed to decode modification date: {err}")))?;
+        let title: Option<String> = row
+            .get(1)
+            .map_err(|err| MacosError::Other(format!("failed to decode note title: {err}")))?;
+        let filename: String = row
+            .get(2)
+            .map_err(|err| MacosError::Other(format!("failed to decode attachment filename: {err}")))?;
+        let identifier: String = row
+            .get(3)
+            .map_err(|err| MacosError::Other(format!("failed to decode attachment identifier: {err}")))?;
+
+        let Some(path) = resolve_media_path(&media_root, &identifier, &filename) else {
+            continue;
+        };
+        let sha256 = compute_sha256(&path);
+
+        let timestamp = (modification_date + APPLE_EPOCH_OFFSET).round() as i64;
+        grouped
+            .entry((timestamp, normalize_media_title(title)))
+            .or_default()
+            .push(MediaAttachment {
+                filename,
+                path,
+                sha256,
+            });
+    }
+
+    Ok(grouped
+        .into_iter()
+        .map(|((timestamp, title), attachments)| MediaNote {
+            timestamp,
+            title,
+            attachments,
+        })
+        .collect())
+}
+
+fn normalize_media_title(title: Option<String>) -> Option<String> {
+    title.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn notes_group_container_path() -> PathBuf {
+    PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| "/Users/unknown".into()))
+        .join("Library/Group Containers/group.com.apple.notes")
+}
+
+fn resolve_media_path(media_root: &Path, identifier: &str, filename: &str) -> Option<PathBuf> {
+    let accounts = fs::read_dir(media_root).ok()?;
+    for account in accounts.flatten() {
+        let media_dir = account.path().join("Media").join(identifier);
+        if !media_dir.is_dir() {
+            continue;
+        }
+
+        if let Some(path) = find_named_file(&media_dir, filename) {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
+fn find_named_file(root: &Path, filename: &str) -> Option<PathBuf> {
+    let entries = fs::read_dir(root).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() && path.file_name().and_then(|name| name.to_str()) == Some(filename) {
+            return Some(path);
+        }
+        if path.is_dir() {
+            if let Some(found) = find_named_file(&path, filename) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+fn compute_sha256(path: &Path) -> Option<String> {
+    let mut file = fs::File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 8192];
+
+    loop {
+        let read = file.read(&mut buffer).ok()?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+
+    Some(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    use chrono::{TimeZone, Utc};
+    use cueward_core::{Cue, CueSource};
+
+    use super::{
+        append_attachment_ocr, attachment_placeholder_count, build_attachment_segments, compute_sha256,
+        enrich_cues_with_media, find_named_file, normalize_plaintext, ocr_cache_file_path,
+        replace_attachment_labels, AttachmentOcrBlock, MediaAttachment, MediaNote,
+        ATTACHMENT_LABEL,
+    };
+
+    #[test]
+    fn normalize_plaintext_replaces_attachment_placeholder_chars() {
+        let body = format!("before{}after", '\u{fffc}');
+
+        let (normalized, placeholders) = normalize_plaintext(&body);
+
+        assert_eq!(normalized, format!("before{ATTACHMENT_LABEL}after"));
+        assert_eq!(placeholders, 1);
+    }
+
+    #[test]
+    fn normalize_plaintext_keeps_regular_text_unchanged() {
+        let (normalized, placeholders) = normalize_plaintext("plain text note");
+
+        assert_eq!(normalized, "plain text note");
+        assert_eq!(placeholders, 0);
+    }
+
+    #[test]
+    fn replace_attachment_labels_uses_filenames() {
+        let body = "[Attachment]\n[Attachment]";
+        let attachments = vec![
+            MediaAttachment {
+                filename: "one.png".into(),
+                path: PathBuf::from("/tmp/one.png"),
+                sha256: None,
+            },
+            MediaAttachment {
+                filename: "two.jpg".into(),
+                path: PathBuf::from("/tmp/two.jpg"),
+                sha256: None,
+            },
+        ];
+
+        let replaced = replace_attachment_labels(body, &attachments, 2);
+
+        assert_eq!(replaced, "[Attachment 1: one.png]\n[Attachment 2: two.jpg]");
+    }
+
+    #[test]
+    fn enrich_cues_with_media_adds_paths_and_filenames() {
+        let timestamp = Utc.with_ymd_and_hms(2026, 4, 9, 23, 42, 54).unwrap();
+        let mut cues = vec![Cue {
+            source: CueSource::Notes,
+            timestamp,
+            content: "[Attachment]".into(),
+            url: None,
+            title: Some("新增備忘錄".into()),
+            tags: Vec::new(),
+            attachment_segments: Vec::new(),
+            metadata: HashMap::new(),
+        }];
+        let media_notes = vec![MediaNote {
+            timestamp: timestamp.timestamp() - 1,
+            title: None,
+            attachments: vec![MediaAttachment {
+                filename: "scan.jpg".into(),
+                path: PathBuf::from("/tmp/scan.jpg"),
+                sha256: Some("abc123".into()),
+            }],
+        }];
+
+        enrich_cues_with_media(&mut cues, &media_notes);
+
+        assert_eq!(cues[0].content, "[Attachment 1: scan.jpg]");
+        assert_eq!(cues[0].attachment_segments.len(), 1);
+        assert_eq!(cues[0].attachment_segments[0].filename, "scan.jpg");
+        assert_eq!(cues[0].attachment_segments[0].path, "/tmp/scan.jpg");
+        assert_eq!(cues[0].attachment_segments[0].sha256.as_deref(), Some("abc123"));
+        assert!(!cues[0].attachment_segments[0].has_ocr);
+    }
+
+    #[test]
+    fn find_named_file_walks_nested_media_directory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let nested = temp.path().join("a/b");
+        fs::create_dir_all(&nested).expect("create nested dirs");
+        let target = nested.join("image.png");
+        fs::write(&target, b"png").expect("write media file");
+
+        let found = find_named_file(temp.path(), "image.png");
+
+        assert_eq!(found, Some(target));
+    }
+
+    #[test]
+    fn compute_sha256_returns_stable_digest() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let target = temp.path().join("image.png");
+        fs::write(&target, b"hello world").expect("write media file");
+
+        let digest = compute_sha256(&target);
+
+        assert_eq!(
+            digest.as_deref(),
+            Some("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+        );
+    }
+
+    #[test]
+    fn append_attachment_ocr_adds_readable_sections() {
+        let content = "[Attachment 1: image.png]";
+        let blocks = vec![AttachmentOcrBlock {
+            filename: "image.png".into(),
+            sha256: Some("hash1".into()),
+            text: "detected text".into(),
+        }];
+
+        let combined = append_attachment_ocr(content, &blocks);
+
+        assert_eq!(
+            combined,
+            "[Attachment 1: image.png]\n\n[Attachment 1 OCR: image.png]\ndetected text"
+        );
+    }
+
+    #[test]
+    fn ocr_cache_file_path_uses_hash_name() {
+        let path = ocr_cache_file_path("abc123");
+
+        assert!(path.ends_with(".cueward/cache/ocr/abc123.txt"));
+    }
+
+    #[test]
+    fn attachment_placeholder_count_counts_remaining_plain_labels() {
+        assert_eq!(attachment_placeholder_count("[Attachment]\n[Attachment]"), 2);
+        assert_eq!(attachment_placeholder_count("[Attachment 1: image.png]"), 0);
+    }
+
+    #[test]
+    fn build_attachment_segments_includes_ocr_fields() {
+        let attachments = vec![MediaAttachment {
+            filename: "image.png".into(),
+            path: PathBuf::from("/tmp/image.png"),
+            sha256: Some("hash1".into()),
+        }];
+        let blocks = vec![AttachmentOcrBlock {
+            filename: "image.png".into(),
+            sha256: Some("hash1".into()),
+            text: "detected text".into(),
+        }];
+
+        let segments = build_attachment_segments(&attachments, 1, Some(&blocks));
+
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].index, 1);
+        assert_eq!(segments[0].filename, "image.png");
+        assert_eq!(segments[0].path, "/tmp/image.png");
+        assert_eq!(segments[0].sha256.as_deref(), Some("hash1"));
+        assert_eq!(segments[0].ocr_text.as_deref(), Some("detected text"));
+        assert!(segments[0].has_ocr);
+    }
 }

--- a/crates/adapter-macos/src/ocr.rs
+++ b/crates/adapter-macos/src/ocr.rs
@@ -71,6 +71,7 @@ pub fn capture(path: &str) -> Result<Vec<Cue>, MacosError> {
         url: Some(format!("file://{}", abs_path.display())),
         title: filename,
         tags: Vec::new(),
+        attachment_segments: Vec::new(),
         metadata: HashMap::from([("ocr".into(), "true".into())]),
     }])
 }

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -72,6 +72,7 @@ pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
             url: Some(url),
             title,
             tags: Vec::new(),
+            attachment_segments: Vec::new(),
             metadata: HashMap::new(),
         })
         .collect();

--- a/crates/adapter-macos/src/screenshot.rs
+++ b/crates/adapter-macos/src/screenshot.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::{Component, Path};
 use std::process::Command;
 
 use chrono::Local;
@@ -16,9 +17,30 @@ pub struct ScreenshotResult {
 
 const CACHE_DIR: &str = ".cueward/cache/screenshots";
 
+fn validate_user_output_path(path: &str) -> Result<&Path, String> {
+    let candidate = Path::new(path);
+    if candidate
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err("path must not contain parent directory components".into());
+    }
+    Ok(candidate)
+}
+
+fn ensure_screenshot_file_exists(path: &Path) -> Result<(), String> {
+    if path.exists() {
+        Ok(())
+    } else {
+        Err(format!(
+            "screenshot file was not created at {}",
+            path.display()
+        ))
+    }
+}
+
 fn ensure_cache_dir() -> Result<String, MacosError> {
-    let home = std::env::var("HOME")
-        .map_err(|_| MacosError::Other("HOME not set".into()))?;
+    let home = std::env::var("HOME").map_err(|_| MacosError::Other("HOME not set".into()))?;
     let dir = format!("{home}/{CACHE_DIR}");
     fs::create_dir_all(&dir)
         .map_err(|e| MacosError::Other(format!("failed to create {dir}: {e}")))?;
@@ -38,7 +60,10 @@ pub fn capture(
     let timestamp = now.format("%Y%m%d-%H%M%S").to_string();
 
     let path = match output {
-        Some(p) => p.to_string(),
+        Some(p) => {
+            validate_user_output_path(p).map_err(MacosError::Other)?;
+            p.to_string()
+        }
         None => {
             let dir = ensure_cache_dir()?;
             let suffix = display.map(|d| format!("-d{d}")).unwrap_or_default();
@@ -60,6 +85,8 @@ pub fn capture(
     if !status.success() {
         return Err(MacosError::Other("screencapture failed".into()));
     }
+
+    ensure_screenshot_file_exists(Path::new(&path)).map_err(MacosError::Other)?;
 
     let ocr_text = if ocr {
         match crate::ocr::capture(&path) {
@@ -85,4 +112,26 @@ pub fn capture(
         timestamp: now.to_rfc3339(),
         ocr_text,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{ensure_screenshot_file_exists, validate_user_output_path};
+
+    #[test]
+    fn validate_user_output_path_rejects_parent_components() {
+        let err = validate_user_output_path("../shot.png").expect_err("should reject");
+
+        assert!(err.contains("parent directory"));
+    }
+
+    #[test]
+    fn ensure_screenshot_file_exists_reports_missing_file() {
+        let err = ensure_screenshot_file_exists(Path::new("/tmp/does-not-exist-cueward.png"))
+            .expect_err("should fail");
+
+        assert!(err.contains("was not created"));
+    }
 }

--- a/crates/adapter-macos/src/screenshot.rs
+++ b/crates/adapter-macos/src/screenshot.rs
@@ -25,10 +25,15 @@ fn ensure_cache_dir() -> Result<String, MacosError> {
     Ok(dir)
 }
 
-/// Capture a screenshot of the entire screen.
-/// If `ocr` is true, runs Vision OCR on the image.
-/// If `output` is Some, saves to that path instead of cache dir.
-pub fn capture(ocr: bool, output: Option<&str>) -> Result<ScreenshotResult, MacosError> {
+/// Capture a screenshot.
+/// `display`: None = main screen, Some(n) = display number (1 = main, 2 = secondary, 3 = third).
+/// `ocr`: run Vision OCR on the captured image.
+/// `output`: save to this path instead of cache dir.
+pub fn capture(
+    ocr: bool,
+    output: Option<&str>,
+    display: Option<u32>,
+) -> Result<ScreenshotResult, MacosError> {
     let now = Local::now();
     let timestamp = now.format("%Y%m%d-%H%M%S").to_string();
 
@@ -36,13 +41,19 @@ pub fn capture(ocr: bool, output: Option<&str>) -> Result<ScreenshotResult, Maco
         Some(p) => p.to_string(),
         None => {
             let dir = ensure_cache_dir()?;
-            format!("{dir}/{timestamp}.png")
+            let suffix = display.map(|d| format!("-d{d}")).unwrap_or_default();
+            format!("{dir}/{timestamp}{suffix}.png")
         }
     };
 
-    // -x = silent (no shutter sound)
-    let status = Command::new("screencapture")
-        .args(["-x", &path])
+    // -x = silent (no shutter sound), -D = display number
+    let mut cmd = Command::new("screencapture");
+    cmd.arg("-x");
+    if let Some(d) = display {
+        cmd.args(["-D", &d.to_string()]);
+    }
+    cmd.arg(&path);
+    let status = cmd
         .status()
         .map_err(|e| MacosError::Other(format!("screencapture: {e}")))?;
 

--- a/crates/adapter-macos/src/screenshot.rs
+++ b/crates/adapter-macos/src/screenshot.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use std::process::Command;
+
+use chrono::Local;
+use serde::Serialize;
+
+use crate::MacosError;
+
+#[derive(Debug, Serialize)]
+pub struct ScreenshotResult {
+    pub path: String,
+    pub timestamp: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_text: Option<String>,
+}
+
+const CACHE_DIR: &str = ".cueward/cache/screenshots";
+
+fn ensure_cache_dir() -> Result<String, MacosError> {
+    let home = std::env::var("HOME")
+        .map_err(|_| MacosError::Other("HOME not set".into()))?;
+    let dir = format!("{home}/{CACHE_DIR}");
+    fs::create_dir_all(&dir)
+        .map_err(|e| MacosError::Other(format!("failed to create {dir}: {e}")))?;
+    Ok(dir)
+}
+
+/// Capture a screenshot of the entire screen.
+/// If `ocr` is true, runs Vision OCR on the image.
+/// If `output` is Some, saves to that path instead of cache dir.
+pub fn capture(ocr: bool, output: Option<&str>) -> Result<ScreenshotResult, MacosError> {
+    let now = Local::now();
+    let timestamp = now.format("%Y%m%d-%H%M%S").to_string();
+
+    let path = match output {
+        Some(p) => p.to_string(),
+        None => {
+            let dir = ensure_cache_dir()?;
+            format!("{dir}/{timestamp}.png")
+        }
+    };
+
+    // -x = silent (no shutter sound)
+    let status = Command::new("screencapture")
+        .args(["-x", &path])
+        .status()
+        .map_err(|e| MacosError::Other(format!("screencapture: {e}")))?;
+
+    if !status.success() {
+        return Err(MacosError::Other("screencapture failed".into()));
+    }
+
+    let ocr_text = if ocr {
+        match crate::ocr::capture(&path) {
+            Ok(cues) => {
+                let text: String = cues
+                    .into_iter()
+                    .map(|c| c.content)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if text.is_empty() { None } else { Some(text) }
+            }
+            Err(e) => {
+                eprintln!("warning: OCR failed: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    Ok(ScreenshotResult {
+        path,
+        timestamp: now.to_rfc3339(),
+        ocr_text,
+    })
+}

--- a/crates/adapter-macos/src/screenshot.rs
+++ b/crates/adapter-macos/src/screenshot.rs
@@ -19,6 +19,9 @@ const CACHE_DIR: &str = ".cueward/cache/screenshots";
 
 fn validate_user_output_path(path: &str) -> Result<&Path, String> {
     let candidate = Path::new(path);
+    if path.contains('\n') || path.contains('\r') {
+        return Err("path must not contain control characters".into());
+    }
     if candidate
         .components()
         .any(|component| matches!(component, Component::ParentDir))
@@ -26,6 +29,17 @@ fn validate_user_output_path(path: &str) -> Result<&Path, String> {
         return Err("path must not contain parent directory components".into());
     }
     Ok(candidate)
+}
+
+fn validate_display(display: Option<u32>) -> Result<(), String> {
+    if let Some(display) = display {
+        if !(1..=10).contains(&display) {
+            return Err(format!(
+                "invalid display number {display}: must be between 1 and 10"
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn ensure_screenshot_file_exists(path: &Path) -> Result<(), String> {
@@ -56,6 +70,8 @@ pub fn capture(
     output: Option<&str>,
     display: Option<u32>,
 ) -> Result<ScreenshotResult, MacosError> {
+    validate_display(display).map_err(MacosError::Other)?;
+
     let now = Local::now();
     let timestamp = now.format("%Y%m%d-%H%M%S").to_string();
 
@@ -118,7 +134,7 @@ pub fn capture(
 mod tests {
     use std::path::Path;
 
-    use super::{ensure_screenshot_file_exists, validate_user_output_path};
+    use super::{ensure_screenshot_file_exists, validate_display, validate_user_output_path};
 
     #[test]
     fn validate_user_output_path_rejects_parent_components() {
@@ -133,5 +149,12 @@ mod tests {
             .expect_err("should fail");
 
         assert!(err.contains("was not created"));
+    }
+
+    #[test]
+    fn validate_display_rejects_out_of_range_values() {
+        let err = validate_display(Some(11)).expect_err("should reject");
+
+        assert!(err.contains("between 1 and 10"));
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,10 +4,13 @@ use chrono::{DateTime, Local, TimeZone, Utc};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use cueward_adapter_macos::MacosAdapter;
-use cueward_core::{inbox, CueIndex, PlatformAdapter, State, Tagger};
+use cueward_core::{CueIndex, PlatformAdapter, State, Tagger, inbox};
 
 #[derive(Parser)]
-#[command(name = "cueward", about = "Capture and triage your scattered knowledge")]
+#[command(
+    name = "cueward",
+    about = "Capture and triage your scattered knowledge"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -322,6 +325,20 @@ fn parse_datetime(s: &str) -> Option<DateTime<Local>> {
     None
 }
 
+fn parse_datetime_arg(label: &str, value: &str) -> Result<DateTime<Local>, String> {
+    parse_datetime(value).ok_or_else(|| format!("error: invalid {label} datetime '{value}'"))
+}
+
+fn parse_required_datetime_arg(
+    label: &str,
+    value: Option<&str>,
+) -> Result<DateTime<Local>, String> {
+    match value {
+        Some(value) => parse_datetime_arg(label, value),
+        None => Err(format!("error: missing {label} datetime")),
+    }
+}
+
 fn parse_duration(s: &str) -> Option<chrono::Duration> {
     let s = s.trim();
     if let Some(hours) = s.strip_suffix('h') {
@@ -495,7 +512,9 @@ fn main() {
             let body = body.unwrap_or_else(|| {
                 use std::io::Read;
                 let mut buf = String::new();
-                std::io::stdin().read_to_string(&mut buf).unwrap_or_default();
+                std::io::stdin()
+                    .read_to_string(&mut buf)
+                    .unwrap_or_default();
                 buf
             });
 
@@ -531,34 +550,30 @@ fn main() {
             }
         }
 
-        Command::Ocr { path } => {
-            match cueward_adapter_macos::ocr::capture(&path) {
-                Ok(cues) => {
-                    let json = serde_json::to_string_pretty(&cues).unwrap();
-                    println!("{json}");
-                    eprintln!("extracted {} cues", cues.len());
-                }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
-                }
+        Command::Ocr { path } => match cueward_adapter_macos::ocr::capture(&path) {
+            Ok(cues) => {
+                let json = serde_json::to_string_pretty(&cues).unwrap();
+                println!("{json}");
+                eprintln!("extracted {} cues", cues.len());
             }
-        }
+            Err(e) => {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        },
 
         Command::Notes { action } => match action {
             NotesAction::Update {
                 title,
                 body,
                 folder,
-            } => {
-                match cueward_adapter_macos::send::update_note(&title, &body, &folder) {
-                    Ok(()) => eprintln!("note updated: {title}"),
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        process::exit(1);
-                    }
+            } => match cueward_adapter_macos::send::update_note(&title, &body, &folder) {
+                Ok(()) => eprintln!("note updated: {title}"),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
                 }
-            }
+            },
             NotesAction::Delete { title, folder } => {
                 match cueward_adapter_macos::send::delete_note(&title, &folder) {
                     Ok(()) => eprintln!("note deleted: {title}"),
@@ -580,23 +595,21 @@ fn main() {
         },
 
         Command::QuickNotes { action } => match action {
-            QuickNotesAction::List => {
-                match cueward_adapter_macos::quick_notes::list() {
-                    Ok(notes) => {
-                        if notes.is_empty() {
-                            eprintln!("no quick notes found");
-                        } else {
-                            let count = notes.len();
-                            println!("{}", serde_json::to_string_pretty(&notes).unwrap());
-                            eprintln!("{count} quick note(s)");
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        process::exit(1);
+            QuickNotesAction::List => match cueward_adapter_macos::quick_notes::list() {
+                Ok(notes) => {
+                    if notes.is_empty() {
+                        eprintln!("no quick notes found");
+                    } else {
+                        let count = notes.len();
+                        println!("{}", serde_json::to_string_pretty(&notes).unwrap());
+                        eprintln!("{count} quick note(s)");
                     }
                 }
-            }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
+                }
+            },
             QuickNotesAction::Create { title, body } => {
                 match cueward_adapter_macos::quick_notes::create(&title, &body) {
                     Ok(()) => eprintln!("quick note created: {title}"),
@@ -635,18 +648,20 @@ fn main() {
             }
         },
 
-        Command::Screenshot { ocr, output, display } => {
-            match cueward_adapter_macos::screenshot::capture(ocr, output.as_deref(), display) {
-                Ok(result) => {
-                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                    eprintln!("screenshot saved to {}", result.path);
-                }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
-                }
+        Command::Screenshot {
+            ocr,
+            output,
+            display,
+        } => match cueward_adapter_macos::screenshot::capture(ocr, output.as_deref(), display) {
+            Ok(result) => {
+                println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                eprintln!("screenshot saved to {}", result.path);
             }
-        }
+            Err(e) => {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        },
 
         Command::Clipboard { action } => match action {
             ClipboardAction::Get { save_image } => {
@@ -654,7 +669,10 @@ fn main() {
                     Ok(content) => {
                         println!("{}", serde_json::to_string_pretty(&content).unwrap());
                         match content.content_type.as_str() {
-                            "image" => eprintln!("clipboard image saved to {}", content.path.unwrap_or_default()),
+                            "image" => eprintln!(
+                                "clipboard image saved to {}",
+                                content.path.unwrap_or_default()
+                            ),
                             _ => eprintln!("clipboard text read"),
                         }
                     }
@@ -664,15 +682,13 @@ fn main() {
                     }
                 }
             }
-            ClipboardAction::Set { text } => {
-                match cueward_adapter_macos::clipboard::set(&text) {
-                    Ok(()) => eprintln!("copied to clipboard"),
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        process::exit(1);
-                    }
+            ClipboardAction::Set { text } => match cueward_adapter_macos::clipboard::set(&text) {
+                Ok(()) => eprintln!("copied to clipboard"),
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
                 }
-            }
+            },
         },
 
         Command::Calendar { action } => match action {
@@ -702,11 +718,26 @@ fn main() {
 
             CalendarAction::List { from, to, calendar } => {
                 let now = Local::now();
-                let from_dt = from.as_deref().and_then(parse_datetime).unwrap_or(now);
-                let to_dt = to
-                    .as_deref()
-                    .and_then(parse_datetime)
-                    .unwrap_or_else(|| from_dt + chrono::Duration::hours(24));
+                let from_dt = match from.as_deref() {
+                    Some(value) => match parse_required_datetime_arg("--from", Some(value)) {
+                        Ok(dt) => dt,
+                        Err(err) => {
+                            eprintln!("{err}");
+                            process::exit(1);
+                        }
+                    },
+                    None => now,
+                };
+                let to_dt = match to.as_deref() {
+                    Some(value) => match parse_required_datetime_arg("--to", Some(value)) {
+                        Ok(dt) => dt,
+                        Err(err) => {
+                            eprintln!("{err}");
+                            process::exit(1);
+                        }
+                    },
+                    None => from_dt + chrono::Duration::hours(24),
+                };
                 match cueward_adapter_macos::calendar::list_events(
                     from_dt,
                     to_dt,
@@ -731,17 +762,17 @@ fn main() {
                 notes,
                 location,
             } => {
-                let start_dt = match parse_datetime(&start) {
-                    Some(dt) => dt,
-                    None => {
-                        eprintln!("error: invalid start datetime '{start}'");
+                let start_dt = match parse_datetime_arg("start", &start) {
+                    Ok(dt) => dt,
+                    Err(err) => {
+                        eprintln!("{err}");
                         process::exit(1);
                     }
                 };
-                let end_dt = match parse_datetime(&end) {
-                    Some(dt) => dt,
-                    None => {
-                        eprintln!("error: invalid end datetime '{end}'");
+                let end_dt = match parse_datetime_arg("end", &end) {
+                    Ok(dt) => dt,
+                    Err(err) => {
+                        eprintln!("{err}");
                         process::exit(1);
                     }
                 };
@@ -766,10 +797,10 @@ fn main() {
                 start,
                 calendar,
             } => {
-                let start_dt = match parse_datetime(&start) {
-                    Some(dt) => dt,
-                    None => {
-                        eprintln!("error: invalid start datetime '{start}'");
+                let start_dt = match parse_datetime_arg("start", &start) {
+                    Ok(dt) => dt,
+                    Err(err) => {
+                        eprintln!("{err}");
                         process::exit(1);
                     }
                 };
@@ -782,5 +813,20 @@ fn main() {
                 }
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_required_datetime_arg;
+
+    #[test]
+    fn parse_required_datetime_arg_rejects_invalid_values() {
+        let result = parse_required_datetime_arg("--from", Some("April 11"));
+
+        assert_eq!(
+            result,
+            Err("error: invalid --from datetime 'April 11'".to_string())
+        );
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::process;
 
-use chrono::Utc;
+use chrono::{DateTime, Local, TimeZone, Utc};
 use clap::{Parser, Subcommand, ValueEnum};
 
 use cueward_adapter_macos::MacosAdapter;
@@ -89,6 +89,12 @@ enum Command {
     QuickNotes {
         #[command(subcommand)]
         action: QuickNotesAction,
+    },
+
+    /// Query and manage Apple Calendar events
+    Calendar {
+        #[command(subcommand)]
+        action: CalendarAction,
     },
 }
 
@@ -182,12 +188,101 @@ enum QuickNotesAction {
     },
 }
 
+#[derive(Subcommand)]
+enum CalendarAction {
+    /// List events in a time range (default: next 24h)
+    List {
+        /// Start datetime (RFC3339 or "YYYY-MM-DD HH:MM")
+        #[arg(long)]
+        from: Option<String>,
+
+        /// End datetime (RFC3339 or "YYYY-MM-DD HH:MM")
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Filter by calendar name
+        #[arg(long)]
+        calendar: Option<String>,
+    },
+
+    /// List today's events (00:00 to 23:59)
+    Today {
+        /// Filter by calendar name
+        #[arg(long)]
+        calendar: Option<String>,
+    },
+
+    /// Create a calendar event
+    Create {
+        /// Event title
+        #[arg(long)]
+        title: String,
+
+        /// Start datetime (RFC3339 or "YYYY-MM-DD HH:MM")
+        #[arg(long)]
+        start: String,
+
+        /// End datetime (RFC3339 or "YYYY-MM-DD HH:MM")
+        #[arg(long)]
+        end: String,
+
+        /// Calendar name (uses default calendar if omitted)
+        #[arg(long)]
+        calendar: Option<String>,
+
+        /// Notes/description
+        #[arg(long)]
+        notes: Option<String>,
+
+        /// Location
+        #[arg(long)]
+        location: Option<String>,
+    },
+
+    /// Delete a calendar event by title and start datetime
+    Delete {
+        /// Event title
+        #[arg(long)]
+        title: String,
+
+        /// Start datetime (RFC3339 or "YYYY-MM-DD HH:MM")
+        #[arg(long)]
+        start: String,
+
+        /// Calendar name
+        #[arg(long)]
+        calendar: String,
+    },
+}
+
 #[derive(Clone, ValueEnum)]
 enum Source {
     Safari,
     Notes,
     Messages,
     All,
+}
+
+fn parse_datetime(s: &str) -> Option<DateTime<Local>> {
+    use chrono::NaiveDateTime;
+
+    // Try RFC 3339 first
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&Local));
+    }
+    // Try "YYYY-MM-DD HH:MM:SS"
+    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+        if let Some(dt) = Local.from_local_datetime(&ndt).single() {
+            return Some(dt);
+        }
+    }
+    // Try "YYYY-MM-DD HH:MM"
+    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M") {
+        if let Some(dt) = Local.from_local_datetime(&ndt).single() {
+            return Some(dt);
+        }
+    }
+    None
 }
 
 fn parse_duration(s: &str) -> Option<chrono::Duration> {
@@ -495,6 +590,114 @@ fn main() {
             QuickNotesAction::Archive { title, to } => {
                 match cueward_adapter_macos::quick_notes::archive(&title, &to) {
                     Ok(()) => eprintln!("quick note archived: {title} -> {to}"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+        },
+
+        Command::Calendar { action } => match action {
+            CalendarAction::Today { calendar } => {
+                let now = Local::now();
+                let from = now
+                    .date_naive()
+                    .and_hms_opt(0, 0, 0)
+                    .and_then(|dt| Local.from_local_datetime(&dt).single())
+                    .unwrap_or(now);
+                let to = now
+                    .date_naive()
+                    .and_hms_opt(23, 59, 59)
+                    .and_then(|dt| Local.from_local_datetime(&dt).single())
+                    .unwrap_or(now);
+                match cueward_adapter_macos::calendar::list_events(from, to, calendar.as_deref()) {
+                    Ok(events) => {
+                        println!("{}", serde_json::to_string_pretty(&events).unwrap());
+                        eprintln!("{} event(s)", events.len());
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+
+            CalendarAction::List { from, to, calendar } => {
+                let now = Local::now();
+                let from_dt = from.as_deref().and_then(parse_datetime).unwrap_or(now);
+                let to_dt = to
+                    .as_deref()
+                    .and_then(parse_datetime)
+                    .unwrap_or_else(|| from_dt + chrono::Duration::hours(24));
+                match cueward_adapter_macos::calendar::list_events(
+                    from_dt,
+                    to_dt,
+                    calendar.as_deref(),
+                ) {
+                    Ok(events) => {
+                        println!("{}", serde_json::to_string_pretty(&events).unwrap());
+                        eprintln!("{} event(s)", events.len());
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+
+            CalendarAction::Create {
+                title,
+                start,
+                end,
+                calendar,
+                notes,
+                location,
+            } => {
+                let start_dt = match parse_datetime(&start) {
+                    Some(dt) => dt,
+                    None => {
+                        eprintln!("error: invalid start datetime '{start}'");
+                        process::exit(1);
+                    }
+                };
+                let end_dt = match parse_datetime(&end) {
+                    Some(dt) => dt,
+                    None => {
+                        eprintln!("error: invalid end datetime '{end}'");
+                        process::exit(1);
+                    }
+                };
+                match cueward_adapter_macos::calendar::create_event(
+                    &title,
+                    start_dt,
+                    end_dt,
+                    calendar.as_deref(),
+                    notes.as_deref(),
+                    location.as_deref(),
+                ) {
+                    Ok(()) => eprintln!("event created: {title}"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+
+            CalendarAction::Delete {
+                title,
+                start,
+                calendar,
+            } => {
+                let start_dt = match parse_datetime(&start) {
+                    Some(dt) => dt,
+                    None => {
+                        eprintln!("error: invalid start datetime '{start}'");
+                        process::exit(1);
+                    }
+                };
+                match cueward_adapter_macos::calendar::delete_event(&title, start_dt, &calendar) {
+                    Ok(()) => eprintln!("event deleted: {title}"),
                     Err(e) => {
                         eprintln!("error: {e}");
                         process::exit(1);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -96,6 +96,17 @@ enum Command {
         #[command(subcommand)]
         action: CalendarAction,
     },
+
+    /// Capture a screenshot of the entire screen
+    Screenshot {
+        /// Also run OCR on the captured image
+        #[arg(long)]
+        ocr: bool,
+
+        /// Output path (default: ~/.cueward/cache/screenshots/<timestamp>.png)
+        #[arg(long)]
+        output: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -597,6 +608,19 @@ fn main() {
                 }
             }
         },
+
+        Command::Screenshot { ocr, output } => {
+            match cueward_adapter_macos::screenshot::capture(ocr, output.as_deref()) {
+                Ok(result) => {
+                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                    eprintln!("screenshot saved to {}", result.path);
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
 
         Command::Calendar { action } => match action {
             CalendarAction::Today { calendar } => {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -97,7 +97,7 @@ enum Command {
         action: CalendarAction,
     },
 
-    /// Capture a screenshot of the entire screen
+    /// Capture a screenshot of the screen
     Screenshot {
         /// Also run OCR on the captured image
         #[arg(long)]
@@ -106,6 +106,10 @@ enum Command {
         /// Output path (default: ~/.cueward/cache/screenshots/<timestamp>.png)
         #[arg(long)]
         output: Option<String>,
+
+        /// Display number (1 = main, 2 = secondary, 3 = third)
+        #[arg(long)]
+        display: Option<u32>,
     },
 
     /// Read or write the system clipboard
@@ -631,8 +635,8 @@ fn main() {
             }
         },
 
-        Command::Screenshot { ocr, output } => {
-            match cueward_adapter_macos::screenshot::capture(ocr, output.as_deref()) {
+        Command::Screenshot { ocr, output, display } => {
+            match cueward_adapter_macos::screenshot::capture(ocr, output.as_deref(), display) {
                 Ok(result) => {
                     println!("{}", serde_json::to_string_pretty(&result).unwrap());
                     eprintln!("screenshot saved to {}", result.path);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -312,13 +312,23 @@ fn parse_datetime(s: &str) -> Option<DateTime<Local>> {
     }
     // Try "YYYY-MM-DD HH:MM:SS"
     if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
-        if let Some(dt) = Local.from_local_datetime(&ndt).single() {
+        if let Some(dt) = Local
+            .from_local_datetime(&ndt)
+            .single()
+            .or_else(|| Local.from_local_datetime(&ndt).earliest())
+            .or_else(|| Local.from_local_datetime(&ndt).latest())
+        {
             return Some(dt);
         }
     }
     // Try "YYYY-MM-DD HH:MM"
     if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M") {
-        if let Some(dt) = Local.from_local_datetime(&ndt).single() {
+        if let Some(dt) = Local
+            .from_local_datetime(&ndt)
+            .single()
+            .or_else(|| Local.from_local_datetime(&ndt).earliest())
+            .or_else(|| Local.from_local_datetime(&ndt).latest())
+        {
             return Some(dt);
         }
     }
@@ -885,5 +895,12 @@ mod tests {
         assert_eq!(to.hour(), 23);
         assert_eq!(to.minute(), 59);
         assert_eq!(to.second(), 59);
+    }
+
+    #[test]
+    fn parse_datetime_accepts_ambiguous_local_time() {
+        let parsed = super::parse_datetime("2026-11-01 01:30");
+
+        assert!(parsed.is_some());
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -339,6 +339,34 @@ fn parse_required_datetime_arg(
     }
 }
 
+fn validate_optional_output_path(label: &str, value: Option<&str>) -> Result<(), String> {
+    if let Some(path) = value {
+        if std::path::Path::new(path)
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+        {
+            return Err(format!(
+                "error: {label} path must not contain parent directory components"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn local_day_bounds(now: DateTime<Local>) -> Result<(DateTime<Local>, DateTime<Local>), String> {
+    let from = now
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .and_then(|dt| Local.from_local_datetime(&dt).single())
+        .ok_or_else(|| "error: could not determine start of today".to_string())?;
+    let to = now
+        .date_naive()
+        .and_hms_opt(23, 59, 59)
+        .and_then(|dt| Local.from_local_datetime(&dt).single())
+        .ok_or_else(|| "error: could not determine end of today".to_string())?;
+    Ok((from, to))
+}
+
 fn parse_duration(s: &str) -> Option<chrono::Duration> {
     let s = s.trim();
     if let Some(hours) = s.strip_suffix('h') {
@@ -652,19 +680,31 @@ fn main() {
             ocr,
             output,
             display,
-        } => match cueward_adapter_macos::screenshot::capture(ocr, output.as_deref(), display) {
-            Ok(result) => {
-                println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                eprintln!("screenshot saved to {}", result.path);
-            }
-            Err(e) => {
-                eprintln!("error: {e}");
+        } => {
+            if let Err(err) = validate_optional_output_path("--output", output.as_deref()) {
+                eprintln!("{err}");
                 process::exit(1);
             }
-        },
+            match cueward_adapter_macos::screenshot::capture(ocr, output.as_deref(), display) {
+                Ok(result) => {
+                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                    eprintln!("screenshot saved to {}", result.path);
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
 
         Command::Clipboard { action } => match action {
             ClipboardAction::Get { save_image } => {
+                if let Err(err) =
+                    validate_optional_output_path("--save-image", save_image.as_deref())
+                {
+                    eprintln!("{err}");
+                    process::exit(1);
+                }
                 match cueward_adapter_macos::clipboard::get(save_image.as_deref()) {
                     Ok(content) => {
                         println!("{}", serde_json::to_string_pretty(&content).unwrap());
@@ -694,16 +734,13 @@ fn main() {
         Command::Calendar { action } => match action {
             CalendarAction::Today { calendar } => {
                 let now = Local::now();
-                let from = now
-                    .date_naive()
-                    .and_hms_opt(0, 0, 0)
-                    .and_then(|dt| Local.from_local_datetime(&dt).single())
-                    .unwrap_or(now);
-                let to = now
-                    .date_naive()
-                    .and_hms_opt(23, 59, 59)
-                    .and_then(|dt| Local.from_local_datetime(&dt).single())
-                    .unwrap_or(now);
+                let (from, to) = match local_day_bounds(now) {
+                    Ok(bounds) => bounds,
+                    Err(err) => {
+                        eprintln!("{err}");
+                        process::exit(1);
+                    }
+                };
                 match cueward_adapter_macos::calendar::list_events(from, to, calendar.as_deref()) {
                     Ok(events) => {
                         println!("{}", serde_json::to_string_pretty(&events).unwrap());
@@ -818,15 +855,35 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_required_datetime_arg;
+    use chrono::Timelike;
+    use chrono::{Local, TimeZone};
+
+    use super::{local_day_bounds, validate_optional_output_path};
 
     #[test]
-    fn parse_required_datetime_arg_rejects_invalid_values() {
-        let result = parse_required_datetime_arg("--from", Some("April 11"));
+    fn validate_optional_output_path_rejects_parent_components() {
+        let result = validate_optional_output_path("--output", Some("../secret.png"));
 
         assert_eq!(
             result,
-            Err("error: invalid --from datetime 'April 11'".to_string())
+            Err("error: --output path must not contain parent directory components".to_string())
         );
+    }
+
+    #[test]
+    fn local_day_bounds_covers_full_day() {
+        let now = Local
+            .with_ymd_and_hms(2026, 4, 11, 10, 30, 0)
+            .single()
+            .expect("local dt");
+
+        let (from, to) = local_day_bounds(now).expect("bounds");
+
+        assert_eq!(from.hour(), 0);
+        assert_eq!(from.minute(), 0);
+        assert_eq!(from.second(), 0);
+        assert_eq!(to.hour(), 23);
+        assert_eq!(to.minute(), 59);
+        assert_eq!(to.second(), 59);
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -107,6 +107,28 @@ enum Command {
         #[arg(long)]
         output: Option<String>,
     },
+
+    /// Read or write the system clipboard
+    Clipboard {
+        #[command(subcommand)]
+        action: ClipboardAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum ClipboardAction {
+    /// Read clipboard content (text or image)
+    Get {
+        /// Save image to this path instead of default cache dir
+        #[arg(long)]
+        save_image: Option<String>,
+    },
+
+    /// Write text to clipboard
+    Set {
+        /// Text to copy to clipboard
+        text: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -621,6 +643,33 @@ fn main() {
                 }
             }
         }
+
+        Command::Clipboard { action } => match action {
+            ClipboardAction::Get { save_image } => {
+                match cueward_adapter_macos::clipboard::get(save_image.as_deref()) {
+                    Ok(content) => {
+                        println!("{}", serde_json::to_string_pretty(&content).unwrap());
+                        match content.content_type.as_str() {
+                            "image" => eprintln!("clipboard image saved to {}", content.path.unwrap_or_default()),
+                            _ => eprintln!("clipboard text read"),
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            ClipboardAction::Set { text } => {
+                match cueward_adapter_macos::clipboard::set(&text) {
+                    Ok(()) => eprintln!("copied to clipboard"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+        },
 
         Command::Calendar { action } => match action {
             CalendarAction::Today { calendar } => {

--- a/crates/core/src/cue.rs
+++ b/crates/core/src/cue.rs
@@ -12,6 +12,19 @@ pub enum CueSource {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachmentSegment {
+    pub index: usize,
+    pub filename: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_text: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub has_ocr: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Cue {
     pub source: CueSource,
     pub timestamp: DateTime<Utc>,
@@ -22,6 +35,8 @@ pub struct Cue {
     pub title: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachment_segments: Vec<AttachmentSegment>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub metadata: HashMap<String, String>,
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,7 +5,7 @@ pub mod inbox;
 pub mod index;
 pub mod tagger;
 
-pub use cue::{Cue, CueSource};
+pub use cue::{AttachmentSegment, Cue, CueSource};
 pub use adapter::PlatformAdapter;
 pub use state::State;
 pub use index::CueIndex;

--- a/docs/plans/2026-04-11-calendar-screenshot-clipboard.md
+++ b/docs/plans/2026-04-11-calendar-screenshot-clipboard.md
@@ -1,0 +1,1142 @@
+# Calendar / Screenshot / Clipboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three macOS integrations to cueward: calendar read/write, screenshot with optional OCR, clipboard read/write.
+
+**Architecture:** Each feature is a new module in `crates/adapter-macos/src/` with a corresponding CLI subcommand in `crates/cli/src/main.rs`. Calendar and clipboard use AppleScript via the existing `applescript::run` helper (extended with `run_capture` for stdout). Screenshot uses macOS `screencapture` command. All follow the existing pattern: adapter module → CLI handler → JSON stdout / stderr status.
+
+**Tech Stack:** Rust, clap (CLI), AppleScript via osascript, macOS screencapture, existing Vision OCR pipeline
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Modify | `crates/adapter-macos/src/applescript.rs` | Add `run_capture()` that returns stdout |
+| Create | `crates/adapter-macos/src/calendar.rs` | Calendar CRUD via AppleScript |
+| Create | `crates/adapter-macos/src/screenshot.rs` | screencapture + optional OCR |
+| Create | `crates/adapter-macos/src/clipboard.rs` | pbpaste/pbcopy + image detection |
+| Modify | `crates/adapter-macos/src/lib.rs` | Export new modules |
+| Modify | `crates/cli/src/main.rs` | Add Calendar, Screenshot, Clipboard subcommands |
+
+---
+
+### Task 1: Extend applescript helper with `run_capture`
+
+Calendar list needs to capture AppleScript stdout. Currently `applescript::run` discards it.
+
+**Files:**
+- Modify: `crates/adapter-macos/src/applescript.rs`
+
+- [ ] **Step 1: Add `run_capture` function**
+
+Add after the existing `run` function in `crates/adapter-macos/src/applescript.rs`:
+
+```rust
+/// Run an AppleScript and return its stdout on success.
+pub fn run_capture(script: &str, context: &str) -> Result<String, MacosError> {
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .map_err(|e| MacosError::Other(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::Other(format!("{context}: {stderr}")));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/cyh/Development/cueward && cargo check -p cueward-adapter-macos 2>&1 | tail -5`
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/cyh/Development/cueward
+git add crates/adapter-macos/src/applescript.rs
+git commit -m "feat(applescript): add run_capture to return stdout"
+```
+
+---
+
+### Task 2: Calendar module
+
+**Files:**
+- Create: `crates/adapter-macos/src/calendar.rs`
+- Modify: `crates/adapter-macos/src/lib.rs`
+
+- [ ] **Step 1: Create calendar.rs with CalendarEvent struct and list_events**
+
+Create `crates/adapter-macos/src/calendar.rs`:
+
+```rust
+use std::process::Command;
+
+use chrono::{DateTime, Local, NaiveDateTime, Utc};
+use serde::Serialize;
+
+use crate::applescript::escape;
+use crate::MacosError;
+
+#[derive(Debug, Serialize)]
+pub struct CalendarEvent {
+    pub title: String,
+    pub start: String,
+    pub end: String,
+    pub calendar: String,
+    pub location: String,
+    pub notes: String,
+    pub all_day: bool,
+}
+
+/// Format a DateTime for AppleScript: "YYYY-MM-DD HH:MM:SS"
+fn format_for_applescript(dt: &DateTime<Local>) -> String {
+    dt.format("%Y-%m-%d %H:%M:%S").to_string()
+}
+
+/// Parse a single tab-separated line from the AppleScript output into a CalendarEvent.
+fn parse_event_line(line: &str) -> Option<CalendarEvent> {
+    // Fields: title \t start \t end \t calendar \t location \t notes \t all_day
+    let parts: Vec<&str> = line.split('\t').collect();
+    if parts.len() < 7 {
+        return None;
+    }
+    Some(CalendarEvent {
+        title: parts[0].to_string(),
+        start: parts[1].to_string(),
+        end: parts[2].to_string(),
+        calendar: parts[3].to_string(),
+        location: parts[4].to_string(),
+        notes: parts[5].to_string(),
+        all_day: parts[6].trim() == "true",
+    })
+}
+
+/// List calendar events between two dates.
+pub fn list_events(
+    from: DateTime<Local>,
+    to: DateTime<Local>,
+    calendar_filter: Option<&str>,
+) -> Result<Vec<CalendarEvent>, MacosError> {
+    let from_str = format_for_applescript(&from);
+    let to_str = format_for_applescript(&to);
+
+    // AppleScript to query events. Output tab-separated fields, one event per line.
+    let calendar_clause = match calendar_filter {
+        Some(name) => format!(r#"set cals to {{calendar "{}"}}"#, escape(name)),
+        None => "set cals to every calendar".to_string(),
+    };
+
+    let script = format!(
+        r#"
+        tell application "Calendar"
+            {calendar_clause}
+            set output to ""
+            set fromDate to date "{from_str}"
+            set toDate to date "{to_str}"
+            repeat with cal in cals
+                set calName to name of cal
+                set evts to (every event of cal whose start date ≥ fromDate and start date ≤ toDate)
+                repeat with evt in evts
+                    set evtTitle to summary of evt
+                    set evtStart to start date of evt
+                    set evtEnd to end date of evt
+                    set evtLoc to ""
+                    try
+                        set evtLoc to location of evt
+                    end try
+                    if evtLoc is missing value then set evtLoc to ""
+                    set evtNotes to ""
+                    try
+                        set evtNotes to description of evt
+                    end try
+                    if evtNotes is missing value then set evtNotes to ""
+                    set isAllDay to allday event of evt
+                    set evtStartStr to (evtStart as «class isot» as string)
+                    set evtEndStr to (evtEnd as «class isot» as string)
+                    set output to output & evtTitle & tab & evtStartStr & tab & evtEndStr & tab & calName & tab & evtLoc & tab & evtNotes & tab & isAllDay & linefeed
+                end repeat
+            end repeat
+            return output
+        end tell
+        "#
+    );
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| MacosError::Other(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::Other(format!("failed to list events: {stderr}")));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let events: Vec<CalendarEvent> = stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(parse_event_line)
+        .collect();
+
+    Ok(events)
+}
+
+/// Create a calendar event.
+pub fn create_event(
+    title: &str,
+    start: &DateTime<Local>,
+    end: &DateTime<Local>,
+    calendar_name: Option<&str>,
+    notes: Option<&str>,
+    location: Option<&str>,
+) -> Result<(), MacosError> {
+    let escaped_title = escape(title);
+    let start_str = format_for_applescript(start);
+    let end_str = format_for_applescript(end);
+
+    let cal_clause = match calendar_name {
+        Some(name) => format!(r#"set targetCal to calendar "{}""#, escape(name)),
+        None => "set targetCal to default calendar".to_string(),
+    };
+
+    let mut props = format!(
+        r#"summary:"{escaped_title}", start date:date "{start_str}", end date:date "{end_str}""#
+    );
+    if let Some(loc) = location {
+        props.push_str(&format!(r#", location:"{}""#, escape(loc)));
+    }
+    if let Some(n) = notes {
+        props.push_str(&format!(r#", description:"{}""#, escape(n)));
+    }
+
+    let script = format!(
+        r#"
+        tell application "Calendar"
+            {cal_clause}
+            make new event at end of events of targetCal with properties {{{props}}}
+        end tell
+        "#
+    );
+
+    crate::applescript::run(&script, "failed to create event")
+}
+
+/// Delete a calendar event by title and start date.
+pub fn delete_event(
+    title: &str,
+    start: &DateTime<Local>,
+    calendar_name: Option<&str>,
+) -> Result<(), MacosError> {
+    let escaped_title = escape(title);
+    let start_str = format_for_applescript(start);
+
+    let cal_clause = match calendar_name {
+        Some(name) => format!(r#"set cals to {{calendar "{}"}}"#, escape(name)),
+        None => "set cals to every calendar".to_string(),
+    };
+
+    let script = format!(
+        r#"
+        tell application "Calendar"
+            {cal_clause}
+            set targetDate to date "{start_str}"
+            set found to false
+            repeat with cal in cals
+                set evts to (every event of cal whose summary is "{escaped_title}" and start date is targetDate)
+                repeat with evt in evts
+                    delete evt
+                    set found to true
+                end repeat
+            end repeat
+            if not found then error "event not found: {escaped_title} at {start_str}"
+        end tell
+        "#
+    );
+
+    crate::applescript::run(&script, "failed to delete event")
+}
+```
+
+- [ ] **Step 2: Export calendar module from lib.rs**
+
+Add to `crates/adapter-macos/src/lib.rs` after `pub mod quick_notes;`:
+
+```rust
+pub mod calendar;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/cyh/Development/cueward && cargo check -p cueward-adapter-macos 2>&1 | tail -5`
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/cyh/Development/cueward
+git add crates/adapter-macos/src/calendar.rs crates/adapter-macos/src/lib.rs
+git commit -m "feat(calendar): add list/create/delete via AppleScript"
+```
+
+---
+
+### Task 3: Calendar CLI subcommand
+
+**Files:**
+- Modify: `crates/cli/src/main.rs`
+
+- [ ] **Step 1: Add CalendarAction enum and Calendar command variant**
+
+Add after the `QuickNotesAction` enum (around line 183):
+
+```rust
+#[derive(Subcommand)]
+enum CalendarAction {
+    /// List events in a time range
+    List {
+        /// Start of range (ISO 8601 or "YYYY-MM-DD HH:MM")
+        #[arg(long)]
+        from: Option<String>,
+
+        /// End of range (ISO 8601 or "YYYY-MM-DD HH:MM")
+        #[arg(long)]
+        to: Option<String>,
+
+        /// Filter by calendar name
+        #[arg(long)]
+        calendar: Option<String>,
+    },
+
+    /// List today's events (shortcut for list --from "today 00:00" --to "today 23:59")
+    Today,
+
+    /// Create a new calendar event
+    Create {
+        /// Event title
+        #[arg(long)]
+        title: String,
+
+        /// Start time (ISO 8601 or "YYYY-MM-DD HH:MM")
+        #[arg(long)]
+        start: String,
+
+        /// End time (ISO 8601 or "YYYY-MM-DD HH:MM")
+        #[arg(long)]
+        end: String,
+
+        /// Calendar name (uses default if not specified)
+        #[arg(long)]
+        calendar: Option<String>,
+
+        /// Event notes/description
+        #[arg(long)]
+        notes: Option<String>,
+
+        /// Event location
+        #[arg(long)]
+        location: Option<String>,
+    },
+
+    /// Delete a calendar event
+    Delete {
+        /// Event title
+        #[arg(long)]
+        title: String,
+
+        /// Event start time (to identify the specific occurrence)
+        #[arg(long)]
+        start: String,
+
+        /// Calendar name (searches all if not specified)
+        #[arg(long)]
+        calendar: Option<String>,
+    },
+}
+```
+
+Add the `Calendar` variant to the `Command` enum:
+
+```rust
+    /// Manage Apple Calendar events
+    Calendar {
+        #[command(subcommand)]
+        action: CalendarAction,
+    },
+```
+
+- [ ] **Step 2: Add datetime parser helper**
+
+Add after `parse_duration` function:
+
+```rust
+fn parse_datetime(s: &str) -> Option<DateTime<Local>> {
+    use chrono::{Local, NaiveDateTime, TimeZone};
+    // Try ISO 8601 with timezone
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&Local));
+    }
+    // Try "YYYY-MM-DD HH:MM:SS"
+    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+        return Local.from_local_datetime(&ndt).single();
+    }
+    // Try "YYYY-MM-DD HH:MM"
+    if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M") {
+        return Local.from_local_datetime(&ndt).single();
+    }
+    None
+}
+```
+
+Add to imports at top of main.rs:
+
+```rust
+use chrono::{DateTime, Local, TimeZone, Utc};
+```
+
+- [ ] **Step 3: Add Calendar command handler**
+
+Add in the main `match cli.command` block, before the closing `}`:
+
+```rust
+        Command::Calendar { action } => match action {
+            CalendarAction::List { from, to, calendar } => {
+                let from_dt = match from {
+                    Some(s) => match parse_datetime(&s) {
+                        Some(dt) => dt,
+                        None => {
+                            eprintln!("error: invalid --from datetime '{s}' (use YYYY-MM-DD HH:MM)");
+                            process::exit(1);
+                        }
+                    },
+                    None => Local::now(),
+                };
+                let to_dt = match to {
+                    Some(s) => match parse_datetime(&s) {
+                        Some(dt) => dt,
+                        None => {
+                            eprintln!("error: invalid --to datetime '{s}' (use YYYY-MM-DD HH:MM)");
+                            process::exit(1);
+                        }
+                    },
+                    None => from_dt + chrono::Duration::hours(24),
+                };
+                match cueward_adapter_macos::calendar::list_events(from_dt, to_dt, calendar.as_deref()) {
+                    Ok(events) => {
+                        println!("{}", serde_json::to_string_pretty(&events).unwrap());
+                        eprintln!("{} event(s)", events.len());
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            CalendarAction::Today => {
+                let today_start = Local::now()
+                    .date_naive()
+                    .and_hms_opt(0, 0, 0)
+                    .and_then(|ndt| Local.from_local_datetime(&ndt).single())
+                    .unwrap();
+                let today_end = Local::now()
+                    .date_naive()
+                    .and_hms_opt(23, 59, 59)
+                    .and_then(|ndt| Local.from_local_datetime(&ndt).single())
+                    .unwrap();
+                match cueward_adapter_macos::calendar::list_events(today_start, today_end, None) {
+                    Ok(events) => {
+                        println!("{}", serde_json::to_string_pretty(&events).unwrap());
+                        eprintln!("{} event(s) today", events.len());
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            CalendarAction::Create { title, start, end, calendar, notes, location } => {
+                let start_dt = match parse_datetime(&start) {
+                    Some(dt) => dt,
+                    None => {
+                        eprintln!("error: invalid --start datetime '{start}'");
+                        process::exit(1);
+                    }
+                };
+                let end_dt = match parse_datetime(&end) {
+                    Some(dt) => dt,
+                    None => {
+                        eprintln!("error: invalid --end datetime '{end}'");
+                        process::exit(1);
+                    }
+                };
+                match cueward_adapter_macos::calendar::create_event(
+                    &title, &start_dt, &end_dt, calendar.as_deref(), notes.as_deref(), location.as_deref(),
+                ) {
+                    Ok(()) => eprintln!("event created: {title}"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            CalendarAction::Delete { title, start, calendar } => {
+                let start_dt = match parse_datetime(&start) {
+                    Some(dt) => dt,
+                    None => {
+                        eprintln!("error: invalid --start datetime '{start}'");
+                        process::exit(1);
+                    }
+                };
+                match cueward_adapter_macos::calendar::delete_event(
+                    &title, &start_dt, calendar.as_deref(),
+                ) {
+                    Ok(()) => eprintln!("event deleted: {title}"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+        },
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd /Users/cyh/Development/cueward && cargo check 2>&1 | tail -5`
+Expected: no errors
+
+- [ ] **Step 5: Test manually**
+
+Run: `cd /Users/cyh/Development/cueward && cargo run -- calendar today 2>&1`
+Expected: JSON output of today's events (or empty array)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/cyh/Development/cueward
+git add crates/cli/src/main.rs
+git commit -m "feat(cli): add calendar subcommand (list/today/create/delete)"
+```
+
+---
+
+### Task 4: Screenshot module
+
+**Files:**
+- Create: `crates/adapter-macos/src/screenshot.rs`
+- Modify: `crates/adapter-macos/src/lib.rs`
+
+- [ ] **Step 1: Create screenshot.rs**
+
+Create `crates/adapter-macos/src/screenshot.rs`:
+
+```rust
+use std::fs;
+use std::process::Command;
+
+use chrono::Local;
+use serde::Serialize;
+
+use crate::MacosError;
+
+#[derive(Debug, Serialize)]
+pub struct ScreenshotResult {
+    pub path: String,
+    pub timestamp: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_text: Option<String>,
+}
+
+const CACHE_DIR: &str = ".cueward/cache/screenshots";
+
+fn ensure_cache_dir() -> Result<String, MacosError> {
+    let home = std::env::var("HOME")
+        .map_err(|_| MacosError::Other("HOME not set".into()))?;
+    let dir = format!("{home}/{CACHE_DIR}");
+    fs::create_dir_all(&dir)
+        .map_err(|e| MacosError::Other(format!("failed to create {dir}: {e}")))?;
+    Ok(dir)
+}
+
+/// Capture a screenshot of the entire screen.
+/// If `ocr` is true, also runs Vision OCR on the captured image.
+/// If `output` is Some, saves to that path instead of the default cache dir.
+pub fn capture(ocr: bool, output: Option<&str>) -> Result<ScreenshotResult, MacosError> {
+    let now = Local::now();
+    let timestamp = now.format("%Y%m%d-%H%M%S").to_string();
+
+    let path = match output {
+        Some(p) => p.to_string(),
+        None => {
+            let dir = ensure_cache_dir()?;
+            format!("{dir}/{timestamp}.png")
+        }
+    };
+
+    // -x = silent (no shutter sound)
+    let status = Command::new("screencapture")
+        .args(["-x", &path])
+        .status()
+        .map_err(|e| MacosError::Other(format!("screencapture: {e}")))?;
+
+    if !status.success() {
+        return Err(MacosError::Other("screencapture failed".into()));
+    }
+
+    let ocr_text = if ocr {
+        match crate::ocr::capture(&path) {
+            Ok(cues) => {
+                let text: String = cues.into_iter().map(|c| c.content).collect::<Vec<_>>().join("\n");
+                if text.is_empty() { None } else { Some(text) }
+            }
+            Err(e) => {
+                eprintln!("warning: OCR failed: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    Ok(ScreenshotResult {
+        path,
+        timestamp: now.to_rfc3339(),
+        ocr_text,
+    })
+}
+```
+
+- [ ] **Step 2: Export screenshot module from lib.rs**
+
+Add to `crates/adapter-macos/src/lib.rs`:
+
+```rust
+pub mod screenshot;
+```
+
+- [ ] **Step 3: Fix ocr module visibility**
+
+The `screenshot` module needs to call `crate::ocr::capture`, but `ocr` is currently `pub mod ocr`. Verify it's accessible — it already is (`pub mod ocr` in lib.rs). No change needed.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd /Users/cyh/Development/cueward && cargo check -p cueward-adapter-macos 2>&1 | tail -5`
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/cyh/Development/cueward
+git add crates/adapter-macos/src/screenshot.rs crates/adapter-macos/src/lib.rs
+git commit -m "feat(screenshot): screencapture with optional OCR"
+```
+
+---
+
+### Task 5: Screenshot CLI subcommand
+
+**Files:**
+- Modify: `crates/cli/src/main.rs`
+
+- [ ] **Step 1: Add Screenshot command variant**
+
+Add to the `Command` enum:
+
+```rust
+    /// Capture a screenshot of the entire screen
+    Screenshot {
+        /// Also run OCR on the captured image
+        #[arg(long)]
+        ocr: bool,
+
+        /// Output path (default: ~/.cueward/cache/screenshots/<timestamp>.png)
+        #[arg(long)]
+        output: Option<String>,
+    },
+```
+
+- [ ] **Step 2: Add Screenshot handler**
+
+Add in the main `match cli.command` block:
+
+```rust
+        Command::Screenshot { ocr, output } => {
+            match cueward_adapter_macos::screenshot::capture(ocr, output.as_deref()) {
+                Ok(result) => {
+                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                    eprintln!("screenshot saved to {}", result.path);
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
+                }
+            }
+        }
+```
+
+- [ ] **Step 3: Verify it compiles and test**
+
+Run: `cd /Users/cyh/Development/cueward && cargo run -- screenshot 2>&1`
+Expected: JSON with path to screenshot file
+
+Run: `cd /Users/cyh/Development/cueward && cargo run -- screenshot --ocr 2>&1`
+Expected: JSON with path + ocr_text field
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/cyh/Development/cueward
+git add crates/cli/src/main.rs
+git commit -m "feat(cli): add screenshot subcommand"
+```
+
+---
+
+### Task 6: Clipboard module
+
+**Files:**
+- Create: `crates/adapter-macos/src/clipboard.rs`
+- Modify: `crates/adapter-macos/src/lib.rs`
+
+- [ ] **Step 1: Create clipboard.rs**
+
+Create `crates/adapter-macos/src/clipboard.rs`:
+
+```rust
+use std::fs;
+use std::process::Command;
+
+use chrono::Local;
+use serde::Serialize;
+
+use crate::MacosError;
+
+#[derive(Debug, Serialize)]
+pub struct ClipboardContent {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+const CACHE_DIR: &str = ".cueward/cache/clipboard";
+
+fn ensure_cache_dir() -> Result<String, MacosError> {
+    let home = std::env::var("HOME")
+        .map_err(|_| MacosError::Other("HOME not set".into()))?;
+    let dir = format!("{home}/{CACHE_DIR}");
+    fs::create_dir_all(&dir)
+        .map_err(|e| MacosError::Other(format!("failed to create {dir}: {e}")))?;
+    Ok(dir)
+}
+
+/// Check if clipboard contains an image.
+fn has_image() -> bool {
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg("clipboard info")
+        .output();
+    match output {
+        Ok(o) => {
+            let info = String::from_utf8_lossy(&o.stdout);
+            info.contains("«class PNGf»") || info.contains("«class TIFF»")
+        }
+        Err(_) => false,
+    }
+}
+
+/// Save clipboard image to a PNG file using AppleScript + osascript.
+fn save_clipboard_image(save_path: &str) -> Result<(), MacosError> {
+    // Use osascript with a small script to write clipboard image as PNG
+    let script = format!(
+        r#"
+        use framework "AppKit"
+        set pb to current application's NSPasteboard's generalPasteboard()
+        set imgData to pb's dataForType:(current application's NSPasteboardTypePNG)
+        if imgData is missing value then
+            set tiffData to pb's dataForType:(current application's NSPasteboardTypeTIFF)
+            if tiffData is missing value then error "no image in clipboard"
+            set bitmapRep to current application's NSBitmapImageRep's imageRepWithData:tiffData
+            set imgData to bitmapRep's representationUsingType:(current application's NSBitmapImageFileTypePNG) properties:(missing value)
+        end if
+        imgData's writeToFile:"{save_path}" atomically:true
+        "#,
+        save_path = save_path.replace('"', "\\\""),
+    );
+
+    let output = Command::new("osascript")
+        .arg("-l")
+        .arg("AppleScript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| MacosError::Other(format!("osascript: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(MacosError::Other(format!("failed to save clipboard image: {stderr}")));
+    }
+
+    Ok(())
+}
+
+/// Read clipboard content. Returns text or saves image and returns path.
+pub fn get(save_image_path: Option<&str>) -> Result<ClipboardContent, MacosError> {
+    // Check for image first
+    if has_image() {
+        let path = match save_image_path {
+            Some(p) => p.to_string(),
+            None => {
+                let dir = ensure_cache_dir()?;
+                let ts = Local::now().format("%Y%m%d-%H%M%S").to_string();
+                format!("{dir}/{ts}.png")
+            }
+        };
+
+        save_clipboard_image(&path)?;
+
+        return Ok(ClipboardContent {
+            content_type: "image".into(),
+            content: None,
+            path: Some(path),
+        });
+    }
+
+    // Fall back to text
+    let output = Command::new("pbpaste")
+        .output()
+        .map_err(|e| MacosError::Other(format!("pbpaste: {e}")))?;
+
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+
+    Ok(ClipboardContent {
+        content_type: "text".into(),
+        content: Some(text),
+        path: None,
+    })
+}
+
+/// Write text to clipboard.
+pub fn set(text: &str) -> Result<(), MacosError> {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    let mut child = Command::new("pbcopy")
+        .stdin(Stdio::piped())
+        .spawn()
+        .map_err(|e| MacosError::Other(format!("pbcopy: {e}")))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|e| MacosError::Other(format!("failed to write to pbcopy: {e}")))?;
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| MacosError::Other(format!("pbcopy: {e}")))?;
+
+    if !status.success() {
+        return Err(MacosError::Other("pbcopy failed".into()));
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Export clipboard module from lib.rs**
+
+Add to `crates/adapter-macos/src/lib.rs`:
+
+```rust
+pub mod clipboard;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/cyh/Development/cueward && cargo check -p cueward-adapter-macos 2>&1 | tail -5`
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/cyh/Development/cueward
+git add crates/adapter-macos/src/clipboard.rs crates/adapter-macos/src/lib.rs
+git commit -m "feat(clipboard): get/set with text and image support"
+```
+
+---
+
+### Task 7: Clipboard CLI subcommand
+
+**Files:**
+- Modify: `crates/cli/src/main.rs`
+
+- [ ] **Step 1: Add ClipboardAction enum and Clipboard command variant**
+
+Add `ClipboardAction` enum:
+
+```rust
+#[derive(Subcommand)]
+enum ClipboardAction {
+    /// Read clipboard content (text or image)
+    Get {
+        /// Save image to this path (default: ~/.cueward/cache/clipboard/<timestamp>.png)
+        #[arg(long)]
+        save_image: Option<String>,
+    },
+
+    /// Write text to clipboard
+    Set {
+        /// Text to copy to clipboard
+        text: String,
+    },
+}
+```
+
+Add `Clipboard` to `Command` enum:
+
+```rust
+    /// Read or write the system clipboard
+    Clipboard {
+        #[command(subcommand)]
+        action: ClipboardAction,
+    },
+```
+
+- [ ] **Step 2: Add Clipboard handler**
+
+```rust
+        Command::Clipboard { action } => match action {
+            ClipboardAction::Get { save_image } => {
+                match cueward_adapter_macos::clipboard::get(save_image.as_deref()) {
+                    Ok(content) => {
+                        println!("{}", serde_json::to_string_pretty(&content).unwrap());
+                        match content.content_type.as_str() {
+                            "image" => eprintln!("clipboard image saved to {}", content.path.unwrap_or_default()),
+                            _ => eprintln!("clipboard text read"),
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            ClipboardAction::Set { text } => {
+                match cueward_adapter_macos::clipboard::set(&text) {
+                    Ok(()) => eprintln!("copied to clipboard"),
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+        },
+```
+
+- [ ] **Step 3: Verify it compiles and test**
+
+Run: `cd /Users/cyh/Development/cueward && cargo check 2>&1 | tail -5`
+Expected: no errors
+
+Test read: `cd /Users/cyh/Development/cueward && echo "hello" | pbcopy && cargo run -- clipboard get 2>&1`
+Expected: JSON with `type: "text"`, `content: "hello\n"`
+
+Test write: `cd /Users/cyh/Development/cueward && cargo run -- clipboard set "written by cueward" && pbpaste`
+Expected: `written by cueward`
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/cyh/Development/cueward
+git add crates/cli/src/main.rs
+git commit -m "feat(cli): add clipboard subcommand (get/set)"
+```
+
+---
+
+### Task 8: Build, install, and end-to-end test
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Full build**
+
+Run: `cd /Users/cyh/Development/cueward && cargo build --release 2>&1 | tail -5`
+Expected: Compiling... Finished
+
+- [ ] **Step 2: Install**
+
+Run: `cd /Users/cyh/Development/cueward && cargo install --path crates/cli 2>&1 | tail -3`
+Expected: Installing cueward... Installed
+
+- [ ] **Step 3: Test calendar**
+
+Run: `cueward calendar today 2>&1`
+Expected: JSON array of today's events
+
+- [ ] **Step 4: Test screenshot**
+
+Run: `cueward screenshot --ocr 2>&1`
+Expected: JSON with path and ocr_text
+
+- [ ] **Step 5: Test clipboard roundtrip**
+
+Run: `cueward clipboard set "cueward test" && cueward clipboard get 2>&1`
+Expected: JSON with content "cueward test"
+
+- [ ] **Step 6: Verify help output**
+
+Run: `cueward --help 2>&1`
+Expected: calendar, screenshot, clipboard all listed
+
+- [ ] **Step 7: Final commit**
+
+```bash
+cd /Users/cyh/Development/cueward
+git add -A
+git commit -m "build: release build with calendar, screenshot, clipboard"
+```
+
+---
+
+### Task 9: Update Ryugu daemon tools/cueward.ts
+
+**Files:**
+- Modify: `/Users/cyh/Development/Ryugu/daemon/src/tools/cueward.ts`
+- Modify: `/Users/cyh/Development/Ryugu/daemon/src/tools/tools.test.ts`
+
+- [ ] **Step 1: Add new actions to VALID_ACTIONS and subcommand whitelists**
+
+In `cueward.ts`, update `VALID_ACTIONS`:
+
+```typescript
+const VALID_ACTIONS = [
+  "capture", "search", "send", "plan", "ocr",
+  "notes", "quick-notes", "triage",
+  "calendar", "screenshot", "clipboard",
+] as const;
+```
+
+Add subcommand whitelists:
+
+```typescript
+const VALID_CALENDAR_SUBS = ["list", "today", "create", "delete"] as const;
+const VALID_CLIPBOARD_SUBS = ["get", "set"] as const;
+```
+
+- [ ] **Step 2: Add cases to buildCuewardCmd switch**
+
+```typescript
+    case "calendar": {
+      const subcommand = String(args.subcommand ?? "");
+      if (!VALID_CALENDAR_SUBS.includes(subcommand as any)) {
+        throw new Error(`Invalid calendar subcommand: "${subcommand}". Valid: ${VALID_CALENDAR_SUBS.join(", ")}`);
+      }
+      let cmd = `${bin} calendar ${subcommand}`;
+      if (args.from) cmd += ` --from ${escapeArg(String(args.from))}`;
+      if (args.to) cmd += ` --to ${escapeArg(String(args.to))}`;
+      if (args.calendar) cmd += ` --calendar ${escapeArg(String(args.calendar))}`;
+      if (args.title) cmd += ` --title ${escapeArg(String(args.title))}`;
+      if (args.start) cmd += ` --start ${escapeArg(String(args.start))}`;
+      if (args.end) cmd += ` --end ${escapeArg(String(args.end))}`;
+      if (args.notes) cmd += ` --notes ${escapeArg(String(args.notes))}`;
+      if (args.location) cmd += ` --location ${escapeArg(String(args.location))}`;
+      return cmd;
+    }
+
+    case "screenshot": {
+      let cmd = `${bin} screenshot`;
+      if (args.ocr) cmd += ` --ocr`;
+      if (args.output) cmd += ` --output ${escapeArg(String(args.output))}`;
+      return cmd;
+    }
+
+    case "clipboard": {
+      const subcommand = String(args.subcommand ?? "");
+      if (!VALID_CLIPBOARD_SUBS.includes(subcommand as any)) {
+        throw new Error(`Invalid clipboard subcommand: "${subcommand}". Valid: ${VALID_CLIPBOARD_SUBS.join(", ")}`);
+      }
+      let cmd = `${bin} clipboard ${subcommand}`;
+      if (subcommand === "get" && args.save_image) cmd += ` --save-image ${escapeArg(String(args.save_image))}`;
+      if (subcommand === "set" && args.text) cmd += ` ${escapeArg(String(args.text))}`;
+      return cmd;
+    }
+```
+
+- [ ] **Step 3: Add tests**
+
+Add to `tools.test.ts`:
+
+```typescript
+  it("buildCuewardCmd: calendar today", () => {
+    const cmd = buildCuewardCmd("calendar", { subcommand: "today" });
+    assert.equal(cmd, "cueward calendar today");
+  });
+
+  it("buildCuewardCmd: calendar list with range", () => {
+    const cmd = buildCuewardCmd("calendar", { subcommand: "list", from: "2026-04-11 00:00", to: "2026-04-11 23:59" });
+    assert.equal(cmd, 'cueward calendar list --from "2026-04-11 00:00" --to "2026-04-11 23:59"');
+  });
+
+  it("buildCuewardCmd: calendar create", () => {
+    const cmd = buildCuewardCmd("calendar", { subcommand: "create", title: "Meeting", start: "2026-04-11 14:00", end: "2026-04-11 15:00" });
+    assert.equal(cmd, 'cueward calendar create --title "Meeting" --start "2026-04-11 14:00" --end "2026-04-11 15:00"');
+  });
+
+  it("buildCuewardCmd: rejects invalid calendar subcommand", () => {
+    assert.throws(() => buildCuewardCmd("calendar", { subcommand: "drop" }), /Invalid calendar subcommand/);
+  });
+
+  it("buildCuewardCmd: screenshot with ocr", () => {
+    const cmd = buildCuewardCmd("screenshot", { ocr: true });
+    assert.equal(cmd, "cueward screenshot --ocr");
+  });
+
+  it("buildCuewardCmd: screenshot plain", () => {
+    const cmd = buildCuewardCmd("screenshot", {});
+    assert.equal(cmd, "cueward screenshot");
+  });
+
+  it("buildCuewardCmd: clipboard get", () => {
+    const cmd = buildCuewardCmd("clipboard", { subcommand: "get" });
+    assert.equal(cmd, "cueward clipboard get");
+  });
+
+  it("buildCuewardCmd: clipboard set", () => {
+    const cmd = buildCuewardCmd("clipboard", { subcommand: "set", text: "hello" });
+    assert.equal(cmd, 'cueward clipboard set "hello"');
+  });
+
+  it("buildCuewardCmd: rejects invalid clipboard subcommand", () => {
+    assert.throws(() => buildCuewardCmd("clipboard", { subcommand: "watch" }), /Invalid clipboard subcommand/);
+  });
+```
+
+- [ ] **Step 4: Run daemon tests**
+
+Run: `cd /Users/cyh/Development/Ryugu/daemon && npx tsx --test src/tools/tools.test.ts 2>&1 | tail -10`
+Expected: all PASS
+
+Run: `cd /Users/cyh/Development/Ryugu/daemon && npm test 2>&1 | tail -5`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/cyh/Development/Ryugu
+git add daemon/src/tools/cueward.ts daemon/src/tools/tools.test.ts
+git commit -m "feat(tools): add calendar, screenshot, clipboard to cueward wrapper"
+```

--- a/docs/specs/2026-04-11-calendar-screenshot-clipboard.md
+++ b/docs/specs/2026-04-11-calendar-screenshot-clipboard.md
@@ -1,0 +1,174 @@
+# Calendar / Screenshot / Clipboard — 設計規格
+
+**Goal:** 為 cueward 新增三個 macOS 整合功能：日曆讀寫、螢幕截圖（含可選 OCR）、剪貼簿讀寫。
+
+**動機:** Ryugu（AI 助手）需要這三個能力來更好地輔助老闆 — 知道行程判斷何時打擾、主動看螢幕狀態、存取剪貼簿省去手動貼上。
+
+---
+
+## 1. Calendar
+
+### CLI 介面
+
+```
+cueward calendar list [--from <datetime>] [--to <datetime>] [--calendar <name>]
+cueward calendar today
+cueward calendar create --title <TITLE> --start <DATETIME> --end <DATETIME> [--calendar <NAME>] [--notes <NOTES>] [--location <LOCATION>]
+cueward calendar delete --title <TITLE> --start <DATETIME> [--calendar <NAME>]
+```
+
+- `list`：列出時間範圍內的事件。`--from` 預設 now，`--to` 預設 now + 24h。
+- `today`：語法糖，等同 `list --from "today 00:00" --to "today 23:59"`。
+- `create`：建立事件。`--start` / `--end` 接受 ISO 8601（`2026-04-11T14:00:00`）或自然格式（`"2026-04-11 14:00"`）。`--calendar` 預設使用系統預設日曆。
+- `delete`：刪除指定標題 + 開始時間的事件。需要兩者都匹配避免誤刪。
+
+### 輸出格式
+
+**list / today** — JSON array to stdout：
+```json
+[
+  {
+    "title": "週會",
+    "start": "2026-04-11T14:00:00+08:00",
+    "end": "2026-04-11T15:00:00+08:00",
+    "calendar": "Work",
+    "location": "Google Meet",
+    "notes": "",
+    "all_day": false
+  }
+]
+```
+
+**create / delete** — stderr 狀態訊息，無 stdout。
+
+### 實作
+
+- **AppleScript** via `osascript`，跟 notes/plan 同模式。
+- `tell application "Calendar"` 查詢 `every event of every calendar whose start date >= X and start date <= Y`。
+- 全天事件：`all_day: true`，start/end 只取日期。
+- 重複事件：AppleScript 會回傳展開後的實例，不需要特別處理 recurrence rule。
+- 日期解析：CLI 層用 `chrono` 解析，轉成 AppleScript 的 `date "YYYY-MM-DD HH:MM:SS"` 格式。
+
+### 檔案
+
+- `crates/adapter-macos/src/calendar.rs` — 新增
+- `crates/cli/src/main.rs` — 加 `Calendar` subcommand + `CalendarAction` enum
+
+---
+
+## 2. Screenshot
+
+### CLI 介面
+
+```
+cueward screenshot [--ocr] [--output <PATH>]
+```
+
+- 預設截全螢幕，存到 `~/.cueward/cache/screenshots/<timestamp>.png`。
+- `--ocr`：截完後自動跑 Vision OCR，回傳內容含辨識文字。
+- `--output`：指定輸出路徑（覆寫預設位置）。
+
+### 輸出格式
+
+JSON to stdout：
+```json
+{
+  "path": "/Users/cyh/.cueward/cache/screenshots/20260411-143022.png",
+  "timestamp": "2026-04-11T14:30:22+08:00",
+  "ocr_text": "（如果有 --ocr flag）辨識到的文字內容..."
+}
+```
+
+### 實作
+
+- 用 macOS 內建 `screencapture -x <path>`（`-x` 靜音）。
+- 確保 `~/.cueward/cache/screenshots/` 目錄存在。
+- `--ocr` 時呼叫現有的 `ocr.rs` 邏輯（已有 Vision Framework + Swift 腳本）。
+- 不做 Cue 結構包裝（截圖不是 capture 流程的一部分），直接回傳獨立 JSON。
+
+### 檔案
+
+- `crates/adapter-macos/src/screenshot.rs` — 新增
+- `crates/cli/src/main.rs` — 加 `Screenshot` subcommand
+
+---
+
+## 3. Clipboard
+
+### CLI 介面
+
+```
+cueward clipboard get [--save-image <PATH>]
+cueward clipboard set <TEXT>
+```
+
+- `get`：讀取當前剪貼簿。文字直接回傳；如果是圖片，存成 PNG 回傳路徑。`--save-image` 指定圖片存放路徑，預設 `~/.cueward/cache/clipboard/<timestamp>.png`。
+- `set`：寫入文字到剪貼簿。
+
+### 輸出格式
+
+**get** — JSON to stdout：
+```json
+{
+  "type": "text",
+  "content": "剪貼簿裡的文字"
+}
+```
+或圖片時：
+```json
+{
+  "type": "image",
+  "path": "/Users/cyh/.cueward/cache/clipboard/20260411-143022.png"
+}
+```
+
+**set** — stderr 狀態訊息，無 stdout。
+
+### 實作
+
+- **讀取文字**：`pbpaste` 指令。
+- **偵測圖片**：用 AppleScript 檢查剪貼簿類型 — `the clipboard info` 回傳 MIME type list，檢查是否含 `«class PNGf»` 或 `«class TIFF»`。
+- **讀取圖片**：用小段 Swift 腳本（類似 OCR 模式）從 `NSPasteboard.general` 取圖片存成 PNG。或用 `osascript -e 'the clipboard as «class PNGf»'` 寫入檔案。
+- **寫入文字**：`echo "text" | pbcopy`（透過 stdin pipe，避免 shell injection）。
+
+### 檔案
+
+- `crates/adapter-macos/src/clipboard.rs` — 新增
+- `crates/cli/src/main.rs` — 加 `Clipboard` subcommand + `ClipboardAction` enum
+
+---
+
+## 共通事項
+
+### CueSource 擴展
+
+在 `crates/core/src/cue.rs` 加兩個 variant：
+```rust
+pub enum CueSource {
+    Safari, Notes, Messages, Ocr,
+    Calendar,   // 新增
+    Screenshot, // 新增
+    // Clipboard 不需要 — 剪貼簿不進 capture/triage 流程
+}
+```
+
+Clipboard 不加 CueSource，因為它是即時操作，不進 inbox/triage/search 流程。
+Calendar 和 Screenshot 加了以備未來需要（calendar events 可能進 capture 流程）。
+
+### 錯誤處理
+
+跟現有模式一致：
+- 成功：exit 0，資料到 stdout，狀態到 stderr
+- 失敗：exit 1，錯誤到 stderr
+- 權限問題：顯示 Automation 授權指引
+
+### 不做的事
+
+- Calendar 重複事件的 recurrence rule 解析（AppleScript 自動展開實例）
+- Screenshot 截指定 app 視窗（未來可加 `--app` flag）
+- Clipboard 監聽/歷史記錄
+- 這三個功能的 capture → triage → search 整合（先獨立運作，有需要再接）
+
+### daemon 側更新
+
+完成後需要在 Ryugu daemon 的 `tools/cueward.ts` 加對應的 action handler（calendar、screenshot、clipboard），以及更新 `buildCuewardCmd` 的 switch/case。


### PR DESCRIPTION
## Summary

- **Calendar** — AppleScript 讀寫 Apple Calendar（list/today/create/delete）
- **Screenshot** — `screencapture` 截圖 + 可選 Vision OCR + `--display` 多螢幕支援
- **Clipboard** — `pbpaste`/`pbcopy` 讀寫剪貼簿，支援文字和圖片（圖片存 PNG）
- **Docs** — README 更新所有新功能用法、權限說明、架構圖

## New CLI commands

```bash
# Calendar
cueward calendar today
cueward calendar list --from "2026-04-11 09:00" --to "2026-04-11 18:00"
cueward calendar create --title "Meeting" --start "..." --end "..."
cueward calendar delete --title "Meeting" --start "..."

# Screenshot
cueward screenshot [--ocr] [--display 2] [--output path.png]

# Clipboard
cueward clipboard get [--save-image path.png]
cueward clipboard set "text"
```

## New files

- `crates/adapter-macos/src/calendar.rs`
- `crates/adapter-macos/src/screenshot.rs`
- `crates/adapter-macos/src/clipboard.rs`
- `crates/adapter-macos/src/applescript.rs` — added `run_capture()`

## Test plan

- [x] `cargo build --release` passes
- [x] `calendar today` returns JSON array
- [x] `screenshot` captures screen, returns JSON with path
- [x] `screenshot --display 1/2/3` captures correct display
- [x] `clipboard set/get` roundtrip works
- [x] `clipboard get` detects image vs text
- [x] `--help` lists all new subcommands
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


Closes #18, #19, #20