### PR TITLE
[codex] add Safari Gemini workflows

### DIFF
--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -414,22 +414,39 @@ fn selector_fill_js(selector: &str, text: &str) -> String {
     )
 }
 
-fn gemini_mode_label(mode: GeminiMode) -> &'static str {
+fn gemini_mode_labels(mode: GeminiMode) -> &'static [&'static str] {
     match mode {
-        GeminiMode::Image => "建立圖像",
-        GeminiMode::DeepResearch => "Deep Research",
-        GeminiMode::Video => "建立影片",
-        GeminiMode::Music => "創作音樂",
+        GeminiMode::Image => &["建立圖像", "Create image", "Create Image"],
+        GeminiMode::DeepResearch => &["Deep Research"],
+        GeminiMode::Video => &["建立影片", "Create video", "Create Video"],
+        GeminiMode::Music => &["創作音樂", "Create music", "Create Music"],
     }
 }
 
-fn gemini_mode_placeholder(mode: GeminiMode) -> &'static str {
+fn gemini_mode_placeholders(mode: GeminiMode) -> &'static [&'static str] {
     match mode {
-        GeminiMode::Image => "請輸入圖片說明",
-        GeminiMode::DeepResearch => "你想研究什麼？",
-        GeminiMode::Video => "描述影片",
-        GeminiMode::Music => "描述音樂",
+        GeminiMode::Image => &[
+            "請輸入圖片說明",
+            "Describe the image",
+            "Describe the image you want to create",
+        ],
+        GeminiMode::DeepResearch => &["你想研究什麼？", "What do you want to research?"],
+        GeminiMode::Video => &["描述影片", "Describe the video"],
+        GeminiMode::Music => &["描述音樂", "Describe the music"],
     }
+}
+
+fn js_string_array(values: &[&str]) -> String {
+    let escaped = values
+        .iter()
+        .map(|value| format!("\"{}\"", escape_js_string(value)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{escaped}]")
+}
+
+fn should_skip_gemini_response(trimmed: &str, prompt: &str) -> bool {
+    trimmed.is_empty() || trimmed == prompt.trim()
 }
 
 fn gemini_mode_slug(mode: GeminiMode) -> &'static str {
@@ -442,12 +459,12 @@ fn gemini_mode_slug(mode: GeminiMode) -> &'static str {
 }
 
 fn build_gemini_mode_switch_js(mode: GeminiMode) -> String {
-    let mode_label = escape_js_string(gemini_mode_label(mode));
-    let expected_placeholder = escape_js_string(gemini_mode_placeholder(mode));
+    let mode_labels = js_string_array(gemini_mode_labels(mode));
+    let expected_placeholders = js_string_array(gemini_mode_placeholders(mode));
     format!(
         r#"(() => {{
-            const modeLabel = "{mode_label}";
-            const expectedPlaceholder = "{expected_placeholder}";
+            const modeLabels = {mode_labels};
+            const expectedPlaceholders = {expected_placeholders};
             const clickableSelector = [
               "button",
               "[role='button']",
@@ -472,8 +489,8 @@ fn build_gemini_mode_switch_js(mode: GeminiMode) -> String {
             }};
 
             clickByText(["工具", "Tools", "模式", "Mode"]);
-            if (!clickByText([modeLabel])) {{
-              throw new Error(`gemini mode not found: ${{modeLabel}}`);
+            if (!clickByText(modeLabels)) {{
+              throw new Error(`gemini mode not found: ${{modeLabels.join(", ")}}`);
             }}
 
             const input = document.querySelector(
@@ -489,11 +506,11 @@ fn build_gemini_mode_switch_js(mode: GeminiMode) -> String {
               input.getAttribute("aria-label") ||
               ""
             );
-            if (!placeholder.includes(expectedPlaceholder)) {{
+            if (!expectedPlaceholders.some((value) => placeholder.includes(value))) {{
               throw new Error(`placeholder mismatch: ${{placeholder}}`);
             }}
 
-            return expectedPlaceholder;
+            return placeholder;
         }})()"#
     )
 }
@@ -707,8 +724,10 @@ pub fn wait(selector: &str, timeout_seconds: u64) -> Result<SafariWaitResult, Ma
 
 pub fn prepare_gemini_mode(mode: GeminiMode) -> Result<SafariAiReadyResult, MacosError> {
     let placeholder = execute_js(&build_gemini_mode_switch_js(mode), "safari_gemini_mode")?;
-    let expected_placeholder = gemini_mode_placeholder(mode);
-    if !placeholder.contains(expected_placeholder) {
+    if !gemini_mode_placeholders(mode)
+        .iter()
+        .any(|value| placeholder.contains(value))
+    {
         return Err(MacosError::Other(format!(
             "unexpected Gemini placeholder after mode switch: {placeholder}"
         )));
@@ -738,7 +757,7 @@ pub fn send_gemini_prompt(prompt: &str) -> Result<SafariAiResponseResult, MacosE
         thread::sleep(Duration::from_secs(1));
         let text = execute_js(&response_js, "safari_gemini_response")?;
         let trimmed = text.trim();
-        if trimmed.is_empty() || trimmed == prompt {
+        if should_skip_gemini_response(trimmed, prompt) {
             continue;
         }
 
@@ -760,7 +779,7 @@ pub fn send_gemini_prompt(prompt: &str) -> Result<SafariAiResponseResult, MacosE
     if !last_text.is_empty() {
         return Ok(SafariAiResponseResult {
             provider: "gemini".to_string(),
-            status: "complete".to_string(),
+            status: "timeout".to_string(),
             response: last_text,
         });
     }
@@ -782,6 +801,7 @@ mod tests {
         build_gemini_chat_prompt_js, build_gemini_mode_switch_js, build_open_script,
         build_tabs_script, extract_profile, gemini_response_extract_js, parse_tab_line,
         parse_tabs_output, selector_click_js, selector_fill_js, selector_text_js,
+        should_skip_gemini_response,
     };
 
     #[test]
@@ -877,6 +897,7 @@ mod tests {
         let script = build_gemini_mode_switch_js(GeminiMode::DeepResearch);
 
         assert!(script.contains("Deep Research"));
+        assert!(script.contains("What do you want to research?"));
         assert!(script.contains("你想研究什麼？"));
         assert!(script.contains("document.querySelector"));
     }
@@ -897,5 +918,11 @@ mod tests {
         assert!(script.contains(".model-response-text"));
         assert!(script.contains("querySelectorAll"));
         assert!(script.contains("elements[elements.length - 1]"));
+    }
+
+    #[test]
+    fn should_skip_gemini_response_trims_prompt_whitespace() {
+        assert!(should_skip_gemini_response("hello", "  hello  "));
+        assert!(!should_skip_gemini_response("world", "  hello  "));
     }
 }

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -72,6 +72,28 @@ pub struct SafariWaitResult {
     pub timeout_seconds: u64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GeminiMode {
+    Image,
+    DeepResearch,
+    Video,
+    Music,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct SafariAiReadyResult {
+    pub provider: String,
+    pub mode: String,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct SafariAiResponseResult {
+    pub provider: String,
+    pub status: String,
+    pub response: String,
+}
+
 fn history_db_path() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_default();
     PathBuf::from(home).join("Library/Safari/History.db")
@@ -392,6 +414,139 @@ fn selector_fill_js(selector: &str, text: &str) -> String {
     )
 }
 
+fn gemini_mode_label(mode: GeminiMode) -> &'static str {
+    match mode {
+        GeminiMode::Image => "建立圖像",
+        GeminiMode::DeepResearch => "Deep Research",
+        GeminiMode::Video => "建立影片",
+        GeminiMode::Music => "創作音樂",
+    }
+}
+
+fn gemini_mode_placeholder(mode: GeminiMode) -> &'static str {
+    match mode {
+        GeminiMode::Image => "請輸入圖片說明",
+        GeminiMode::DeepResearch => "你想研究什麼？",
+        GeminiMode::Video => "描述影片",
+        GeminiMode::Music => "描述音樂",
+    }
+}
+
+fn gemini_mode_slug(mode: GeminiMode) -> &'static str {
+    match mode {
+        GeminiMode::Image => "image",
+        GeminiMode::DeepResearch => "deep-research",
+        GeminiMode::Video => "video",
+        GeminiMode::Music => "music",
+    }
+}
+
+fn build_gemini_mode_switch_js(mode: GeminiMode) -> String {
+    let mode_label = escape_js_string(gemini_mode_label(mode));
+    let expected_placeholder = escape_js_string(gemini_mode_placeholder(mode));
+    format!(
+        r#"(() => {{
+            const modeLabel = "{mode_label}";
+            const expectedPlaceholder = "{expected_placeholder}";
+            const clickableSelector = [
+              "button",
+              "[role='button']",
+              "[role='option']",
+              "mat-option",
+              "li",
+              "span"
+            ].join(",");
+            const normalize = (value) => (value ?? "").replace(/\s+/g, " ").trim();
+            const clickByText = (labels) => {{
+              const wanted = labels.map(normalize).filter(Boolean);
+              const nodes = [...document.querySelectorAll(clickableSelector)];
+              for (const node of nodes) {{
+                const text = normalize(node.innerText || node.textContent);
+                if (!text) continue;
+                if (!wanted.some((label) => text.includes(label))) continue;
+                const clickable = node.closest("button,[role='button'],[role='option'],mat-option,li") || node;
+                clickable.click();
+                return true;
+              }}
+              return false;
+            }};
+
+            clickByText(["工具", "Tools", "模式", "Mode"]);
+            if (!clickByText([modeLabel])) {{
+              throw new Error(`gemini mode not found: ${{modeLabel}}`);
+            }}
+
+            const input = document.querySelector(
+              ".ql-editor, rich-textarea .ProseMirror, div[role='textbox'][contenteditable='true'], div[contenteditable='true']"
+            );
+            if (!input) {{
+              throw new Error("gemini input not found after mode switch");
+            }}
+
+            const placeholder = normalize(
+              input.getAttribute("data-placeholder") ||
+              input.getAttribute("placeholder") ||
+              input.getAttribute("aria-label") ||
+              ""
+            );
+            if (!placeholder.includes(expectedPlaceholder)) {{
+              throw new Error(`placeholder mismatch: ${{placeholder}}`);
+            }}
+
+            return expectedPlaceholder;
+        }})()"#
+    )
+}
+
+fn build_gemini_chat_prompt_js(prompt: &str) -> String {
+    let prompt = escape_js_string(prompt);
+    format!(
+        r#"(() => {{
+            const promptText = "{prompt}";
+            const input = document.querySelector(
+              ".ql-editor, rich-textarea .ProseMirror, div[role='textbox'][contenteditable='true'], div[contenteditable='true']"
+            );
+            if (!input) {{
+              throw new Error("gemini input not found");
+            }}
+
+            input.focus();
+            if ("value" in input) {{
+              input.value = promptText;
+            }} else {{
+              input.textContent = promptText;
+            }}
+            input.dispatchEvent(new Event("input", {{ bubbles: true }}));
+            input.dispatchEvent(new Event("change", {{ bubbles: true }}));
+
+            input.dispatchEvent(new KeyboardEvent("keydown", {{ key: "Enter", bubbles: true }}));
+            input.dispatchEvent(new KeyboardEvent("keypress", {{ key: "Enter", bubbles: true }}));
+            input.dispatchEvent(new KeyboardEvent("keyup", {{ key: "Enter", bubbles: true }}));
+            return "true";
+        }})()"#
+    )
+}
+
+fn gemini_response_extract_js() -> String {
+    r#"(() => {
+        const selectors = [
+          ".model-response-text",
+          ".message-content",
+          ".markdown",
+          "div[data-test-id='message-content']"
+        ];
+        for (const selector of selectors) {
+          const elements = document.querySelectorAll(selector);
+          if (!elements.length) continue;
+          const last = elements[elements.length - 1];
+          const text = (last.innerText || last.textContent || "").trim();
+          if (text) return text;
+        }
+        return "";
+    })()"#
+        .to_string()
+}
+
 pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
     let db_path = history_db_path();
 
@@ -550,6 +705,71 @@ pub fn wait(selector: &str, timeout_seconds: u64) -> Result<SafariWaitResult, Ma
     }
 }
 
+pub fn prepare_gemini_mode(mode: GeminiMode) -> Result<SafariAiReadyResult, MacosError> {
+    let placeholder = execute_js(&build_gemini_mode_switch_js(mode), "safari_gemini_mode")?;
+    let expected_placeholder = gemini_mode_placeholder(mode);
+    if !placeholder.contains(expected_placeholder) {
+        return Err(MacosError::Other(format!(
+            "unexpected Gemini placeholder after mode switch: {placeholder}"
+        )));
+    }
+
+    Ok(SafariAiReadyResult {
+        provider: "gemini".to_string(),
+        mode: gemini_mode_slug(mode).to_string(),
+        status: "ready".to_string(),
+    })
+}
+
+pub fn send_gemini_prompt(prompt: &str) -> Result<SafariAiResponseResult, MacosError> {
+    let sent = execute_js(&build_gemini_chat_prompt_js(prompt), "safari_gemini_prompt")?;
+    if sent.trim() != "true" {
+        return Err(MacosError::Other(format!(
+            "failed to trigger Gemini prompt submission: {sent}"
+        )));
+    }
+
+    let mut last_text = String::new();
+    let mut stable_count = 0;
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let response_js = gemini_response_extract_js();
+
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_secs(1));
+        let text = execute_js(&response_js, "safari_gemini_response")?;
+        let trimmed = text.trim();
+        if trimmed.is_empty() || trimmed == prompt {
+            continue;
+        }
+
+        if trimmed == last_text {
+            stable_count += 1;
+            if stable_count >= 2 {
+                return Ok(SafariAiResponseResult {
+                    provider: "gemini".to_string(),
+                    status: "complete".to_string(),
+                    response: trimmed.to_string(),
+                });
+            }
+        } else {
+            last_text = trimmed.to_string();
+            stable_count = 0;
+        }
+    }
+
+    if !last_text.is_empty() {
+        return Ok(SafariAiResponseResult {
+            provider: "gemini".to_string(),
+            status: "complete".to_string(),
+            response: last_text,
+        });
+    }
+
+    Err(MacosError::Other(
+        "timeout waiting for Gemini response".to_string(),
+    ))
+}
+
 fn execute_js(js_code: &str, context: &str) -> Result<String, MacosError> {
     let stdout = run_capture(&build_exec_script(js_code), context)?;
     Ok(decode_field(stdout.trim()))
@@ -558,9 +778,10 @@ fn execute_js(js_code: &str, context: &str) -> Result<String, MacosError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        TAB_SEPARATOR, build_active_tab_script, build_close_script, build_exec_script,
-        build_open_script, build_tabs_script, extract_profile, parse_tab_line, parse_tabs_output,
-        selector_click_js, selector_fill_js, selector_text_js,
+        GeminiMode, TAB_SEPARATOR, build_active_tab_script, build_close_script, build_exec_script,
+        build_gemini_chat_prompt_js, build_gemini_mode_switch_js, build_open_script,
+        build_tabs_script, extract_profile, gemini_response_extract_js, parse_tab_line,
+        parse_tabs_output, selector_click_js, selector_fill_js, selector_text_js,
     };
 
     #[test]
@@ -572,8 +793,7 @@ mod tests {
 
     #[test]
     fn parse_tab_line_decodes_fields() {
-        let line =
-            "61998\tRyugu — Google\\tGemini\t0\tGoogle\\tGemini\thttps://gemini.google.com/app\ttrue";
+        let line = "61998\tRyugu — Google\\tGemini\t0\tGoogle\\tGemini\thttps://gemini.google.com/app\ttrue";
 
         let tab = parse_tab_line(line).expect("tab");
 
@@ -650,5 +870,32 @@ mod tests {
         let fill = selector_fill_js("input[name=q]", "hello");
         assert!(fill.contains("input[name=q]"));
         assert!(fill.contains("hello"));
+    }
+
+    #[test]
+    fn gemini_mode_switch_script_targets_requested_mode() {
+        let script = build_gemini_mode_switch_js(GeminiMode::DeepResearch);
+
+        assert!(script.contains("Deep Research"));
+        assert!(script.contains("你想研究什麼？"));
+        assert!(script.contains("document.querySelector"));
+    }
+
+    #[test]
+    fn gemini_chat_prompt_script_targets_editor_and_send() {
+        let script = build_gemini_chat_prompt_js("hello world");
+
+        assert!(script.contains(".ql-editor"));
+        assert!(script.contains("hello world"));
+        assert!(script.contains("KeyboardEvent"));
+    }
+
+    #[test]
+    fn gemini_response_extract_script_targets_latest_response() {
+        let script = gemini_response_extract_js();
+
+        assert!(script.contains(".model-response-text"));
+        assert!(script.contains("querySelectorAll"));
+        assert!(script.contains("elements[elements.length - 1]"));
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -194,6 +194,20 @@ enum NotesAction {
     },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum SafariAiProvider {
+    Gemini,
+    Chatgpt,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum GeminiMode {
+    Image,
+    DeepResearch,
+    Video,
+    Music,
+}
+
 #[derive(Subcommand)]
 enum SafariAction {
     /// List all current Safari tabs
@@ -256,6 +270,19 @@ enum SafariAction {
         /// Timeout in seconds
         #[arg(long, default_value = "30")]
         timeout: u64,
+    },
+
+    /// Run a high-level Safari AI workflow
+    Ai {
+        /// AI provider to target
+        #[arg(long)]
+        provider: SafariAiProvider,
+        /// Optional Gemini mode to switch into before interaction
+        #[arg(long)]
+        mode: Option<GeminiMode>,
+        /// Prompt to send in a later workflow stage
+        #[arg(long)]
+        prompt: Option<String>,
     },
 }
 
@@ -489,6 +516,15 @@ fn source_name(src: &Source) -> &'static str {
     }
 }
 
+fn to_adapter_gemini_mode(mode: GeminiMode) -> cueward_adapter_macos::safari::GeminiMode {
+    match mode {
+        GeminiMode::Image => cueward_adapter_macos::safari::GeminiMode::Image,
+        GeminiMode::DeepResearch => cueward_adapter_macos::safari::GeminiMode::DeepResearch,
+        GeminiMode::Video => cueward_adapter_macos::safari::GeminiMode::Video,
+        GeminiMode::Music => cueward_adapter_macos::safari::GeminiMode::Music,
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -716,16 +752,18 @@ fn main() {
         },
 
         Command::Safari { action } => match action {
-            SafariAction::Tabs { profile } => match cueward_adapter_macos::safari::tabs(profile.as_deref()) {
-                Ok(tabs) => {
-                    println!("{}", serde_json::to_string_pretty(&tabs).unwrap());
-                    eprintln!("{} tab(s)", tabs.len());
+            SafariAction::Tabs { profile } => {
+                match cueward_adapter_macos::safari::tabs(profile.as_deref()) {
+                    Ok(tabs) => {
+                        println!("{}", serde_json::to_string_pretty(&tabs).unwrap());
+                        eprintln!("{} tab(s)", tabs.len());
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
-                }
-            },
+            }
             SafariAction::Active => match cueward_adapter_macos::safari::active() {
                 Ok(tab) => {
                     println!("{}", serde_json::to_string_pretty(&tab).unwrap());
@@ -768,16 +806,18 @@ fn main() {
                     process::exit(1);
                 }
             },
-            SafariAction::Read { selector } => match cueward_adapter_macos::safari::read(selector.as_deref()) {
-                Ok(result) => {
-                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                    eprintln!("read page content");
+            SafariAction::Read { selector } => {
+                match cueward_adapter_macos::safari::read(selector.as_deref()) {
+                    Ok(result) => {
+                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("read page content");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
-                }
-            },
+            }
             SafariAction::Source => match cueward_adapter_macos::safari::source() {
                 Ok(result) => {
                     println!("{}", serde_json::to_string_pretty(&result).unwrap());
@@ -798,33 +838,81 @@ fn main() {
                     process::exit(1);
                 }
             },
-            SafariAction::Click { selector } => match cueward_adapter_macos::safari::click(&selector) {
-                Ok(result) => {
-                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                    eprintln!("clicked element");
+            SafariAction::Click { selector } => {
+                match cueward_adapter_macos::safari::click(&selector) {
+                    Ok(result) => {
+                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("clicked element");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
+            }
+            SafariAction::Fill { selector, text } => {
+                match cueward_adapter_macos::safari::fill(&selector, &text) {
+                    Ok(result) => {
+                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("filled element");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
                 }
-            },
-            SafariAction::Fill { selector, text } => match cueward_adapter_macos::safari::fill(&selector, &text) {
-                Ok(result) => {
-                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                    eprintln!("filled element");
+            }
+            SafariAction::Wait { selector, timeout } => {
+                match cueward_adapter_macos::safari::wait(&selector, timeout) {
+                    Ok(result) => {
+                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("selector found");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
+            }
+            SafariAction::Ai {
+                provider,
+                mode,
+                prompt,
+            } => match provider {
+                SafariAiProvider::Gemini => {
+                    if let Some(mode) = mode {
+                        match cueward_adapter_macos::safari::prepare_gemini_mode(
+                            to_adapter_gemini_mode(mode),
+                        ) {
+                            Ok(result) => {
+                                println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                                eprintln!("gemini mode ready");
+                            }
+                            Err(e) => {
+                                eprintln!("error: {e}");
+                                process::exit(1);
+                            }
+                        }
+                    } else {
+                        let Some(prompt) = prompt.as_deref() else {
+                            eprintln!("error: --prompt is required for Gemini chat workflow");
+                            process::exit(1);
+                        };
+
+                        match cueward_adapter_macos::safari::send_gemini_prompt(prompt) {
+                            Ok(result) => {
+                                println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                                eprintln!("gemini response ready");
+                            }
+                            Err(e) => {
+                                eprintln!("error: {e}");
+                                process::exit(1);
+                            }
+                        }
+                    }
                 }
-            },
-            SafariAction::Wait { selector, timeout } => match cueward_adapter_macos::safari::wait(&selector, timeout) {
-                Ok(result) => {
-                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                    eprintln!("selector found");
-                }
-                Err(e) => {
-                    eprintln!("error: {e}");
+                SafariAiProvider::Chatgpt => {
+                    eprintln!("error: ChatGPT Safari AI workflow not implemented yet");
                     process::exit(1);
                 }
             },
@@ -1097,8 +1185,12 @@ fn main() {
 mod tests {
     use chrono::Timelike;
     use chrono::{Local, TimeZone};
+    use clap::Parser;
 
-    use super::{local_day_bounds, validate_optional_output_path};
+    use super::{
+        Cli, Command, GeminiMode, SafariAction, SafariAiProvider, local_day_bounds,
+        validate_optional_output_path,
+    };
 
     #[test]
     fn validate_optional_output_path_rejects_parent_components() {
@@ -1132,5 +1224,67 @@ mod tests {
         let parsed = super::parse_datetime("2026-11-01 01:30");
 
         assert!(parsed.is_some());
+    }
+
+    #[test]
+    fn cli_parses_gemini_mode_switch_command() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "gemini",
+            "--mode",
+            "deep-research",
+            "--prompt",
+            "研究議題",
+        ])
+        .expect("parse safari ai command");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        mode,
+                        prompt,
+                    },
+            } => {
+                assert_eq!(provider, SafariAiProvider::Gemini);
+                assert_eq!(mode, Some(GeminiMode::DeepResearch));
+                assert_eq!(prompt, Some("研究議題".to_string()));
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_gemini_chat_command() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "gemini",
+            "--prompt",
+            "哈囉",
+        ])
+        .expect("parse gemini chat command");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        mode,
+                        prompt,
+                    },
+            } => {
+                assert_eq!(provider, SafariAiProvider::Gemini);
+                assert_eq!(mode, None);
+                assert_eq!(prompt, Some("哈囉".to_string()));
+            }
+            _ => panic!("unexpected command"),
+        }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -525,6 +525,25 @@ fn to_adapter_gemini_mode(mode: GeminiMode) -> cueward_adapter_macos::safari::Ge
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum GeminiAiAction {
+    ModeOnly(GeminiMode),
+    PromptOnly(String),
+    ModeThenPrompt(GeminiMode, String),
+}
+
+fn build_gemini_ai_action(
+    mode: Option<GeminiMode>,
+    prompt: Option<&str>,
+) -> Result<GeminiAiAction, &'static str> {
+    match (mode, prompt) {
+        (Some(mode), Some(prompt)) => Ok(GeminiAiAction::ModeThenPrompt(mode, prompt.to_string())),
+        (Some(mode), None) => Ok(GeminiAiAction::ModeOnly(mode)),
+        (None, Some(prompt)) => Ok(GeminiAiAction::PromptOnly(prompt.to_string())),
+        (None, None) => Err("--mode or --prompt is required for Gemini Safari AI workflow"),
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -880,33 +899,58 @@ fn main() {
                 prompt,
             } => match provider {
                 SafariAiProvider::Gemini => {
-                    if let Some(mode) = mode {
-                        match cueward_adapter_macos::safari::prepare_gemini_mode(
-                            to_adapter_gemini_mode(mode),
-                        ) {
-                            Ok(result) => {
-                                println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                                eprintln!("gemini mode ready");
-                            }
-                            Err(e) => {
-                                eprintln!("error: {e}");
-                                process::exit(1);
+                    let action = match build_gemini_ai_action(mode, prompt.as_deref()) {
+                        Ok(action) => action,
+                        Err(err) => {
+                            eprintln!("error: {err}");
+                            process::exit(1);
+                        }
+                    };
+
+                    match action {
+                        GeminiAiAction::ModeOnly(mode) => {
+                            match cueward_adapter_macos::safari::prepare_gemini_mode(
+                                to_adapter_gemini_mode(mode),
+                            ) {
+                                Ok(result) => {
+                                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                                    eprintln!("gemini mode ready");
+                                }
+                                Err(e) => {
+                                    eprintln!("error: {e}");
+                                    process::exit(1);
+                                }
                             }
                         }
-                    } else {
-                        let Some(prompt) = prompt.as_deref() else {
-                            eprintln!("error: --prompt is required for Gemini chat workflow");
-                            process::exit(1);
-                        };
-
-                        match cueward_adapter_macos::safari::send_gemini_prompt(prompt) {
-                            Ok(result) => {
-                                println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                                eprintln!("gemini response ready");
+                        GeminiAiAction::PromptOnly(prompt) => {
+                            match cueward_adapter_macos::safari::send_gemini_prompt(&prompt) {
+                                Ok(result) => {
+                                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                                    eprintln!("gemini response ready");
+                                }
+                                Err(e) => {
+                                    eprintln!("error: {e}");
+                                    process::exit(1);
+                                }
                             }
-                            Err(e) => {
+                        }
+                        GeminiAiAction::ModeThenPrompt(mode, prompt) => {
+                            if let Err(e) = cueward_adapter_macos::safari::prepare_gemini_mode(
+                                to_adapter_gemini_mode(mode),
+                            ) {
                                 eprintln!("error: {e}");
                                 process::exit(1);
+                            }
+
+                            match cueward_adapter_macos::safari::send_gemini_prompt(&prompt) {
+                                Ok(result) => {
+                                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                                    eprintln!("gemini response ready");
+                                }
+                                Err(e) => {
+                                    eprintln!("error: {e}");
+                                    process::exit(1);
+                                }
                             }
                         }
                     }
@@ -1188,8 +1232,8 @@ mod tests {
     use clap::Parser;
 
     use super::{
-        Cli, Command, GeminiMode, SafariAction, SafariAiProvider, local_day_bounds,
-        validate_optional_output_path,
+        Cli, Command, GeminiAiAction, GeminiMode, SafariAction, SafariAiProvider,
+        build_gemini_ai_action, local_day_bounds, validate_optional_output_path,
     };
 
     #[test]
@@ -1286,5 +1330,21 @@ mod tests {
             }
             _ => panic!("unexpected command"),
         }
+    }
+
+    #[test]
+    fn build_gemini_ai_action_allows_mode_and_prompt_together() {
+        assert_eq!(
+            build_gemini_ai_action(Some(GeminiMode::DeepResearch), Some("研究主題")).unwrap(),
+            GeminiAiAction::ModeThenPrompt(GeminiMode::DeepResearch, "研究主題".to_string())
+        );
+    }
+
+    #[test]
+    fn build_gemini_ai_action_requires_mode_or_prompt() {
+        assert_eq!(
+            build_gemini_ai_action(None, None),
+            Err("--mode or --prompt is required for Gemini Safari AI workflow")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add `cueward safari ai` command shape for provider-based Safari AI workflows
- implement Gemini mode switching with ready-state JSON output
- implement Gemini default chat prompt/response workflow on top of Safari primitives

## Issues
- Closes #33
- Closes #37

## Validation
- `cargo test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
