### PR TITLE
[codex] add workspace package metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+.termdock/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,8 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
+license = "MIT"
+repository = "https://github.com/HCYT/cueward"
+homepage = "https://github.com/HCYT/cueward"
+readme = "README.md"
+rust-version = "1.85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ repository = "https://github.com/HCYT/cueward"
 homepage = "https://github.com/HCYT/cueward"
 readme = "README.md"
 rust-version = "1.85"
+
+[workspace.dependencies]
+cueward-core = { version = "0.1.0", path = "crates/core" }
+cueward-adapter-macos = { version = "0.1.0", path = "crates/adapter-macos" }
+cueward-adapter-windows = { version = "0.1.0", path = "crates/adapter-windows" }

--- a/crates/adapter-windows/Cargo.toml
+++ b/crates/adapter-windows/Cargo.toml
@@ -2,6 +2,13 @@
 name = "cueward-adapter-windows"
 version.workspace = true
 edition.workspace = true
+publish = false
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+rust-version.workspace = true
+description = "Reserved Windows adapter crate for future Cueward platform support."
 
 [dependencies]
-cueward-core = { path = "../core" }
+cueward-core = { version = "0.1.0", path = "../core" }

--- a/crates/adapter-windows/Cargo.toml
+++ b/crates/adapter-windows/Cargo.toml
@@ -11,4 +11,4 @@ rust-version.workspace = true
 description = "Reserved Windows adapter crate for future Cueward platform support."
 
 [dependencies]
-cueward-core = { version = "0.1.0", path = "../core" }
+cueward-core = { workspace = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -2,14 +2,20 @@
 name = "cueward-cli"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+rust-version.workspace = true
+description = "CLI for capturing and searching local knowledge from macOS native sources."
 
 [[bin]]
 name = "cueward"
 path = "src/main.rs"
 
 [dependencies]
-cueward-core = { path = "../core" }
-cueward-adapter-macos = { path = "../adapter-macos" }
+cueward-core = { version = "0.1.0", path = "../core" }
+cueward-adapter-macos = { version = "0.1.0", path = "../adapter-macos" }
 clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 serde_json = "1"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,8 +14,8 @@ name = "cueward"
 path = "src/main.rs"
 
 [dependencies]
-cueward-core = { version = "0.1.0", path = "../core" }
-cueward-adapter-macos = { version = "0.1.0", path = "../adapter-macos" }
+cueward-core = { workspace = true }
+cueward-adapter-macos = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 chrono = "0.4"
 serde_json = "1"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -2,6 +2,12 @@
 name = "cueward-core"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+rust-version.workspace = true
+description = "Core types, indexing, and tagging engine for the Cueward knowledge capture toolkit."
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- add shared workspace package metadata such as license, repository, homepage, readme, and rust-version
- wire crate manifests to inherit that metadata from the workspace
- ignore local `.termdock/` artifacts so repo status stays clean

## Validation
- `cargo build`
- `cargo test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
