### PR TITLE
[codex] add safari current tabs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ cueward capture --source safari --since 7d
 cueward capture --source notes --since 3h
 ```
 
+### Safari
+
+Read current Safari tabs, not just browsing history:
+
+```bash
+# List all open tabs
+cueward safari tabs
+
+# Filter by Safari profile name parsed from window title
+cueward safari tabs --profile Ryugu
+
+# Current active tab in the front window
+cueward safari active
+```
+
 Outputs JSON to stdout:
 
 ```json
@@ -274,11 +289,12 @@ mkdir -p ~/.claude/skills/ && cp -r skills/cueward-agent ~/.claude/skills/
 ```
 crates/
 ├── core/            Cue struct, PlatformAdapter trait, BM25 index, auto-tagger
-├── cli/             clap CLI (capture, triage, search, send, plan, reminders, ocr, notes,
-│                    quick-notes, calendar, screenshot, clipboard)
+├── cli/             clap CLI (capture, triage, search, send, plan, reminders, ocr, safari,
+│                    notes, quick-notes, calendar, screenshot, clipboard)
 ├── adapter-macos/   Safari (SQLite), Notes (AppleScript), Messages (SQLite),
-│                    Reminders write/read (AppleScript), Calendar (AppleScript),
-│                    Vision OCR (Swift), Screenshot (screencapture), Clipboard (pbpaste/pbcopy)
+│                    Safari current tabs (AppleScript), Reminders write/read (AppleScript),
+│                    Calendar (AppleScript), Vision OCR (Swift), Screenshot (screencapture),
+│                    Clipboard (pbpaste/pbcopy)
 └── adapter-windows/ Reserved for future cross-platform support
 ```
 

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -1,4 +1,4 @@
-mod safari;
+pub mod safari;
 mod notes;
 mod messages;
 pub mod applescript;

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -87,12 +87,10 @@ fn parse_tab_line(line: &str) -> Option<SafariTab> {
     let title = decode_field(parts[3]);
     let url = decode_field(parts[4]);
     let active = parts[5].trim() == "true";
-    let profile = extract_profile(&window_name, &title);
-
     Some(SafariTab {
         window_id,
         window_name,
-        profile,
+        profile: None,
         index,
         title,
         url,
@@ -101,11 +99,26 @@ fn parse_tab_line(line: &str) -> Option<SafariTab> {
 }
 
 fn parse_tabs_output(stdout: &str) -> Vec<SafariTab> {
-    stdout
+    let mut tabs: Vec<SafariTab> = stdout
         .split(TAB_SEPARATOR)
         .filter(|line| !line.trim().is_empty())
         .filter_map(parse_tab_line)
-        .collect()
+        .collect();
+
+    let mut profiles_by_window = HashMap::new();
+    for tab in &tabs {
+        if tab.active {
+            if let Some(profile) = extract_profile(&tab.window_name, &tab.title) {
+                profiles_by_window.insert(tab.window_id, profile);
+            }
+        }
+    }
+
+    for tab in &mut tabs {
+        tab.profile = profiles_by_window.get(&tab.window_id).cloned();
+    }
+
+    tabs
 }
 
 fn safari_script_prelude() -> String {
@@ -276,7 +289,7 @@ mod tests {
 
         assert_eq!(tab.window_id, 61998);
         assert_eq!(tab.window_name, "Ryugu — Google\tGemini");
-        assert_eq!(tab.profile.as_deref(), Some("Ryugu"));
+        assert_eq!(tab.profile, None);
         assert_eq!(tab.index, 0);
         assert_eq!(tab.title, "Google\tGemini");
         assert_eq!(tab.url, "https://gemini.google.com/app");
@@ -295,6 +308,8 @@ mod tests {
         assert_eq!(tabs.len(), 2);
         assert_eq!(tabs[0].title, "Mail");
         assert_eq!(tabs[1].title, "Docs");
+        assert_eq!(tabs[0].profile.as_deref(), Some("Work"));
+        assert_eq!(tabs[1].profile.as_deref(), Some("Work"));
     }
 
     #[test]

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -3,13 +3,28 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::Connection;
+use serde::Serialize;
 
 use cueward_core::{Cue, CueSource};
 
 use crate::MacosError;
+use crate::applescript::run_capture;
 
 /// Core Data epoch: 2001-01-01 00:00:00 UTC
 const CORE_DATA_EPOCH: i64 = 978_307_200;
+const TAB_SEPARATOR: &str = "---TAB_SEP---";
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct SafariTab {
+    pub window_id: i64,
+    pub window_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    pub index: usize,
+    pub title: String,
+    pub url: String,
+    pub active: bool,
+}
 
 fn history_db_path() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_default();
@@ -24,6 +39,154 @@ fn from_core_data_timestamp(ts: f64) -> DateTime<Utc> {
     Utc.timestamp_opt(ts as i64 + CORE_DATA_EPOCH, 0)
         .single()
         .unwrap_or_default()
+}
+
+fn decode_field(value: &str) -> String {
+    let mut decoded = String::with_capacity(value.len());
+    let mut chars = value.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            decoded.push(ch);
+            continue;
+        }
+
+        match chars.next() {
+            Some('n') => decoded.push('\n'),
+            Some('r') => decoded.push('\r'),
+            Some('t') => decoded.push('\t'),
+            Some('s') => decoded.push_str(TAB_SEPARATOR),
+            Some('\\') => decoded.push('\\'),
+            Some(other) => {
+                decoded.push('\\');
+                decoded.push(other);
+            }
+            None => decoded.push('\\'),
+        }
+    }
+    decoded
+}
+
+fn extract_profile(window_name: &str, tab_title: &str) -> Option<String> {
+    let expected_suffix = format!(" — {tab_title}");
+    window_name
+        .strip_suffix(&expected_suffix)
+        .map(str::trim)
+        .filter(|profile| !profile.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn parse_tab_line(line: &str) -> Option<SafariTab> {
+    let parts: Vec<&str> = line.split('\t').collect();
+    if parts.len() != 6 {
+        return None;
+    }
+
+    let window_id = parts[0].trim().parse().ok()?;
+    let window_name = decode_field(parts[1]);
+    let index: usize = parts[2].trim().parse().ok()?;
+    let title = decode_field(parts[3]);
+    let url = decode_field(parts[4]);
+    let active = parts[5].trim() == "true";
+    let profile = extract_profile(&window_name, &title);
+
+    Some(SafariTab {
+        window_id,
+        window_name,
+        profile,
+        index,
+        title,
+        url,
+        active,
+    })
+}
+
+fn parse_tabs_output(stdout: &str) -> Vec<SafariTab> {
+    stdout
+        .split(TAB_SEPARATOR)
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(parse_tab_line)
+        .collect()
+}
+
+fn safari_script_prelude() -> String {
+    format!(
+        r#"
+        on replace_text(find_text, replace_text, source_text)
+            set previous_delimiters to AppleScript's text item delimiters
+            set AppleScript's text item delimiters to find_text
+            set chunks to every text item of source_text
+            set AppleScript's text item delimiters to replace_text
+            set replaced_text to chunks as text
+            set AppleScript's text item delimiters to previous_delimiters
+            return replaced_text
+        end replace_text
+
+        on encode_field(source_text)
+            if source_text is missing value then
+                return ""
+            end if
+            set escaped_text to my replace_text("\\", "\\\\", source_text)
+            set escaped_text to my replace_text(tab, "\\t", escaped_text)
+            set escaped_text to my replace_text(return, "\\r", escaped_text)
+            set escaped_text to my replace_text(linefeed, "\\n", escaped_text)
+            set escaped_text to my replace_text("{separator}", "\\s", escaped_text)
+            return escaped_text
+        end encode_field
+    "#,
+        separator = TAB_SEPARATOR,
+    )
+}
+
+fn build_tabs_script() -> String {
+    format!(
+        r#"
+        {prelude}
+        tell application "Safari"
+            set output to ""
+            repeat with w in every window
+                set winId to id of w
+                set winName to my encode_field(name of w)
+                set activeTabIndex to index of current tab of w
+                repeat with t in tabs of w
+                    set tabIndex to (index of t) - 1
+                    set tabTitle to my encode_field(name of t)
+                    set tabURL to my encode_field(URL of t)
+                    if (index of t) is activeTabIndex then
+                        set isActive to "true"
+                    else
+                        set isActive to "false"
+                    end if
+                    set output to output & winId & tab & winName & tab & tabIndex & tab & tabTitle & tab & tabURL & tab & isActive & "{separator}"
+                end repeat
+            end repeat
+            return output
+        end tell
+    "#,
+        prelude = safari_script_prelude(),
+        separator = TAB_SEPARATOR,
+    )
+}
+
+fn build_active_tab_script() -> String {
+    format!(
+        r#"
+        {prelude}
+        tell application "Safari"
+            if (count of windows) is 0 then
+                return ""
+            end if
+            set w to front window
+            set t to current tab of w
+            set winId to id of w
+            set winName to my encode_field(name of w)
+            set tabIndex to (index of t) - 1
+            set tabTitle to my encode_field(name of t)
+            set tabURL to my encode_field(URL of t)
+            return winId & tab & winName & tab & tabIndex & tab & tabTitle & tab & tabURL & tab & "true"
+        end tell
+    "#,
+        prelude = safari_script_prelude(),
+    )
 }
 
 pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
@@ -78,4 +241,67 @@ pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
         .collect();
 
     Ok(cues)
+}
+
+pub fn tabs(profile_filter: Option<&str>) -> Result<Vec<SafariTab>, MacosError> {
+    let stdout = run_capture(&build_tabs_script(), "safari_tabs")?;
+    let mut tabs = parse_tabs_output(&stdout);
+    if let Some(profile) = profile_filter {
+        tabs.retain(|tab| tab.profile.as_deref() == Some(profile));
+    }
+    Ok(tabs)
+}
+
+pub fn active() -> Result<Option<SafariTab>, MacosError> {
+    let stdout = run_capture(&build_active_tab_script(), "safari_active")?;
+    Ok(parse_tab_line(stdout.trim()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_tabs_script, extract_profile, parse_tab_line, parse_tabs_output, TAB_SEPARATOR};
+
+    #[test]
+    fn extract_profile_from_window_name() {
+        let profile = extract_profile("Ryugu — Google Gemini", "Google Gemini");
+
+        assert_eq!(profile.as_deref(), Some("Ryugu"));
+    }
+
+    #[test]
+    fn parse_tab_line_decodes_fields() {
+        let line = "61998\tRyugu — Google\\tGemini\t0\tGoogle\\tGemini\thttps://gemini.google.com/app\ttrue";
+
+        let tab = parse_tab_line(line).expect("tab");
+
+        assert_eq!(tab.window_id, 61998);
+        assert_eq!(tab.window_name, "Ryugu — Google\tGemini");
+        assert_eq!(tab.profile.as_deref(), Some("Ryugu"));
+        assert_eq!(tab.index, 0);
+        assert_eq!(tab.title, "Google\tGemini");
+        assert_eq!(tab.url, "https://gemini.google.com/app");
+        assert!(tab.active);
+    }
+
+    #[test]
+    fn parse_tabs_output_keeps_multiple_tabs() {
+        let raw = concat!(
+            "1\tWork — Mail\t0\tMail\thttps://mail.google.com\ttrue---TAB_SEP---",
+            "1\tWork — Docs\t1\tDocs\thttps://docs.google.com\tfalse---TAB_SEP---"
+        );
+
+        let tabs = parse_tabs_output(raw);
+
+        assert_eq!(tabs.len(), 2);
+        assert_eq!(tabs[0].title, "Mail");
+        assert_eq!(tabs[1].title, "Docs");
+    }
+
+    #[test]
+    fn safari_script_escapes_record_separator() {
+        let script = build_tabs_script();
+
+        assert!(script.contains(TAB_SEPARATOR));
+        assert!(script.contains("\\s"));
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -88,6 +88,12 @@ enum Command {
         path: String,
     },
 
+    /// Read current Safari tabs and active tab
+    Safari {
+        #[command(subcommand)]
+        action: SafariAction,
+    },
+
     /// Manage Apple Notes (update, delete, move)
     Notes {
         #[command(subcommand)]
@@ -186,6 +192,19 @@ enum NotesAction {
         #[arg(long)]
         to: String,
     },
+}
+
+#[derive(Subcommand)]
+enum SafariAction {
+    /// List all current Safari tabs
+    Tabs {
+        /// Filter by Safari profile name parsed from window title
+        #[arg(long)]
+        profile: Option<String>,
+    },
+
+    /// Show the current active tab in the front Safari window
+    Active,
 }
 
 #[derive(Subcommand)]
@@ -642,6 +661,33 @@ fn main() {
                 eprintln!("error: {e}");
                 process::exit(1);
             }
+        },
+
+        Command::Safari { action } => match action {
+            SafariAction::Tabs { profile } => match cueward_adapter_macos::safari::tabs(profile.as_deref()) {
+                Ok(tabs) => {
+                    println!("{}", serde_json::to_string_pretty(&tabs).unwrap());
+                    eprintln!("{} tab(s)", tabs.len());
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
+                }
+            },
+            SafariAction::Active => match cueward_adapter_macos::safari::active() {
+                Ok(tab) => {
+                    println!("{}", serde_json::to_string_pretty(&tab).unwrap());
+                    if tab.is_some() {
+                        eprintln!("active tab");
+                    } else {
+                        eprintln!("no Safari window");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    process::exit(1);
+                }
+            },
         },
 
         Command::Notes { action } => match action {


### PR DESCRIPTION
## Summary
- add Safari AppleScript support for reading current tabs across all windows
- add `cueward safari tabs` and `cueward safari active` CLI commands, including optional profile filtering
- document the new Safari tab-reading commands in the README

## Validation
- `cargo test -p cueward-adapter-macos safari -- --nocapture`
- `cargo test`

Closes #22
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
