### PR TITLE
feat: Safari AI provider automation (Gemini)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,44 @@ cueward safari fill "textarea" "hello from cueward"
 cueward safari wait ".result" --timeout 30
 ```
 
+### Safari AI
+
+Control web-based AI providers (Gemini, ChatGPT) via Safari automation. Uses URL navigation and `execCommand` — no fragile DOM clicking, no focus stealing.
+
+```bash
+# Send a prompt (general chat)
+cueward safari ai --provider gemini prompt --prompt "explain quantum computing"
+
+# Switch to a specific mode first
+cueward safari ai --provider gemini prompt --prompt "a cat on a keyboard" --mode image
+
+# Deep Research with auto-confirm
+cueward safari ai --provider gemini prompt --prompt "台灣 AI 產業分析" --mode deep-research --auto-confirm
+
+# Switch mode only (no prompt)
+cueward safari ai --provider gemini mode deep-research
+
+# List conversations from sidebar
+cueward safari ai --provider gemini list
+
+# Read a conversation's text content (reports, chat history)
+cueward safari ai --provider gemini read https://gemini.google.com/app/abc123
+
+# Poll an in-progress Deep Research
+cueward safari ai --provider gemini poll --timeout 300
+
+# Save AI-generated images as PNG
+cueward safari ai --provider gemini save-images https://gemini.google.com/app/abc123 --output ~/Downloads
+
+# Download video/music via browser (triggers Safari native download)
+cueward safari ai --provider gemini save-media https://gemini.google.com/app/abc123
+
+# Use a specific Safari profile
+cueward safari ai --provider gemini --profile Ryugu list
+```
+
+Supported Gemini modes: `deep-research`, `image`, `video`, `music`.
+
 Outputs JSON to stdout:
 
 ```json

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -17,3 +17,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 sha2 = "0.10"
+base64 = "0.22"

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -757,7 +757,7 @@ pub fn gemini_save_images(
         url = escape_js_string(conversation_url),
     );
     let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_gemini_save_img_navigate")?;
-    thread::sleep(Duration::from_millis(3000));
+    thread::sleep(Duration::from_millis(5000));
 
     let count_js = r#"(() => {
         const imgs = document.querySelectorAll('img[alt*="AI"], img[alt*="生成"]');

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -16,6 +16,7 @@ use crate::applescript::{escape, escape_body, run_capture};
 /// Core Data epoch: 2001-01-01 00:00:00 UTC
 const CORE_DATA_EPOCH: i64 = 978_307_200;
 const TAB_SEPARATOR: &str = "---TAB_SEP---";
+const FIELD_SEPARATOR: &str = "<<<FIELD_SEP>>>";
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct SafariTab {
@@ -167,7 +168,7 @@ fn extract_profile(window_name: &str, active_tab_title: &str) -> Option<String> 
 }
 
 fn parse_tab_line(line: &str) -> Option<SafariTab> {
-    let parts: Vec<&str> = line.split('\t').collect();
+    let parts: Vec<&str> = line.split(FIELD_SEPARATOR).collect();
     if parts.len() != 6 {
         return None;
     }
@@ -249,7 +250,8 @@ fn build_tab_return_block(tab_ref: &str, active_flag: &str) -> String {
             set tabIndex to (index of {tab_ref}) - 1
             set tabTitle to my encode_field(name of {tab_ref})
             set tabURL to my encode_field(URL of {tab_ref})
-            return winId & tab & winName & tab & tabIndex & tab & tabTitle & tab & tabURL & tab & "{active_flag}""#
+            return (winId as text) & "{field_separator}" & winName & "{field_separator}" & (tabIndex as text) & "{field_separator}" & tabTitle & "{field_separator}" & tabURL & "{field_separator}" & "{active_flag}""#,
+        field_separator = FIELD_SEPARATOR,
     )
 }
 
@@ -272,7 +274,7 @@ fn build_tabs_script() -> String {
                     else
                         set isActive to "false"
                     end if
-                    set output to output & winId & tab & winName & tab & tabIndex & tab & tabTitle & tab & tabURL & tab & isActive & "{separator}"
+                    set output to output & (winId as text) & "{field_separator}" & winName & "{field_separator}" & (tabIndex as text) & "{field_separator}" & tabTitle & "{field_separator}" & tabURL & "{field_separator}" & isActive & "{separator}"
                 end repeat
             end repeat
             return output
@@ -280,6 +282,7 @@ fn build_tabs_script() -> String {
     "#,
         prelude = safari_script_prelude(),
         separator = TAB_SEPARATOR,
+        field_separator = FIELD_SEPARATOR,
     )
 }
 
@@ -368,7 +371,12 @@ fn build_exec_script(js_code: &str) -> String {
                 return ""
             end if
             set jsCode to {js_expr}
-            set rawResult to do JavaScript jsCode in current tab of front window
+            set rawResult to missing value
+            try
+                set rawResult to do JavaScript jsCode in current tab of front window
+            on error errMsg number errNum
+                error errMsg number errNum
+            end try
             if rawResult is missing value then
                 return ""
             end if
@@ -553,6 +561,23 @@ fn build_gemini_chat_prompt_js(prompt: &str) -> String {
             input.dispatchEvent(new KeyboardEvent("keydown", {{ key: "Enter", bubbles: true }}));
             input.dispatchEvent(new KeyboardEvent("keypress", {{ key: "Enter", bubbles: true }}));
             input.dispatchEvent(new KeyboardEvent("keyup", {{ key: "Enter", bubbles: true }}));
+
+            const sendLabels = ["傳送訊息", "Send message"];
+            const buttons = [...document.querySelectorAll('button,[role="button"]')];
+            for (const button of buttons) {{
+              const label = [
+                button.getAttribute("aria-label"),
+                button.getAttribute("title"),
+                button.innerText,
+                button.textContent
+              ]
+                .filter(Boolean)
+                .join(" ");
+              if (!sendLabels.some((value) => label.includes(value))) continue;
+              button.click();
+              break;
+            }}
+
             return "true";
         }})()"#
     )
@@ -1009,7 +1034,7 @@ mod tests {
         GeminiMode, TAB_SEPARATOR, build_active_tab_script, build_close_script,
         build_exec_script, build_gemini_chat_prompt_js, build_gemini_deep_research_confirm_js,
         build_gemini_deep_research_plan_js, build_gemini_mode_switch_js, build_open_script,
-        build_tabs_script, extract_profile, gemini_deep_research_poll_js,
+        build_tab_return_block, build_tabs_script, extract_profile, gemini_deep_research_poll_js,
         gemini_response_extract_js, parse_deep_research_payload, parse_tab_line,
         parse_tabs_output, selector_click_js, selector_fill_js, selector_text_js,
         should_skip_gemini_response,
@@ -1024,7 +1049,7 @@ mod tests {
 
     #[test]
     fn parse_tab_line_decodes_fields() {
-        let line = "61998\tRyugu — Google\\tGemini\t0\tGoogle\\tGemini\thttps://gemini.google.com/app\ttrue";
+        let line = "61998<<<FIELD_SEP>>>Ryugu — Google\\tGemini<<<FIELD_SEP>>>0<<<FIELD_SEP>>>Google\\tGemini<<<FIELD_SEP>>>https://gemini.google.com/app<<<FIELD_SEP>>>true";
 
         let tab = parse_tab_line(line).expect("tab");
 
@@ -1040,8 +1065,8 @@ mod tests {
     #[test]
     fn parse_tabs_output_keeps_multiple_tabs() {
         let raw = concat!(
-            "1\tWork — Mail\t0\tMail\thttps://mail.google.com\ttrue---TAB_SEP---",
-            "1\tWork — Mail\t1\tDocs\thttps://docs.google.com\tfalse---TAB_SEP---"
+            "1<<<FIELD_SEP>>>Work — Mail<<<FIELD_SEP>>>0<<<FIELD_SEP>>>Mail<<<FIELD_SEP>>>https://mail.google.com<<<FIELD_SEP>>>true---TAB_SEP---",
+            "1<<<FIELD_SEP>>>Work — Mail<<<FIELD_SEP>>>1<<<FIELD_SEP>>>Docs<<<FIELD_SEP>>>https://docs.google.com<<<FIELD_SEP>>>false---TAB_SEP---"
         );
 
         let tabs = parse_tabs_output(raw);
@@ -1059,6 +1084,7 @@ mod tests {
 
         assert!(script.contains(TAB_SEPARATOR));
         assert!(script.contains("\\s"));
+        assert!(script.contains("<<<FIELD_SEP>>>"));
     }
 
     #[test]
@@ -1085,11 +1111,23 @@ mod tests {
     }
 
     #[test]
+    fn build_tab_return_block_coerces_numeric_fields_to_text() {
+        let script = build_tab_return_block("t", "true");
+
+        assert!(script.contains("(winId as text)"));
+        assert!(script.contains("(tabIndex as text)"));
+        assert!(script.contains("<<<FIELD_SEP>>>"));
+    }
+
+    #[test]
     fn build_exec_script_supports_multiline_js() {
         let script = build_exec_script("const x = 1;\nx + 1;");
 
         assert!(script.contains("set jsCode to"));
+        assert!(script.contains("set rawResult to missing value"));
+        assert!(script.contains("try"));
         assert!(script.contains("do JavaScript jsCode"));
+        assert!(script.contains("on error errMsg"));
         assert!(script.contains("& linefeed &"));
         assert!(script.contains("if rawResult is missing value then"));
     }
@@ -1120,6 +1158,8 @@ mod tests {
         assert!(script.contains(".ql-editor"));
         assert!(script.contains("hello world"));
         assert!(script.contains("KeyboardEvent"));
+        assert!(script.contains("傳送訊息"));
+        assert!(script.contains("Send message"));
     }
 
     #[test]

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -545,7 +545,7 @@ fn build_gemini_go_home_js() -> String {
         .to_string()
 }
 
-fn ensure_gemini_home(profile_filter: Option<&str>) -> Result<(), MacosError> {
+pub fn ensure_gemini_home(profile_filter: Option<&str>) -> Result<(), MacosError> {
     let _ = execute_js_for_profile(
         &build_gemini_go_home_js(),
         profile_filter,
@@ -1102,7 +1102,7 @@ pub fn start_gemini_deep_research(
         result.plan = Some(prompt.to_string());
     }
 
-    if auto_confirm {
+    if auto_confirm && result.status == "plan_ready" {
         let filled = execute_js_for_profile(
             &build_gemini_fill_input_js("ok"),
             profile_filter,
@@ -1159,8 +1159,6 @@ pub fn send_gemini_prompt(
     prompt: &str,
     profile_filter: Option<&str>,
 ) -> Result<SafariAiResponseResult, MacosError> {
-    ensure_gemini_home(profile_filter)?;
-
     let filled = execute_js_for_profile(
         &build_gemini_fill_input_js(prompt),
         profile_filter,

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::Connection;
 use serde::Serialize;
+use serde_json::Value;
 
 use cueward_core::{Cue, CueSource};
 
@@ -92,6 +93,19 @@ pub struct SafariAiResponseResult {
     pub provider: String,
     pub status: String,
     pub response: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct SafariDeepResearchResult {
+    pub provider: String,
+    pub mode: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub actions: Vec<String>,
 }
 
 fn history_db_path() -> PathBuf {
@@ -563,6 +577,111 @@ fn gemini_response_extract_js() -> String {
     })()"#
         .to_string()
 }
+fn build_gemini_deep_research_plan_js(prompt: &str) -> String {
+    let prompt = escape_js_string(prompt);
+    format!(
+        r#"(() => {{
+            const promptText = "{prompt}";
+            const input = document.querySelector(
+              ".ql-editor, rich-textarea .ProseMirror, div[role='textbox'][contenteditable='true'], div[contenteditable='true']"
+            );
+            if (!input) {{
+              throw new Error("gemini deep research input not found");
+            }}
+
+            input.focus();
+            input.textContent = promptText;
+            input.dispatchEvent(new Event("input", {{ bubbles: true }}));
+            input.dispatchEvent(new KeyboardEvent("keydown", {{ key: "Enter", bubbles: true }}));
+            input.dispatchEvent(new KeyboardEvent("keyup", {{ key: "Enter", bubbles: true }}));
+
+            const bodyText = document.body.innerText || "";
+            const plan = (() => {{
+              const selectors = [
+                ".model-response-text",
+                ".message-content",
+                ".markdown",
+                "div[data-test-id='message-content']"
+              ];
+              for (const selector of selectors) {{
+                const elements = document.querySelectorAll(selector);
+                if (!elements.length) continue;
+                const last = elements[elements.length - 1];
+                const text = (last.innerText || last.textContent || "").trim();
+                if (text) return text;
+              }}
+              return promptText;
+            }})();
+            const actions = [];
+            if (bodyText.includes("開始研究") || bodyText.includes("Start research")) actions.push("confirm");
+            if (bodyText.includes("編輯計畫") || bodyText.includes("Edit plan")) actions.push("edit");
+
+            return JSON.stringify({{
+              status: actions.length ? "plan_ready" : "running",
+              plan,
+              actions
+            }});
+        }})()"#
+    )
+}
+
+fn build_gemini_deep_research_confirm_js() -> String {
+    r#"(() => {
+        const labels = ["開始研究", "Start research"];
+        const normalize = (value) => (value ?? "").replace(/\s+/g, " ").trim();
+        const nodes = [...document.querySelectorAll("button,[role='button'],[role='option'],span")];
+        for (const node of nodes) {
+          const text = normalize(node.innerText || node.textContent);
+          if (!labels.some((label) => text.includes(label))) continue;
+          const clickable = node.closest("button,[role='button'],[role='option']") || node;
+          clickable.click();
+          return "true";
+        }
+        throw new Error("deep research confirm button not found");
+    })()"#
+        .to_string()
+}
+
+fn gemini_deep_research_poll_js() -> String {
+    r#"(() => {
+        const text = document.body.innerText || "";
+        const selectors = [
+          ".model-response-text",
+          ".message-content",
+          ".markdown",
+          "div[data-test-id='message-content']"
+        ];
+        const extractLastResponse = () => {
+          for (const selector of selectors) {
+            const elements = document.querySelectorAll(selector);
+            if (!elements.length) continue;
+            const last = elements[elements.length - 1];
+            const content = (last.innerText || last.textContent || "").trim();
+            if (content) return content;
+          }
+          return "";
+        };
+
+        if (text.includes("開始研究") || text.includes("Start research")) {
+          return JSON.stringify({
+            status: "plan_ready",
+            plan: extractLastResponse(),
+            actions: ["confirm", "edit"]
+          });
+        }
+        if (text.includes("研究中") || text.includes("Researching") || text.includes("Generating report")) {
+          return JSON.stringify({ status: "running" });
+        }
+
+        const content = extractLastResponse();
+        if (content) {
+          return JSON.stringify({ status: "complete", response: content });
+        }
+
+        return JSON.stringify({ status: "running" });
+    })()"#
+        .to_string()
+}
 
 pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
     let db_path = history_db_path();
@@ -722,6 +841,35 @@ pub fn wait(selector: &str, timeout_seconds: u64) -> Result<SafariWaitResult, Ma
     }
 }
 
+fn parse_deep_research_payload(payload: &str) -> Result<SafariDeepResearchResult, MacosError> {
+    let value: Value = serde_json::from_str(payload)
+        .map_err(|error| MacosError::Other(format!("invalid deep research payload: {error}: {payload}")))?;
+    let status = value
+        .get("status")
+        .and_then(Value::as_str)
+        .ok_or_else(|| MacosError::Other("deep research payload missing status".to_string()))?;
+    let actions = value
+        .get("actions")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Ok(SafariDeepResearchResult {
+        provider: "gemini".to_string(),
+        mode: "deep-research".to_string(),
+        status: status.to_string(),
+        plan: value.get("plan").and_then(Value::as_str).map(ToOwned::to_owned),
+        response: value.get("response").and_then(Value::as_str).map(ToOwned::to_owned),
+        actions,
+    })
+}
+
 pub fn prepare_gemini_mode(mode: GeminiMode) -> Result<SafariAiReadyResult, MacosError> {
     let placeholder = execute_js(&build_gemini_mode_switch_js(mode), "safari_gemini_mode")?;
     if !gemini_mode_placeholders(mode)
@@ -737,6 +885,67 @@ pub fn prepare_gemini_mode(mode: GeminiMode) -> Result<SafariAiReadyResult, Maco
         provider: "gemini".to_string(),
         mode: gemini_mode_slug(mode).to_string(),
         status: "ready".to_string(),
+    })
+}
+
+
+pub fn start_gemini_deep_research(
+    prompt: &str,
+    auto_confirm: bool,
+) -> Result<SafariDeepResearchResult, MacosError> {
+    let raw = execute_js(
+        &build_gemini_deep_research_plan_js(prompt),
+        "safari_gemini_deep_research_plan",
+    )?;
+    let mut result = parse_deep_research_payload(&raw)?;
+    if result.plan.is_none() {
+        result.plan = Some(prompt.to_string());
+    }
+
+    if auto_confirm {
+        let confirm = execute_js(
+            &build_gemini_deep_research_confirm_js(),
+            "safari_gemini_deep_research_confirm",
+        )?;
+        if confirm.trim() != "true" {
+            return Err(MacosError::Other(format!(
+                "failed to confirm deep research plan: {confirm}"
+            )));
+        }
+        poll_gemini_deep_research(900)
+    } else {
+        Ok(result)
+    }
+}
+
+pub fn poll_gemini_deep_research(timeout_seconds: u64) -> Result<SafariDeepResearchResult, MacosError> {
+    let deadline = Instant::now() + Duration::from_secs(timeout_seconds);
+    let js = gemini_deep_research_poll_js();
+
+    while Instant::now() < deadline {
+        let payload = execute_js(&js, "safari_gemini_deep_research_poll")?;
+        let result = parse_deep_research_payload(&payload)?;
+        match result.status.as_str() {
+            "plan_ready" | "complete" => return Ok(result),
+            "running" => {}
+            _ => {
+                return Err(MacosError::Other(format!(
+                    "unknown deep research status: {}",
+                    result.status
+                )))
+            }
+        }
+
+        thread::sleep(Duration::from_secs(1));
+    }
+
+    Ok(SafariDeepResearchResult {
+        provider: "gemini".to_string(),
+        mode: "deep-research".to_string(),
+        status: "timeout".to_string(),
+        plan: None,
+        response: None,
+        actions: Vec::new(),
     })
 }
 
@@ -797,9 +1006,11 @@ fn execute_js(js_code: &str, context: &str) -> Result<String, MacosError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        GeminiMode, TAB_SEPARATOR, build_active_tab_script, build_close_script, build_exec_script,
-        build_gemini_chat_prompt_js, build_gemini_mode_switch_js, build_open_script,
-        build_tabs_script, extract_profile, gemini_response_extract_js, parse_tab_line,
+        GeminiMode, TAB_SEPARATOR, build_active_tab_script, build_close_script,
+        build_exec_script, build_gemini_chat_prompt_js, build_gemini_deep_research_confirm_js,
+        build_gemini_deep_research_plan_js, build_gemini_mode_switch_js, build_open_script,
+        build_tabs_script, extract_profile, gemini_deep_research_poll_js,
+        gemini_response_extract_js, parse_deep_research_payload, parse_tab_line,
         parse_tabs_output, selector_click_js, selector_fill_js, selector_text_js,
         should_skip_gemini_response,
     };
@@ -909,6 +1120,44 @@ mod tests {
         assert!(script.contains(".ql-editor"));
         assert!(script.contains("hello world"));
         assert!(script.contains("KeyboardEvent"));
+    }
+
+    #[test]
+    fn gemini_deep_research_plan_script_targets_plan_controls() {
+        let script = build_gemini_deep_research_plan_js("研究主題");
+
+        assert!(script.contains("研究主題"));
+        assert!(script.contains("開始研究"));
+        assert!(script.contains("Start research"));
+        assert!(script.contains("編輯計畫"));
+    }
+
+    #[test]
+    fn gemini_deep_research_poll_script_exposes_status_markers() {
+        let script = gemini_deep_research_poll_js();
+
+        assert!(script.contains("plan_ready"));
+        assert!(script.contains("running"));
+        assert!(script.contains("complete"));
+        assert!(script.contains("開始研究"));
+    }
+
+    #[test]
+    fn gemini_deep_research_confirm_script_targets_confirm_button() {
+        let script = build_gemini_deep_research_confirm_js();
+
+        assert!(script.contains("開始研究"));
+        assert!(script.contains("Start research"));
+    }
+
+    #[test]
+    fn parse_deep_research_payload_reads_plan_and_actions() {
+        let payload = r#"{"status":"plan_ready","plan":"Outline","actions":["confirm","edit"]}"#;
+        let result = parse_deep_research_payload(payload).expect("parse payload");
+
+        assert_eq!(result.status, "plan_ready");
+        assert_eq!(result.plan.as_deref(), Some("Outline"));
+        assert_eq!(result.actions, vec!["confirm".to_string(), "edit".to_string()]);
     }
 
     #[test]

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -947,12 +947,12 @@ pub fn source(profile_filter: Option<&str>) -> Result<SafariSourceResult, MacosE
     Ok(SafariSourceResult { html: result })
 }
 
-pub fn read(selector: Option<&str>) -> Result<SafariReadResult, MacosError> {
+pub fn read(selector: Option<&str>, profile_filter: Option<&str>) -> Result<SafariReadResult, MacosError> {
     let js = match selector {
         Some(selector) => selector_text_js(selector),
         None => "(document.body.innerText ?? \"\").trim()".to_string(),
     };
-    let content = execute_js(&js, "safari_read")?;
+    let content = execute_js_for_profile(&js, profile_filter, "safari_read")?;
     Ok(SafariReadResult {
         selector: selector.map(ToOwned::to_owned),
         content,

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -369,9 +369,10 @@ fn build_exec_script_for_profile(js_code: &str, profile_filter: Option<&str>) ->
     )
 }
 
-fn build_open_script(url: &str) -> String {
+fn build_open_script(url: &str, profile_filter: Option<&str>) -> String {
     let escaped_url = escape(url);
     let tab_return = build_tab_return_block("t", "true");
+    let target_window = target_window_block(profile_filter);
     format!(
         r#"
         {prelude}
@@ -380,7 +381,7 @@ fn build_open_script(url: &str) -> String {
                 make new document with properties {{URL:"{escaped_url}"}}
                 set w to front window
             else
-                set w to front window
+                {target_window}
                 set t to make new tab at end of tabs of w with properties {{URL:"{escaped_url}"}}
                 set current tab of w to t
             end if
@@ -391,6 +392,7 @@ fn build_open_script(url: &str) -> String {
     "#,
         prelude = safari_script_prelude(),
         escaped_url = escaped_url,
+        target_window = target_window,
         tab_return = tab_return,
     )
 }
@@ -924,8 +926,8 @@ pub fn active(profile_filter: Option<&str>) -> Result<Option<SafariTab>, MacosEr
     }))
 }
 
-pub fn open(url: &str) -> Result<Option<SafariTab>, MacosError> {
-    let stdout = run_capture(&build_open_script(url), "safari_open")?;
+pub fn open(url: &str, profile_filter: Option<&str>) -> Result<Option<SafariTab>, MacosError> {
+    let stdout = run_capture(&build_open_script(url, profile_filter), "safari_open")?;
     Ok(parse_tab_line(stdout.trim()).map(|mut tab| {
         tab.profile = extract_profile(&tab.window_name, &tab.title);
         tab
@@ -940,8 +942,8 @@ pub fn close(index: Option<usize>) -> Result<SafariCloseResult, MacosError> {
     })
 }
 
-pub fn source() -> Result<SafariSourceResult, MacosError> {
-    let result = execute_js("document.documentElement.outerHTML", "safari_source")?;
+pub fn source(profile_filter: Option<&str>) -> Result<SafariSourceResult, MacosError> {
+    let result = execute_js_for_profile("document.documentElement.outerHTML", profile_filter, "safari_source")?;
     Ok(SafariSourceResult { html: result })
 }
 
@@ -1285,7 +1287,7 @@ mod tests {
 
     #[test]
     fn build_open_script_creates_new_tab() {
-        let script = build_open_script("https://example.com");
+        let script = build_open_script("https://example.com", None);
 
         assert!(script.contains("make new tab at end of tabs of w"));
         assert!(script.contains("https://example.com"));

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -747,6 +747,101 @@ pub fn gemini_read_conversation(
     })
 }
 
+pub fn gemini_save_images(
+    conversation_url: &str,
+    output_dir: &str,
+    profile_filter: Option<&str>,
+) -> Result<Vec<String>, MacosError> {
+    let nav_js = format!(
+        r#"(function() {{ window.location.href = "{url}"; return "true"; }})()"#,
+        url = escape_js_string(conversation_url),
+    );
+    let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_gemini_save_img_navigate")?;
+    thread::sleep(Duration::from_millis(3000));
+
+    let count_js = r#"(() => {
+        const imgs = document.querySelectorAll('img[alt*="AI"], img[alt*="生成"]');
+        return String(imgs.length);
+    })()"#;
+    let count: usize = execute_js_for_profile(count_js, profile_filter, "safari_gemini_img_count")?
+        .trim()
+        .parse()
+        .unwrap_or(0);
+
+    if count == 0 {
+        return Ok(Vec::new());
+    }
+
+    let out_path = std::path::Path::new(output_dir);
+    if !out_path.exists() {
+        std::fs::create_dir_all(out_path)
+            .map_err(|e| MacosError::Other(format!("failed to create output dir: {e}")))?;
+    }
+
+    use base64::Engine;
+    let engine = base64::engine::general_purpose::STANDARD;
+    let mut saved = Vec::new();
+
+    for i in 0..count {
+        let extract_js = format!(
+            r#"(() => {{
+                const imgs = document.querySelectorAll('img[alt*="AI"], img[alt*="生成"]');
+                const img = imgs[{i}];
+                if (!img) return "";
+                const canvas = document.createElement("canvas");
+                canvas.width = img.naturalWidth || img.width;
+                canvas.height = img.naturalHeight || img.height;
+                canvas.getContext("2d").drawImage(img, 0, 0);
+                const dataUrl = canvas.toDataURL("image/png");
+                const idx = dataUrl.indexOf(",");
+                return idx >= 0 ? dataUrl.substring(idx + 1) : "";
+            }})()"#,
+        );
+        let b64 = execute_js_for_profile(&extract_js, profile_filter, "safari_gemini_img_extract")?;
+        let b64 = b64.trim();
+        if b64.is_empty() {
+            continue;
+        }
+
+        let bytes = engine.decode(b64).map_err(|e| {
+            MacosError::Other(format!("base64 decode failed for image {i}: {e}"))
+        })?;
+
+        let filename = format!("gemini_image_{i}.png");
+        let filepath = out_path.join(&filename);
+        std::fs::write(&filepath, &bytes)
+            .map_err(|e| MacosError::Other(format!("failed to write {}: {e}", filepath.display())))?;
+        saved.push(filepath.to_string_lossy().into_owned());
+    }
+
+    Ok(saved)
+}
+
+pub fn gemini_get_video_url(
+    conversation_url: &str,
+    profile_filter: Option<&str>,
+) -> Result<Option<String>, MacosError> {
+    let nav_js = format!(
+        r#"(function() {{ window.location.href = "{url}"; return "true"; }})()"#,
+        url = escape_js_string(conversation_url),
+    );
+    let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_gemini_video_navigate")?;
+    thread::sleep(Duration::from_millis(3000));
+
+    let js = r#"(() => {
+        const video = document.querySelector("video");
+        if (!video) return "";
+        return video.src || video.currentSrc || "";
+    })()"#;
+    let url = execute_js_for_profile(js, profile_filter, "safari_gemini_video_url")?;
+    let url = url.trim();
+    if url.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(url.to_string()))
+    }
+}
+
 pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
     let db_path = history_db_path();
 

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -96,11 +96,19 @@ pub struct SafariAiResponseResult {
     pub response: String,
 }
 
+#[derive(Debug, Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct SafariConversation {
+    pub title: String,
+    pub url: String,
+}
+
 #[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct SafariDeepResearchResult {
     pub provider: String,
     pub mode: String,
     pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -165,6 +173,28 @@ fn extract_profile(window_name: &str, active_tab_title: &str) -> Option<String> 
         .map(str::trim)
         .filter(|profile| !profile.is_empty())
         .map(ToOwned::to_owned)
+}
+
+
+fn target_window_block(profile_filter: Option<&str>) -> String {
+    match profile_filter {
+        Some(profile) => {
+            let profile = escape(profile);
+            format!(
+                r#"set w to missing value
+            repeat with candidate in every window
+                if (name of candidate contains "{profile}") then
+                    set w to candidate
+                    exit repeat
+                end if
+            end repeat
+            if w is missing value then
+                return ""
+            end if"#,
+            )
+        }
+        None => "set w to front window".to_string(),
+    }
 }
 
 fn parse_tab_line(line: &str) -> Option<SafariTab> {
@@ -286,8 +316,9 @@ fn build_tabs_script() -> String {
     )
 }
 
-fn build_active_tab_script() -> String {
+fn build_active_tab_script(profile_filter: Option<&str>) -> String {
     let tab_return = build_tab_return_block("t", "true");
+    let target_window = target_window_block(profile_filter);
     format!(
         r#"
         {prelude}
@@ -295,13 +326,46 @@ fn build_active_tab_script() -> String {
             if (count of windows) is 0 then
                 return ""
             end if
-            set w to front window
+            {target_window}
             set t to current tab of w
             {tab_return}
         end tell
     "#,
         prelude = safari_script_prelude(),
+        target_window = target_window,
         tab_return = tab_return,
+    )
+}
+
+
+fn build_exec_script_for_profile(js_code: &str, profile_filter: Option<&str>) -> String {
+    let js_expr = escape_body(js_code);
+    let target_window = target_window_block(profile_filter);
+    format!(
+        r#"
+        {prelude}
+        tell application "Safari"
+            if (count of windows) is 0 then
+                return ""
+            end if
+            {target_window}
+            set jsCode to {js_expr}
+            set rawResult to missing value
+            try
+                set rawResult to do JavaScript jsCode in current tab of w
+            on error errMsg number errNum
+                error errMsg number errNum
+            end try
+            if rawResult is missing value then
+                return ""
+            end if
+            set rawResult to rawResult as string
+            return my encode_field(rawResult)
+        end tell
+    "#,
+        prelude = safari_script_prelude(),
+        target_window = target_window,
+        js_expr = js_expr,
     )
 }
 
@@ -361,6 +425,7 @@ fn build_close_script(index: Option<usize>) -> String {
     )
 }
 
+#[allow(dead_code)]
 fn build_exec_script(js_code: &str) -> String {
     let js_expr = escape_body(js_code);
     format!(
@@ -436,15 +501,6 @@ fn selector_fill_js(selector: &str, text: &str) -> String {
     )
 }
 
-fn gemini_mode_labels(mode: GeminiMode) -> &'static [&'static str] {
-    match mode {
-        GeminiMode::Image => &["建立圖像", "Create image", "Create Image"],
-        GeminiMode::DeepResearch => &["Deep Research"],
-        GeminiMode::Video => &["建立影片", "Create video", "Create Video"],
-        GeminiMode::Music => &["創作音樂", "Create music", "Create Music"],
-    }
-}
-
 fn gemini_mode_placeholders(mode: GeminiMode) -> &'static [&'static str] {
     match mode {
         GeminiMode::Image => &[
@@ -453,18 +509,9 @@ fn gemini_mode_placeholders(mode: GeminiMode) -> &'static [&'static str] {
             "Describe the image you want to create",
         ],
         GeminiMode::DeepResearch => &["你想研究什麼？", "What do you want to research?"],
-        GeminiMode::Video => &["描述影片", "Describe the video"],
-        GeminiMode::Music => &["描述音樂", "Describe the music"],
+        GeminiMode::Video => &["描述影片", "Describe the video", "Describe your video"],
+        GeminiMode::Music => &["描述音樂", "描述要創作的音樂", "Describe the music", "Describe the music you"],
     }
-}
-
-fn js_string_array(values: &[&str]) -> String {
-    let escaped = values
-        .iter()
-        .map(|value| format!("\"{}\"", escape_js_string(value)))
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!("[{escaped}]")
 }
 
 fn should_skip_gemini_response(trimmed: &str, prompt: &str) -> bool {
@@ -480,107 +527,46 @@ fn gemini_mode_slug(mode: GeminiMode) -> &'static str {
     }
 }
 
-fn build_gemini_mode_switch_js(mode: GeminiMode) -> String {
-    let mode_labels = js_string_array(gemini_mode_labels(mode));
-    let expected_placeholders = js_string_array(gemini_mode_placeholders(mode));
-    format!(
-        r#"(() => {{
-            const modeLabels = {mode_labels};
-            const expectedPlaceholders = {expected_placeholders};
-            const clickableSelector = [
-              "button",
-              "[role='button']",
-              "[role='option']",
-              "mat-option",
-              "li",
-              "span"
-            ].join(",");
-            const normalize = (value) => (value ?? "").replace(/\s+/g, " ").trim();
-            const clickByText = (labels) => {{
-              const wanted = labels.map(normalize).filter(Boolean);
-              const nodes = [...document.querySelectorAll(clickableSelector)];
-              for (const node of nodes) {{
-                const text = normalize(node.innerText || node.textContent);
-                if (!text) continue;
-                if (!wanted.some((label) => text.includes(label))) continue;
-                const clickable = node.closest("button,[role='button'],[role='option'],mat-option,li") || node;
-                clickable.click();
-                return true;
-              }}
-              return false;
-            }};
-
-            clickByText(["工具", "Tools", "模式", "Mode"]);
-            if (!clickByText(modeLabels)) {{
-              throw new Error(`gemini mode not found: ${{modeLabels.join(", ")}}`);
-            }}
-
-            const input = document.querySelector(
-              ".ql-editor, rich-textarea .ProseMirror, div[role='textbox'][contenteditable='true'], div[contenteditable='true']"
-            );
-            if (!input) {{
-              throw new Error("gemini input not found after mode switch");
-            }}
-
-            const placeholder = normalize(
-              input.getAttribute("data-placeholder") ||
-              input.getAttribute("placeholder") ||
-              input.getAttribute("aria-label") ||
-              ""
-            );
-            if (!expectedPlaceholders.some((value) => placeholder.includes(value))) {{
-              throw new Error(`placeholder mismatch: ${{placeholder}}`);
-            }}
-
-            return placeholder;
-        }})()"#
-    )
+fn gemini_mode_url(mode: GeminiMode) -> &'static str {
+    match mode {
+        GeminiMode::Image => "https://gemini.google.com/image",
+        GeminiMode::DeepResearch => "https://gemini.google.com/deepresearch",
+        GeminiMode::Video => "https://gemini.google.com/veo",
+        GeminiMode::Music => "https://gemini.google.com/music",
+    }
 }
 
-fn build_gemini_chat_prompt_js(prompt: &str) -> String {
-    let prompt = escape_js_string(prompt);
-    format!(
-        r#"(() => {{
-            const promptText = "{prompt}";
-            const input = document.querySelector(
-              ".ql-editor, rich-textarea .ProseMirror, div[role='textbox'][contenteditable='true'], div[contenteditable='true']"
-            );
-            if (!input) {{
-              throw new Error("gemini input not found");
-            }}
 
-            input.focus();
-            if ("value" in input) {{
-              input.value = promptText;
-            }} else {{
-              input.textContent = promptText;
-            }}
-            input.dispatchEvent(new Event("input", {{ bubbles: true }}));
-            input.dispatchEvent(new Event("change", {{ bubbles: true }}));
+fn build_gemini_go_home_js() -> String {
+    r#"(function() {
+        window.location.href = "https://gemini.google.com/app";
+        return "true";
+    })()"#
+        .to_string()
+}
 
-            input.dispatchEvent(new KeyboardEvent("keydown", {{ key: "Enter", bubbles: true }}));
-            input.dispatchEvent(new KeyboardEvent("keypress", {{ key: "Enter", bubbles: true }}));
-            input.dispatchEvent(new KeyboardEvent("keyup", {{ key: "Enter", bubbles: true }}));
+fn ensure_gemini_home(profile_filter: Option<&str>) -> Result<(), MacosError> {
+    let _ = execute_js_for_profile(
+        &build_gemini_go_home_js(),
+        profile_filter,
+        "safari_gemini_go_home",
+    )?;
+    thread::sleep(Duration::from_millis(2500));
+    Ok(())
+}
 
-            const sendLabels = ["傳送訊息", "Send message"];
-            const buttons = [...document.querySelectorAll('button,[role="button"]')];
-            for (const button of buttons) {{
-              const label = [
-                button.getAttribute("aria-label"),
-                button.getAttribute("title"),
-                button.innerText,
-                button.textContent
-              ]
-                .filter(Boolean)
-                .join(" ");
-              if (!sendLabels.some((value) => label.includes(value))) continue;
-              button.click();
-              break;
-            }}
-
-            return "true";
-        }})()"#
-    )
+fn build_gemini_placeholder_read_js() -> String {
+    r#"(function() {
+        var input = document.querySelector(".ql-editor, rich-textarea .ProseMirror, div[role='textbox'][contenteditable='true'], div[contenteditable='true']");
+        if (!input) return "";
+        return String(
+          input.getAttribute("data-placeholder") ||
+          input.getAttribute("placeholder") ||
+          input.getAttribute("aria-label") ||
+          ""
+        );
+    })()"#
+        .to_string()
 }
 
 fn gemini_response_extract_js() -> String {
@@ -602,70 +588,56 @@ fn gemini_response_extract_js() -> String {
     })()"#
         .to_string()
 }
-fn build_gemini_deep_research_plan_js(prompt: &str) -> String {
+fn build_gemini_fill_input_js(prompt: &str) -> String {
     let prompt = escape_js_string(prompt);
     format!(
         r#"(() => {{
-            const promptText = "{prompt}";
             const input = document.querySelector(
               ".ql-editor, rich-textarea .ProseMirror, div[role='textbox'][contenteditable='true'], div[contenteditable='true']"
             );
-            if (!input) {{
-              throw new Error("gemini deep research input not found");
-            }}
-
+            if (!input) throw new Error("gemini input not found");
             input.focus();
-            input.textContent = promptText;
-            input.dispatchEvent(new Event("input", {{ bubbles: true }}));
-            input.dispatchEvent(new KeyboardEvent("keydown", {{ key: "Enter", bubbles: true }}));
-            input.dispatchEvent(new KeyboardEvent("keyup", {{ key: "Enter", bubbles: true }}));
-
-            const bodyText = document.body.innerText || "";
-            const plan = (() => {{
-              const selectors = [
-                ".model-response-text",
-                ".message-content",
-                ".markdown",
-                "div[data-test-id='message-content']"
-              ];
-              for (const selector of selectors) {{
-                const elements = document.querySelectorAll(selector);
-                if (!elements.length) continue;
-                const last = elements[elements.length - 1];
-                const text = (last.innerText || last.textContent || "").trim();
-                if (text) return text;
-              }}
-              return promptText;
-            }})();
-            const actions = [];
-            if (bodyText.includes("開始研究") || bodyText.includes("Start research")) actions.push("confirm");
-            if (bodyText.includes("編輯計畫") || bodyText.includes("Edit plan")) actions.push("edit");
-
-            return JSON.stringify({{
-              status: actions.length ? "plan_ready" : "running",
-              plan,
-              actions
-            }});
+            input.textContent = "";
+            document.execCommand("insertText", false, "{prompt}");
+            return "true";
         }})()"#
     )
 }
 
-fn build_gemini_deep_research_confirm_js() -> String {
+fn wait_and_click_send(profile_filter: Option<&str>) -> Result<(), MacosError> {
+    let js = &build_gemini_click_send_js();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(200));
+        let result = execute_js_for_profile(js, profile_filter, "safari_gemini_wait_send")?;
+        if result.trim() == "true" {
+            return Ok(());
+        }
+    }
+    Err(MacosError::Other("send button not found or disabled after 5s".to_string()))
+}
+
+fn build_gemini_click_send_js() -> String {
     r#"(() => {
-        const labels = ["開始研究", "Start research"];
-        const normalize = (value) => (value ?? "").replace(/\s+/g, " ").trim();
-        const nodes = [...document.querySelectorAll("button,[role='button'],[role='option'],span")];
-        for (const node of nodes) {
-          const text = normalize(node.innerText || node.textContent);
-          if (!labels.some((label) => text.includes(label))) continue;
-          const clickable = node.closest("button,[role='button'],[role='option']") || node;
-          clickable.click();
+        const sendLabels = ["傳送訊息", "Send message"];
+        const buttons = [...document.querySelectorAll('button,[role="button"]')];
+        for (const button of buttons) {
+          const label = [
+            button.getAttribute("aria-label"),
+            button.getAttribute("title"),
+            button.innerText,
+            button.textContent
+          ].filter(Boolean).join(" ");
+          if (!sendLabels.some((v) => label.includes(v))) continue;
+          if (button.disabled) return "disabled";
+          button.click();
           return "true";
         }
-        throw new Error("deep research confirm button not found");
+        return "false";
     })()"#
         .to_string()
 }
+
 
 fn gemini_deep_research_poll_js() -> String {
     r#"(() => {
@@ -687,7 +659,7 @@ fn gemini_deep_research_poll_js() -> String {
           return "";
         };
 
-        if (text.includes("開始研究") || text.includes("Start research")) {
+        if (text.includes("開始研究") || text.includes("Start research") || text.includes("編輯計畫") || text.includes("Edit plan")) {
           return JSON.stringify({
             status: "plan_ready",
             plan: extractLastResponse(),
@@ -706,6 +678,73 @@ fn gemini_deep_research_poll_js() -> String {
         return JSON.stringify({ status: "running" });
     })()"#
         .to_string()
+}
+
+fn get_gemini_conversation_url(profile_filter: Option<&str>) -> Result<String, MacosError> {
+    let js = r#"(() => {
+        const url = window.location.href || "";
+        if (url.match(/gemini\.google\.com\/app\/[a-f0-9]{10,}/)) return url;
+        return "";
+    })()"#;
+    let url = execute_js_for_profile(js, profile_filter, "safari_gemini_conversation_url")?;
+    let url = url.trim();
+    if url.is_empty() {
+        return Err(MacosError::Other("no conversation URL found".to_string()));
+    }
+    Ok(url.to_string())
+}
+
+pub fn gemini_list_conversations(profile_filter: Option<&str>) -> Result<Vec<SafariConversation>, MacosError> {
+    let js = r#"(() => {
+        const items = document.querySelectorAll('a[href*="/app/"]');
+        const convos = [];
+        for (const a of items) {
+          const href = a.getAttribute("href") || "";
+          if (!/\/app\/[a-f0-9]{10,}/.test(href)) continue;
+          const title = (a.innerText || a.textContent || "").trim();
+          if (!title) continue;
+          convos.push({ title, url: "https://gemini.google.com" + href });
+        }
+        return JSON.stringify(convos);
+    })()"#;
+    let raw = execute_js_for_profile(js, profile_filter, "safari_gemini_list_conversations")?;
+    let items: Vec<SafariConversation> = serde_json::from_str(&raw)
+        .map_err(|e| MacosError::Other(format!("failed to parse conversations: {e}")))?;
+    Ok(items)
+}
+
+pub fn gemini_read_conversation(
+    url: &str,
+    profile_filter: Option<&str>,
+) -> Result<SafariAiResponseResult, MacosError> {
+    let nav_js = format!(
+        r#"(function() {{ window.location.href = "{url}"; return "true"; }})()"#,
+        url = escape_js_string(url),
+    );
+    let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_gemini_read_navigate")?;
+    thread::sleep(Duration::from_millis(3000));
+
+    let read_js = r#"(() => {
+        const panels = document.querySelectorAll('.markdown.markdown-main-panel');
+        let biggest = null;
+        let maxLen = 0;
+        for (const p of panels) {
+          const len = (p.innerText || "").length;
+          if (len > maxLen) { maxLen = len; biggest = p; }
+        }
+        if (!biggest || maxLen === 0) return JSON.stringify({ status: "empty", response: "" });
+        return JSON.stringify({ status: "complete", response: (biggest.innerText || "").trim() });
+    })()"#;
+    let raw = execute_js_for_profile(read_js, profile_filter, "safari_gemini_read_content")?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| MacosError::Other(format!("failed to parse read result: {e}")))?;
+    let status = value.get("status").and_then(|v| v.as_str()).unwrap_or("error");
+    let response = value.get("response").and_then(|v| v.as_str()).unwrap_or("");
+    Ok(SafariAiResponseResult {
+        provider: "gemini".to_string(),
+        status: status.to_string(),
+        response: response.to_string(),
+    })
 }
 
 pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {
@@ -771,8 +810,8 @@ pub fn tabs(profile_filter: Option<&str>) -> Result<Vec<SafariTab>, MacosError> 
     Ok(tabs)
 }
 
-pub fn active() -> Result<Option<SafariTab>, MacosError> {
-    let stdout = run_capture(&build_active_tab_script(), "safari_active")?;
+pub fn active(profile_filter: Option<&str>) -> Result<Option<SafariTab>, MacosError> {
+    let stdout = run_capture(&build_active_tab_script(profile_filter), "safari_active")?;
     Ok(parse_tab_line(stdout.trim()).map(|mut tab| {
         tab.profile = extract_profile(&tab.window_name, &tab.title);
         tab
@@ -812,8 +851,8 @@ pub fn read(selector: Option<&str>) -> Result<SafariReadResult, MacosError> {
     })
 }
 
-pub fn exec(js_code: &str) -> Result<SafariEvalResult, MacosError> {
-    let result = execute_js(js_code, "safari_exec")?;
+pub fn exec(js_code: &str, profile_filter: Option<&str>) -> Result<SafariEvalResult, MacosError> {
+    let result = execute_js_for_profile(js_code, profile_filter, "safari_exec")?;
     Ok(SafariEvalResult { result })
 }
 
@@ -889,20 +928,35 @@ fn parse_deep_research_payload(payload: &str) -> Result<SafariDeepResearchResult
         provider: "gemini".to_string(),
         mode: "deep-research".to_string(),
         status: status.to_string(),
+        conversation_url: None,
         plan: value.get("plan").and_then(Value::as_str).map(ToOwned::to_owned),
         response: value.get("response").and_then(Value::as_str).map(ToOwned::to_owned),
         actions,
     })
 }
 
-pub fn prepare_gemini_mode(mode: GeminiMode) -> Result<SafariAiReadyResult, MacosError> {
-    let placeholder = execute_js(&build_gemini_mode_switch_js(mode), "safari_gemini_mode")?;
+pub fn prepare_gemini_mode(
+    mode: GeminiMode,
+    profile_filter: Option<&str>,
+) -> Result<SafariAiReadyResult, MacosError> {
+    let url = gemini_mode_url(mode);
+    let nav_js = format!(
+        r#"(function() {{ window.location.href = "{url}"; return "true"; }})()"#,
+    );
+    let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_gemini_mode_navigate")?;
+    thread::sleep(Duration::from_millis(2500));
+
+    let placeholder = execute_js_for_profile(
+        &build_gemini_placeholder_read_js(),
+        profile_filter,
+        "safari_gemini_mode_placeholder",
+    )?;
     if !gemini_mode_placeholders(mode)
         .iter()
         .any(|value| placeholder.contains(value))
     {
         return Err(MacosError::Other(format!(
-            "unexpected Gemini placeholder after mode switch: {placeholder}"
+            "unexpected Gemini placeholder after URL navigation to {url}: {placeholder}"
         )));
     }
 
@@ -917,38 +971,58 @@ pub fn prepare_gemini_mode(mode: GeminiMode) -> Result<SafariAiReadyResult, Maco
 pub fn start_gemini_deep_research(
     prompt: &str,
     auto_confirm: bool,
+    profile_filter: Option<&str>,
 ) -> Result<SafariDeepResearchResult, MacosError> {
-    let raw = execute_js(
-        &build_gemini_deep_research_plan_js(prompt),
-        "safari_gemini_deep_research_plan",
+    prepare_gemini_mode(GeminiMode::DeepResearch, profile_filter)?;
+
+    let filled = execute_js_for_profile(
+        &build_gemini_fill_input_js(prompt),
+        profile_filter,
+        "safari_gemini_deep_research_fill",
     )?;
-    let mut result = parse_deep_research_payload(&raw)?;
+    if filled.trim() != "true" {
+        return Err(MacosError::Other(format!("failed to fill deep research input: {filled}")));
+    }
+
+    wait_and_click_send(profile_filter)?;
+
+    // Capture conversation URL after submission
+    thread::sleep(Duration::from_millis(1000));
+    let conv_url = get_gemini_conversation_url(profile_filter).ok();
+
+    let mut result = poll_gemini_deep_research(30, profile_filter)?;
+    result.conversation_url = conv_url.clone();
     if result.plan.is_none() {
         result.plan = Some(prompt.to_string());
     }
 
     if auto_confirm {
-        let confirm = execute_js(
-            &build_gemini_deep_research_confirm_js(),
-            "safari_gemini_deep_research_confirm",
+        let filled = execute_js_for_profile(
+            &build_gemini_fill_input_js("ok"),
+            profile_filter,
+            "safari_gemini_deep_research_confirm_fill",
         )?;
-        if confirm.trim() != "true" {
-            return Err(MacosError::Other(format!(
-                "failed to confirm deep research plan: {confirm}"
-            )));
+        if filled.trim() != "true" {
+            return Err(MacosError::Other("failed to fill confirm text".to_string()));
         }
-        poll_gemini_deep_research(900)
+        wait_and_click_send(profile_filter)?;
+        let mut final_result = poll_gemini_deep_research(900, profile_filter)?;
+        final_result.conversation_url = conv_url;
+        Ok(final_result)
     } else {
         Ok(result)
     }
 }
 
-pub fn poll_gemini_deep_research(timeout_seconds: u64) -> Result<SafariDeepResearchResult, MacosError> {
+pub fn poll_gemini_deep_research(
+    timeout_seconds: u64,
+    profile_filter: Option<&str>,
+) -> Result<SafariDeepResearchResult, MacosError> {
     let deadline = Instant::now() + Duration::from_secs(timeout_seconds);
     let js = gemini_deep_research_poll_js();
 
     while Instant::now() < deadline {
-        let payload = execute_js(&js, "safari_gemini_deep_research_poll")?;
+        let payload = execute_js_for_profile(&js, profile_filter, "safari_gemini_deep_research_poll")?;
         let result = parse_deep_research_payload(&payload)?;
         match result.status.as_str() {
             "plan_ready" | "complete" => return Ok(result),
@@ -968,19 +1042,29 @@ pub fn poll_gemini_deep_research(timeout_seconds: u64) -> Result<SafariDeepResea
         provider: "gemini".to_string(),
         mode: "deep-research".to_string(),
         status: "timeout".to_string(),
+        conversation_url: None,
         plan: None,
         response: None,
         actions: Vec::new(),
     })
 }
 
-pub fn send_gemini_prompt(prompt: &str) -> Result<SafariAiResponseResult, MacosError> {
-    let sent = execute_js(&build_gemini_chat_prompt_js(prompt), "safari_gemini_prompt")?;
-    if sent.trim() != "true" {
-        return Err(MacosError::Other(format!(
-            "failed to trigger Gemini prompt submission: {sent}"
-        )));
+pub fn send_gemini_prompt(
+    prompt: &str,
+    profile_filter: Option<&str>,
+) -> Result<SafariAiResponseResult, MacosError> {
+    ensure_gemini_home(profile_filter)?;
+
+    let filled = execute_js_for_profile(
+        &build_gemini_fill_input_js(prompt),
+        profile_filter,
+        "safari_gemini_prompt_fill",
+    )?;
+    if filled.trim() != "true" {
+        return Err(MacosError::Other(format!("failed to fill Gemini input: {filled}")));
     }
+
+    wait_and_click_send(profile_filter)?;
 
     let mut last_text = String::new();
     let mut stable_count = 0;
@@ -989,7 +1073,7 @@ pub fn send_gemini_prompt(prompt: &str) -> Result<SafariAiResponseResult, MacosE
 
     while Instant::now() < deadline {
         thread::sleep(Duration::from_secs(1));
-        let text = execute_js(&response_js, "safari_gemini_response")?;
+        let text = execute_js_for_profile(&response_js, profile_filter, "safari_gemini_response")?;
         let trimmed = text.trim();
         if should_skip_gemini_response(trimmed, prompt) {
             continue;
@@ -1024,16 +1108,24 @@ pub fn send_gemini_prompt(prompt: &str) -> Result<SafariAiResponseResult, MacosE
 }
 
 fn execute_js(js_code: &str, context: &str) -> Result<String, MacosError> {
-    let stdout = run_capture(&build_exec_script(js_code), context)?;
+    execute_js_for_profile(js_code, None, context)
+}
+
+fn execute_js_for_profile(
+    js_code: &str,
+    profile_filter: Option<&str>,
+    context: &str,
+) -> Result<String, MacosError> {
+    let stdout = run_capture(&build_exec_script_for_profile(js_code, profile_filter), context)?;
     Ok(decode_field(stdout.trim()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        GeminiMode, TAB_SEPARATOR, build_active_tab_script, build_close_script,
-        build_exec_script, build_gemini_chat_prompt_js, build_gemini_deep_research_confirm_js,
-        build_gemini_deep_research_plan_js, build_gemini_mode_switch_js, build_open_script,
+        TAB_SEPARATOR, build_active_tab_script, build_close_script,
+        build_exec_script, build_gemini_fill_input_js, build_gemini_go_home_js,
+        build_open_script,
         build_tab_return_block, build_tabs_script, extract_profile, gemini_deep_research_poll_js,
         gemini_response_extract_js, parse_deep_research_payload, parse_tab_line,
         parse_tabs_output, selector_click_js, selector_fill_js, selector_text_js,
@@ -1104,7 +1196,7 @@ mod tests {
 
     #[test]
     fn build_active_tab_script_targets_front_window() {
-        let script = build_active_tab_script();
+        let script = build_active_tab_script(None);
 
         assert!(script.contains("set w to front window"));
         assert!(script.contains("set t to current tab of w"));
@@ -1142,34 +1234,12 @@ mod tests {
     }
 
     #[test]
-    fn gemini_mode_switch_script_targets_requested_mode() {
-        let script = build_gemini_mode_switch_js(GeminiMode::DeepResearch);
-
-        assert!(script.contains("Deep Research"));
-        assert!(script.contains("What do you want to research?"));
-        assert!(script.contains("你想研究什麼？"));
-        assert!(script.contains("document.querySelector"));
-    }
-
-    #[test]
-    fn gemini_chat_prompt_script_targets_editor_and_send() {
-        let script = build_gemini_chat_prompt_js("hello world");
+    fn gemini_fill_input_script_targets_editor() {
+        let script = build_gemini_fill_input_js("hello world");
 
         assert!(script.contains(".ql-editor"));
         assert!(script.contains("hello world"));
-        assert!(script.contains("KeyboardEvent"));
-        assert!(script.contains("傳送訊息"));
-        assert!(script.contains("Send message"));
-    }
-
-    #[test]
-    fn gemini_deep_research_plan_script_targets_plan_controls() {
-        let script = build_gemini_deep_research_plan_js("研究主題");
-
-        assert!(script.contains("研究主題"));
-        assert!(script.contains("開始研究"));
-        assert!(script.contains("Start research"));
-        assert!(script.contains("編輯計畫"));
+        assert!(script.contains("execCommand"));
     }
 
     #[test]
@@ -1180,14 +1250,14 @@ mod tests {
         assert!(script.contains("running"));
         assert!(script.contains("complete"));
         assert!(script.contains("開始研究"));
+        assert!(script.contains("編輯計畫"));
     }
 
     #[test]
-    fn gemini_deep_research_confirm_script_targets_confirm_button() {
-        let script = build_gemini_deep_research_confirm_js();
+    fn gemini_go_home_script_targets_root_app() {
+        let script = build_gemini_go_home_js();
 
-        assert!(script.contains("開始研究"));
-        assert!(script.contains("Start research"));
+        assert!(script.contains("gemini.google.com/app"));
     }
 
     #[test]
@@ -1198,6 +1268,17 @@ mod tests {
         assert_eq!(result.status, "plan_ready");
         assert_eq!(result.plan.as_deref(), Some("Outline"));
         assert_eq!(result.actions, vec!["confirm".to_string(), "edit".to_string()]);
+    }
+
+    #[test]
+    fn parse_deep_research_payload_reads_running_without_plan() {
+        let payload = r#"{"status":"running"}"#;
+        let result = parse_deep_research_payload(payload).expect("parse payload");
+
+        assert_eq!(result.status, "running");
+        assert_eq!(result.plan, None);
+        assert_eq!(result.response, None);
+        assert!(result.actions.is_empty());
     }
 
     #[test]

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -817,29 +817,40 @@ pub fn gemini_save_images(
     Ok(saved)
 }
 
-pub fn gemini_get_video_url(
+pub fn gemini_save_media(
     conversation_url: &str,
     profile_filter: Option<&str>,
-) -> Result<Option<String>, MacosError> {
+) -> Result<SafariAiResponseResult, MacosError> {
     let nav_js = format!(
         r#"(function() {{ window.location.href = "{url}"; return "true"; }})()"#,
         url = escape_js_string(conversation_url),
     );
-    let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_gemini_video_navigate")?;
-    thread::sleep(Duration::from_millis(3000));
+    let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_gemini_media_navigate")?;
+    thread::sleep(Duration::from_millis(5000));
 
     let js = r#"(() => {
         const video = document.querySelector("video");
-        if (!video) return "";
-        return video.src || video.currentSrc || "";
+        if (!video) return JSON.stringify({ status: "error", response: "no media found" });
+        const src = video.src || video.currentSrc || "";
+        if (!src) return JSON.stringify({ status: "error", response: "no media source" });
+        const a = document.createElement("a");
+        a.href = src;
+        a.download = "gemini_media.mp4";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        return JSON.stringify({ status: "downloading", response: src });
     })()"#;
-    let url = execute_js_for_profile(js, profile_filter, "safari_gemini_video_url")?;
-    let url = url.trim();
-    if url.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(url.to_string()))
-    }
+    let raw = execute_js_for_profile(js, profile_filter, "safari_gemini_media_download")?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| MacosError::Other(format!("failed to parse media result: {e}")))?;
+    let status = value.get("status").and_then(|v| v.as_str()).unwrap_or("error");
+    let response = value.get("response").and_then(|v| v.as_str()).unwrap_or("");
+    Ok(SafariAiResponseResult {
+        provider: "gemini".to_string(),
+        status: status.to_string(),
+        response: response.to_string(),
+    })
 }
 
 pub fn capture(since: DateTime<Utc>) -> Result<Vec<Cue>, MacosError> {

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -1114,6 +1114,8 @@ pub fn start_gemini_deep_research(
             return Err(MacosError::Other("failed to fill confirm text".to_string()));
         }
         wait_and_click_send(profile_filter)?;
+        // Wait for page to transition from plan_ready to running state
+        thread::sleep(Duration::from_secs(3));
         let mut final_result = poll_gemini_deep_research(900, profile_filter)?;
         final_result.conversation_url = conv_url;
         Ok(final_result)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -343,8 +343,8 @@ enum SafariAction {
         profile: Option<String>,
     },
 
-    /// Get the video download URL from a Gemini conversation
-    AiVideoUrl {
+    /// Download media (video/music) from a Gemini conversation via browser
+    AiSaveMedia {
         /// Conversation URL
         url: String,
         /// Restrict operations to a Safari profile name parsed from the window title
@@ -1113,15 +1113,11 @@ fn main() {
                     }
                 }
             }
-            SafariAction::AiVideoUrl { url, profile } => {
-                match cueward_adapter_macos::safari::gemini_get_video_url(&url, profile.as_deref()) {
-                    Ok(Some(video_url)) => {
-                        println!("{}", serde_json::to_string_pretty(&serde_json::json!({ "url": video_url })).unwrap());
-                        eprintln!("video URL found");
-                    }
-                    Ok(None) => {
-                        eprintln!("no video found in conversation");
-                        process::exit(1);
+            SafariAction::AiSaveMedia { url, profile } => {
+                match cueward_adapter_macos::safari::gemini_save_media(&url, profile.as_deref()) {
+                    Ok(result) => {
+                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("media download triggered");
                     }
                     Err(e) => {
                         eprintln!("error: {e}");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -209,6 +209,53 @@ enum GeminiMode {
 }
 
 #[derive(Subcommand)]
+enum SafariAiAction {
+    /// Send a prompt to the AI provider
+    Prompt {
+        /// Prompt text
+        #[arg(long)]
+        prompt: String,
+        /// Optional mode (e.g. deep-research, image, video, music)
+        #[arg(long)]
+        mode: Option<GeminiMode>,
+        /// Automatically confirm (e.g. Deep Research plan)
+        #[arg(long, default_value_t = false)]
+        auto_confirm: bool,
+    },
+    /// Switch to a specific mode without sending a prompt
+    Mode {
+        /// Mode to switch into
+        mode: GeminiMode,
+    },
+    /// List conversations from the sidebar
+    List,
+    /// Read a conversation's text content by URL
+    Read {
+        /// Conversation URL
+        url: String,
+    },
+    /// Poll an in-progress workflow (e.g. Deep Research)
+    Poll {
+        /// Timeout in seconds
+        #[arg(long, default_value = "900")]
+        timeout: u64,
+    },
+    /// Save AI-generated images as PNG files
+    SaveImages {
+        /// Conversation URL
+        url: String,
+        /// Output directory
+        #[arg(long, default_value = ".")]
+        output: String,
+    },
+    /// Download media (video/music) via browser
+    SaveMedia {
+        /// Conversation URL
+        url: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum SafariAction {
     /// List all current Safari tabs
     Tabs {
@@ -289,7 +336,7 @@ enum SafariAction {
         timeout: u64,
     },
 
-    /// Run a high-level Safari AI workflow
+    /// Safari AI provider workflows
     Ai {
         /// AI provider to target
         #[arg(long)]
@@ -297,59 +344,8 @@ enum SafariAction {
         /// Restrict operations to a Safari profile name parsed from the window title
         #[arg(long)]
         profile: Option<String>,
-        /// Optional Gemini mode to switch into before interaction
-        #[arg(long)]
-        mode: Option<GeminiMode>,
-        /// Prompt to send in a later workflow stage
-        #[arg(long)]
-        prompt: Option<String>,
-        /// Automatically confirm the Deep Research plan when available
-        #[arg(long, default_value_t = false)]
-        auto_confirm: bool,
-    },
-
-    /// Poll an in-progress Safari AI workflow
-    AiPoll {
-        /// Timeout in seconds
-        #[arg(long, default_value = "900")]
-        timeout: u64,
-    },
-
-    /// List Gemini conversations from the sidebar
-    AiList {
-        /// Restrict operations to a Safari profile name parsed from the window title
-        #[arg(long)]
-        profile: Option<String>,
-    },
-
-    /// Read a Gemini conversation by URL
-    AiRead {
-        /// Conversation URL (e.g. https://gemini.google.com/app/abc123)
-        url: String,
-        /// Restrict operations to a Safari profile name parsed from the window title
-        #[arg(long)]
-        profile: Option<String>,
-    },
-
-    /// Save AI-generated images from a Gemini conversation as PNG files
-    AiSaveImages {
-        /// Conversation URL
-        url: String,
-        /// Output directory for saved images
-        #[arg(long, default_value = ".")]
-        output: String,
-        /// Restrict operations to a Safari profile name parsed from the window title
-        #[arg(long)]
-        profile: Option<String>,
-    },
-
-    /// Download media (video/music) from a Gemini conversation via browser
-    AiSaveMedia {
-        /// Conversation URL
-        url: String,
-        /// Restrict operations to a Safari profile name parsed from the window title
-        #[arg(long)]
-        profile: Option<String>,
+        #[command(subcommand)]
+        action: SafariAiAction,
     },
 }
 
@@ -971,156 +967,79 @@ fn main() {
                     }
                 }
             }
-            SafariAction::Ai {
-                provider,
-                profile,
-                mode,
-                prompt,
-                auto_confirm,
-                ..
-            } => match provider {
-                SafariAiProvider::Gemini => {
-                    let action = match build_gemini_ai_action(mode, prompt.as_deref(), auto_confirm) {
-                        Ok(action) => action,
-                        Err(err) => {
-                            eprintln!("error: {err}");
-                            process::exit(1);
-                        }
-                    };
-
-                    match action {
-                        GeminiAiAction::ModeOnly(mode) => {
-                            match cueward_adapter_macos::safari::prepare_gemini_mode(
-                                to_adapter_gemini_mode(mode),
-                                profile.as_deref(),
-                            ) {
-                                Ok(result) => {
-                                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                                    eprintln!("gemini mode ready");
+            SafariAction::Ai { provider, profile, action } => {
+                let p = profile.as_deref();
+                match provider {
+                    SafariAiProvider::Gemini => match action {
+                        SafariAiAction::Prompt { prompt, mode, auto_confirm } => {
+                            let gemini_action = match build_gemini_ai_action(mode, Some(&prompt), auto_confirm) {
+                                Ok(a) => a,
+                                Err(err) => { eprintln!("error: {err}"); process::exit(1); }
+                            };
+                            match gemini_action {
+                                GeminiAiAction::PromptOnly(prompt) => {
+                                    match cueward_adapter_macos::safari::send_gemini_prompt(&prompt, p) {
+                                        Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("gemini response ready"); }
+                                        Err(e) => { eprintln!("error: {e}"); process::exit(1); }
+                                    }
                                 }
-                                Err(e) => {
-                                    eprintln!("error: {e}");
-                                    process::exit(1);
+                                GeminiAiAction::ModeThenPrompt(mode, prompt) => {
+                                    if let Err(e) = cueward_adapter_macos::safari::prepare_gemini_mode(to_adapter_gemini_mode(mode), p) {
+                                        eprintln!("error: {e}"); process::exit(1);
+                                    }
+                                    match cueward_adapter_macos::safari::send_gemini_prompt(&prompt, p) {
+                                        Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("gemini response ready"); }
+                                        Err(e) => { eprintln!("error: {e}"); process::exit(1); }
+                                    }
                                 }
+                                GeminiAiAction::DeepResearchPlan(prompt, auto_confirm) => {
+                                    match cueward_adapter_macos::safari::start_gemini_deep_research(&prompt, auto_confirm, p) {
+                                        Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("gemini deep research state ready"); }
+                                        Err(e) => { eprintln!("error: {e}"); process::exit(1); }
+                                    }
+                                }
+                                GeminiAiAction::ModeOnly(_) => unreachable!(),
                             }
                         }
-                        GeminiAiAction::PromptOnly(prompt) => {
-                            match cueward_adapter_macos::safari::send_gemini_prompt(
-                                &prompt,
-                                profile.as_deref(),
-                            ) {
-                                Ok(result) => {
-                                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                                    eprintln!("gemini response ready");
-                                }
-                                Err(e) => {
-                                    eprintln!("error: {e}");
-                                    process::exit(1);
-                                }
+                        SafariAiAction::Mode { mode } => {
+                            match cueward_adapter_macos::safari::prepare_gemini_mode(to_adapter_gemini_mode(mode), p) {
+                                Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("gemini mode ready"); }
+                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
                             }
                         }
-                        GeminiAiAction::ModeThenPrompt(mode, prompt) => {
-                            if let Err(e) = cueward_adapter_macos::safari::prepare_gemini_mode(
-                                to_adapter_gemini_mode(mode),
-                                profile.as_deref(),
-                            ) {
-                                eprintln!("error: {e}");
-                                process::exit(1);
-                            }
-
-                            match cueward_adapter_macos::safari::send_gemini_prompt(
-                                &prompt,
-                                profile.as_deref(),
-                            ) {
-                                Ok(result) => {
-                                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                                    eprintln!("gemini response ready");
-                                }
-                                Err(e) => {
-                                    eprintln!("error: {e}");
-                                    process::exit(1);
-                                }
+                        SafariAiAction::List => {
+                            match cueward_adapter_macos::safari::gemini_list_conversations(p) {
+                                Ok(convos) => { println!("{}", serde_json::to_string_pretty(&convos).unwrap()); eprintln!("{} conversation(s)", convos.len()); }
+                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
                             }
                         }
-                        GeminiAiAction::DeepResearchPlan(prompt, auto_confirm) => {
-                            match cueward_adapter_macos::safari::start_gemini_deep_research(
-                                &prompt,
-                                auto_confirm,
-                                profile.as_deref(),
-                            ) {
-                                Ok(result) => {
-                                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                                    eprintln!("gemini deep research state ready");
-                                }
-                                Err(e) => {
-                                    eprintln!("error: {e}");
-                                    process::exit(1);
-                                }
+                        SafariAiAction::Read { url } => {
+                            match cueward_adapter_macos::safari::gemini_read_conversation(&url, p) {
+                                Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("conversation read"); }
+                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
                             }
                         }
-                    }
-                }
-                SafariAiProvider::Chatgpt => {
-                    eprintln!("error: ChatGPT Safari AI workflow not implemented yet");
-                    process::exit(1);
-                }
-            },
-                        SafariAction::AiPoll { timeout } => {
-                match cueward_adapter_macos::safari::poll_gemini_deep_research(timeout, None) {
-                    Ok(result) => {
-                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                        eprintln!("gemini deep research polled");
-                    }
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        process::exit(1);
-                    }
-                }
-            }
-            SafariAction::AiList { profile } => {
-                match cueward_adapter_macos::safari::gemini_list_conversations(profile.as_deref()) {
-                    Ok(convos) => {
-                        println!("{}", serde_json::to_string_pretty(&convos).unwrap());
-                        eprintln!("{} conversation(s)", convos.len());
-                    }
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        process::exit(1);
-                    }
-                }
-            }
-            SafariAction::AiRead { url, profile } => {
-                match cueward_adapter_macos::safari::gemini_read_conversation(&url, profile.as_deref()) {
-                    Ok(result) => {
-                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                        eprintln!("conversation read");
-                    }
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        process::exit(1);
-                    }
-                }
-            }
-            SafariAction::AiSaveImages { url, output, profile } => {
-                match cueward_adapter_macos::safari::gemini_save_images(&url, &output, profile.as_deref()) {
-                    Ok(paths) => {
-                        println!("{}", serde_json::to_string_pretty(&paths).unwrap());
-                        eprintln!("{} image(s) saved", paths.len());
-                    }
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        process::exit(1);
-                    }
-                }
-            }
-            SafariAction::AiSaveMedia { url, profile } => {
-                match cueward_adapter_macos::safari::gemini_save_media(&url, profile.as_deref()) {
-                    Ok(result) => {
-                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                        eprintln!("media download triggered");
-                    }
-                    Err(e) => {
-                        eprintln!("error: {e}");
+                        SafariAiAction::Poll { timeout } => {
+                            match cueward_adapter_macos::safari::poll_gemini_deep_research(timeout, p) {
+                                Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("polled"); }
+                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
+                            }
+                        }
+                        SafariAiAction::SaveImages { url, output } => {
+                            match cueward_adapter_macos::safari::gemini_save_images(&url, &output, p) {
+                                Ok(paths) => { println!("{}", serde_json::to_string_pretty(&paths).unwrap()); eprintln!("{} image(s) saved", paths.len()); }
+                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
+                            }
+                        }
+                        SafariAiAction::SaveMedia { url } => {
+                            match cueward_adapter_macos::safari::gemini_save_media(&url, p) {
+                                Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("media download triggered"); }
+                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
+                            }
+                        }
+                    },
+                    SafariAiProvider::Chatgpt => {
+                        eprintln!("error: ChatGPT not implemented yet");
                         process::exit(1);
                     }
                 }
@@ -1398,7 +1317,7 @@ mod tests {
     use clap::Parser;
 
     use super::{
-        Cli, Command, GeminiAiAction, GeminiMode, SafariAction, SafariAiProvider,
+        Cli, Command, GeminiAiAction, GeminiMode, SafariAction, SafariAiAction, SafariAiProvider,
         build_gemini_ai_action, local_day_bounds, validate_optional_output_path,
     };
 
@@ -1480,35 +1399,17 @@ mod tests {
     }
 
     #[test]
-    fn cli_parses_gemini_mode_switch_command() {
+    fn cli_parses_gemini_prompt_with_mode() {
         let cli = Cli::try_parse_from([
-            "cueward",
-            "safari",
-            "ai",
-            "--provider",
-            "gemini",
-            "--mode",
-            "deep-research",
-            "--prompt",
-            "研究議題",
-        ])
-        .expect("parse safari ai command");
+            "cueward", "safari", "ai", "--provider", "gemini",
+            "prompt", "--prompt", "研究議題", "--mode", "deep-research",
+        ]).expect("parse");
 
         match cli.command {
-            Command::Safari {
-                action:
-                    SafariAction::Ai {
-                        provider,
-                        profile: _,
-                        mode,
-                        prompt,
-                        auto_confirm,
-                        ..
-                    },
-            } => {
+            Command::Safari { action: SafariAction::Ai { provider, action: SafariAiAction::Prompt { prompt, mode, auto_confirm }, .. } } => {
                 assert_eq!(provider, SafariAiProvider::Gemini);
+                assert_eq!(prompt, "研究議題");
                 assert_eq!(mode, Some(GeminiMode::DeepResearch));
-                assert_eq!(prompt, Some("研究議題".to_string()));
                 assert!(!auto_confirm);
             }
             _ => panic!("unexpected command"),
@@ -1516,34 +1417,75 @@ mod tests {
     }
 
     #[test]
-    fn cli_parses_gemini_chat_command() {
+    fn cli_parses_gemini_prompt_only() {
         let cli = Cli::try_parse_from([
-            "cueward",
-            "safari",
-            "ai",
-            "--provider",
-            "gemini",
-            "--prompt",
-            "哈囉",
-        ])
-        .expect("parse gemini chat command");
+            "cueward", "safari", "ai", "--provider", "gemini",
+            "prompt", "--prompt", "哈囉",
+        ]).expect("parse");
 
         match cli.command {
-            Command::Safari {
-                action:
-                    SafariAction::Ai {
-                        provider,
-                        profile: _,
-                        mode,
-                        prompt,
-                        auto_confirm,
-                        ..
-                    },
-            } => {
-                assert_eq!(provider, SafariAiProvider::Gemini);
+            Command::Safari { action: SafariAction::Ai { action: SafariAiAction::Prompt { prompt, mode, .. }, .. } } => {
+                assert_eq!(prompt, "哈囉");
                 assert_eq!(mode, None);
-                assert_eq!(prompt, Some("哈囉".to_string()));
-                assert!(!auto_confirm);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_gemini_auto_confirm() {
+        let cli = Cli::try_parse_from([
+            "cueward", "safari", "ai", "--provider", "gemini",
+            "prompt", "--prompt", "研究主題", "--mode", "deep-research", "--auto-confirm",
+        ]).expect("parse");
+
+        match cli.command {
+            Command::Safari { action: SafariAction::Ai { action: SafariAiAction::Prompt { auto_confirm, .. }, .. } } => {
+                assert!(auto_confirm);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_gemini_list() {
+        let cli = Cli::try_parse_from([
+            "cueward", "safari", "ai", "--provider", "gemini", "list",
+        ]).expect("parse");
+
+        match cli.command {
+            Command::Safari { action: SafariAction::Ai { provider, action: SafariAiAction::List, .. } } => {
+                assert_eq!(provider, SafariAiProvider::Gemini);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_gemini_poll() {
+        let cli = Cli::try_parse_from([
+            "cueward", "safari", "ai", "--provider", "gemini",
+            "poll", "--timeout", "120",
+        ]).expect("parse");
+
+        match cli.command {
+            Command::Safari { action: SafariAction::Ai { action: SafariAiAction::Poll { timeout }, .. } } => {
+                assert_eq!(timeout, 120);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_gemini_with_profile() {
+        let cli = Cli::try_parse_from([
+            "cueward", "safari", "ai", "--provider", "gemini", "--profile", "Ryugu",
+            "prompt", "--prompt", "hi",
+        ]).expect("parse");
+
+        match cli.command {
+            Command::Safari { action: SafariAction::Ai { profile, .. } } => {
+                assert_eq!(profile.as_deref(), Some("Ryugu"));
             }
             _ => panic!("unexpected command"),
         }
@@ -1558,115 +1500,10 @@ mod tests {
     }
 
     #[test]
-    fn build_gemini_ai_action_requires_mode_or_prompt() {
-        assert_eq!(
-            build_gemini_ai_action(None, None, false),
-            Err("--mode or --prompt is required for Gemini Safari AI workflow")
-        );
-    }
-
-    #[test]
     fn build_gemini_ai_action_rejects_invalid_auto_confirm_usage() {
         assert_eq!(
             build_gemini_ai_action(Some(GeminiMode::Image), None, true),
             Err("--auto-confirm requires --mode deep-research and --prompt")
         );
-        assert_eq!(
-            build_gemini_ai_action(None, Some("hi"), true),
-            Err("--auto-confirm requires --mode deep-research and --prompt")
-        );
-    }
-
-    #[test]
-    fn cli_parses_gemini_ai_with_profile() {
-        let cli = Cli::try_parse_from([
-            "cueward",
-            "safari",
-            "ai",
-            "--provider",
-            "gemini",
-            "--profile",
-            "Ryugu",
-            "--prompt",
-            "hi",
-        ])
-        .expect("parse safari ai with profile");
-
-        match cli.command {
-            Command::Safari {
-                action:
-                    SafariAction::Ai {
-                        provider,
-                        profile,
-                        mode,
-                        prompt,
-                        auto_confirm,
-                        ..
-                    },
-            } => {
-                assert_eq!(provider, SafariAiProvider::Gemini);
-                assert_eq!(profile.as_deref(), Some("Ryugu"));
-                assert_eq!(mode, None);
-                assert_eq!(prompt.as_deref(), Some("hi"));
-                assert!(!auto_confirm);
-            }
-            _ => panic!("unexpected command"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_gemini_deep_research_auto_confirm_command() {
-        let cli = Cli::try_parse_from([
-            "cueward",
-            "safari",
-            "ai",
-            "--provider",
-            "gemini",
-            "--mode",
-            "deep-research",
-            "--prompt",
-            "研究主題",
-            "--auto-confirm",
-        ])
-        .expect("parse deep research command");
-
-        match cli.command {
-            Command::Safari {
-                action:
-                    SafariAction::Ai {
-                        provider,
-                        profile: _,
-                        mode,
-                        prompt,
-                        auto_confirm,
-                        ..
-                    },
-            } => {
-                assert_eq!(provider, SafariAiProvider::Gemini);
-                assert_eq!(mode, Some(GeminiMode::DeepResearch));
-                assert_eq!(prompt, Some("研究主題".to_string()));
-                assert!(auto_confirm);
-            }
-            _ => panic!("unexpected command"),
-        }
-    }
-
-    #[test]
-    fn cli_parses_safari_ai_poll_command() {
-        let cli = Cli::try_parse_from([
-            "cueward",
-            "safari",
-            "ai-poll",
-            "--timeout",
-            "120",
-        ])
-        .expect("parse ai-poll command");
-
-        match cli.command {
-            Command::Safari {
-                action: SafariAction::AiPoll { timeout },
-            } => assert_eq!(timeout, 120),
-            _ => panic!("unexpected command"),
-        }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -871,7 +871,7 @@ fn main() {
                     process::exit(1);
                 }
             },
-            SafariAction::Open { url, .. } => match cueward_adapter_macos::safari::open(&url) {
+            SafariAction::Open { url, profile } => match cueward_adapter_macos::safari::open(&url, profile.as_deref()) {
                 Ok(tab) => {
                     println!("{}", serde_json::to_string_pretty(&tab).unwrap());
                     if tab.is_some() {
@@ -911,7 +911,7 @@ fn main() {
                     }
                 }
             }
-            SafariAction::Source { .. } => match cueward_adapter_macos::safari::source() {
+            SafariAction::Source { profile } => match cueward_adapter_macos::safari::source(profile.as_deref()) {
                 Ok(result) => {
                     println!("{}", serde_json::to_string_pretty(&result).unwrap());
                     eprintln!("read page source");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -218,12 +218,19 @@ enum SafariAction {
     },
 
     /// Show the current active tab in the front Safari window
-    Active,
+    Active {
+        /// Restrict operations to a Safari profile name parsed from the window title
+        #[arg(long)]
+        profile: Option<String>,
+    },
 
     /// Open a URL in a new Safari tab
     Open {
         /// URL to open
         url: String,
+        /// Restrict operations to a Safari profile name parsed from the window title
+        #[arg(long)]
+        profile: Option<String>,
     },
 
     /// Close a tab in the front Safari window
@@ -238,15 +245,25 @@ enum SafariAction {
         /// Optional CSS selector to extract a specific element's text
         #[arg(long)]
         selector: Option<String>,
+        /// Restrict operations to a Safari profile name parsed from the window title
+        #[arg(long)]
+        profile: Option<String>,
     },
 
     /// Read the full HTML source of the current active tab
-    Source,
+    Source {
+        /// Restrict operations to a Safari profile name parsed from the window title
+        #[arg(long)]
+        profile: Option<String>,
+    },
 
     /// Execute JavaScript in the current active tab
     Exec {
         /// JavaScript code to execute
         js_code: String,
+        /// Restrict operations to a Safari profile name parsed from the window title
+        #[arg(long)]
+        profile: Option<String>,
     },
 
     /// Click an element in the current active tab
@@ -277,6 +294,9 @@ enum SafariAction {
         /// AI provider to target
         #[arg(long)]
         provider: SafariAiProvider,
+        /// Restrict operations to a Safari profile name parsed from the window title
+        #[arg(long)]
+        profile: Option<String>,
         /// Optional Gemini mode to switch into before interaction
         #[arg(long)]
         mode: Option<GeminiMode>,
@@ -293,6 +313,22 @@ enum SafariAction {
         /// Timeout in seconds
         #[arg(long, default_value = "900")]
         timeout: u64,
+    },
+
+    /// List Gemini conversations from the sidebar
+    AiList {
+        /// Restrict operations to a Safari profile name parsed from the window title
+        #[arg(long)]
+        profile: Option<String>,
+    },
+
+    /// Read a Gemini conversation by URL
+    AiRead {
+        /// Conversation URL (e.g. https://gemini.google.com/app/abc123)
+        url: String,
+        /// Restrict operations to a Safari profile name parsed from the window title
+        #[arg(long)]
+        profile: Option<String>,
     },
 }
 
@@ -804,7 +840,7 @@ fn main() {
                     }
                 }
             }
-            SafariAction::Active => match cueward_adapter_macos::safari::active() {
+            SafariAction::Active { profile } => match cueward_adapter_macos::safari::active(profile.as_deref()) {
                 Ok(tab) => {
                     println!("{}", serde_json::to_string_pretty(&tab).unwrap());
                     if tab.is_some() {
@@ -818,7 +854,7 @@ fn main() {
                     process::exit(1);
                 }
             },
-            SafariAction::Open { url } => match cueward_adapter_macos::safari::open(&url) {
+            SafariAction::Open { url, .. } => match cueward_adapter_macos::safari::open(&url) {
                 Ok(tab) => {
                     println!("{}", serde_json::to_string_pretty(&tab).unwrap());
                     if tab.is_some() {
@@ -846,7 +882,7 @@ fn main() {
                     process::exit(1);
                 }
             },
-            SafariAction::Read { selector } => {
+            SafariAction::Read { selector, .. } => {
                 match cueward_adapter_macos::safari::read(selector.as_deref()) {
                     Ok(result) => {
                         println!("{}", serde_json::to_string_pretty(&result).unwrap());
@@ -858,7 +894,7 @@ fn main() {
                     }
                 }
             }
-            SafariAction::Source => match cueward_adapter_macos::safari::source() {
+            SafariAction::Source { .. } => match cueward_adapter_macos::safari::source() {
                 Ok(result) => {
                     println!("{}", serde_json::to_string_pretty(&result).unwrap());
                     eprintln!("read page source");
@@ -868,7 +904,7 @@ fn main() {
                     process::exit(1);
                 }
             },
-            SafariAction::Exec { js_code } => match cueward_adapter_macos::safari::exec(&js_code) {
+            SafariAction::Exec { js_code, profile } => match cueward_adapter_macos::safari::exec(&js_code, profile.as_deref()) {
                 Ok(result) => {
                     println!("{}", serde_json::to_string_pretty(&result).unwrap());
                     eprintln!("executed javascript");
@@ -916,9 +952,11 @@ fn main() {
             }
             SafariAction::Ai {
                 provider,
+                profile,
                 mode,
                 prompt,
                 auto_confirm,
+                ..
             } => match provider {
                 SafariAiProvider::Gemini => {
                     let action = match build_gemini_ai_action(mode, prompt.as_deref(), auto_confirm) {
@@ -933,6 +971,7 @@ fn main() {
                         GeminiAiAction::ModeOnly(mode) => {
                             match cueward_adapter_macos::safari::prepare_gemini_mode(
                                 to_adapter_gemini_mode(mode),
+                                profile.as_deref(),
                             ) {
                                 Ok(result) => {
                                     println!("{}", serde_json::to_string_pretty(&result).unwrap());
@@ -945,7 +984,10 @@ fn main() {
                             }
                         }
                         GeminiAiAction::PromptOnly(prompt) => {
-                            match cueward_adapter_macos::safari::send_gemini_prompt(&prompt) {
+                            match cueward_adapter_macos::safari::send_gemini_prompt(
+                                &prompt,
+                                profile.as_deref(),
+                            ) {
                                 Ok(result) => {
                                     println!("{}", serde_json::to_string_pretty(&result).unwrap());
                                     eprintln!("gemini response ready");
@@ -959,12 +1001,16 @@ fn main() {
                         GeminiAiAction::ModeThenPrompt(mode, prompt) => {
                             if let Err(e) = cueward_adapter_macos::safari::prepare_gemini_mode(
                                 to_adapter_gemini_mode(mode),
+                                profile.as_deref(),
                             ) {
                                 eprintln!("error: {e}");
                                 process::exit(1);
                             }
 
-                            match cueward_adapter_macos::safari::send_gemini_prompt(&prompt) {
+                            match cueward_adapter_macos::safari::send_gemini_prompt(
+                                &prompt,
+                                profile.as_deref(),
+                            ) {
                                 Ok(result) => {
                                     println!("{}", serde_json::to_string_pretty(&result).unwrap());
                                     eprintln!("gemini response ready");
@@ -979,6 +1025,7 @@ fn main() {
                             match cueward_adapter_macos::safari::start_gemini_deep_research(
                                 &prompt,
                                 auto_confirm,
+                                profile.as_deref(),
                             ) {
                                 Ok(result) => {
                                     println!("{}", serde_json::to_string_pretty(&result).unwrap());
@@ -998,10 +1045,34 @@ fn main() {
                 }
             },
                         SafariAction::AiPoll { timeout } => {
-                match cueward_adapter_macos::safari::poll_gemini_deep_research(timeout) {
+                match cueward_adapter_macos::safari::poll_gemini_deep_research(timeout, None) {
                     Ok(result) => {
                         println!("{}", serde_json::to_string_pretty(&result).unwrap());
                         eprintln!("gemini deep research polled");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            SafariAction::AiList { profile } => {
+                match cueward_adapter_macos::safari::gemini_list_conversations(profile.as_deref()) {
+                    Ok(convos) => {
+                        println!("{}", serde_json::to_string_pretty(&convos).unwrap());
+                        eprintln!("{} conversation(s)", convos.len());
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            SafariAction::AiRead { url, profile } => {
+                match cueward_adapter_macos::safari::gemini_read_conversation(&url, profile.as_deref()) {
+                    Ok(result) => {
+                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("conversation read");
                     }
                     Err(e) => {
                         eprintln!("error: {e}");
@@ -1321,6 +1392,49 @@ mod tests {
     }
 
     #[test]
+    fn cli_parses_safari_exec_with_profile() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "exec",
+            "--profile",
+            "Ryugu",
+            "1+1",
+        ])
+        .expect("parse safari exec with profile");
+
+        match cli.command {
+            Command::Safari {
+                action: SafariAction::Exec { js_code, profile },
+            } => {
+                assert_eq!(js_code, "1+1");
+                assert_eq!(profile.as_deref(), Some("Ryugu"));
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+
+    #[test]
+    fn cli_parses_safari_active_with_profile() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "active",
+            "--profile",
+            "Ryugu",
+        ])
+        .expect("parse safari active with profile");
+
+        match cli.command {
+            Command::Safari {
+                action: SafariAction::Active { profile },
+            } => assert_eq!(profile.as_deref(), Some("Ryugu")),
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
     fn cli_parses_gemini_mode_switch_command() {
         let cli = Cli::try_parse_from([
             "cueward",
@@ -1340,9 +1454,11 @@ mod tests {
                 action:
                     SafariAction::Ai {
                         provider,
+                        profile: _,
                         mode,
                         prompt,
                         auto_confirm,
+                        ..
                     },
             } => {
                 assert_eq!(provider, SafariAiProvider::Gemini);
@@ -1372,9 +1488,11 @@ mod tests {
                 action:
                     SafariAction::Ai {
                         provider,
+                        profile: _,
                         mode,
                         prompt,
                         auto_confirm,
+                        ..
                     },
             } => {
                 assert_eq!(provider, SafariAiProvider::Gemini);
@@ -1415,6 +1533,43 @@ mod tests {
     }
 
     #[test]
+    fn cli_parses_gemini_ai_with_profile() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "gemini",
+            "--profile",
+            "Ryugu",
+            "--prompt",
+            "hi",
+        ])
+        .expect("parse safari ai with profile");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        profile,
+                        mode,
+                        prompt,
+                        auto_confirm,
+                        ..
+                    },
+            } => {
+                assert_eq!(provider, SafariAiProvider::Gemini);
+                assert_eq!(profile.as_deref(), Some("Ryugu"));
+                assert_eq!(mode, None);
+                assert_eq!(prompt.as_deref(), Some("hi"));
+                assert!(!auto_confirm);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
     fn cli_parses_gemini_deep_research_auto_confirm_command() {
         let cli = Cli::try_parse_from([
             "cueward",
@@ -1435,9 +1590,11 @@ mod tests {
                 action:
                     SafariAction::Ai {
                         provider,
+                        profile: _,
                         mode,
                         prompt,
                         auto_confirm,
+                        ..
                     },
             } => {
                 assert_eq!(provider, SafariAiProvider::Gemini);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -330,6 +330,27 @@ enum SafariAction {
         #[arg(long)]
         profile: Option<String>,
     },
+
+    /// Save AI-generated images from a Gemini conversation as PNG files
+    AiSaveImages {
+        /// Conversation URL
+        url: String,
+        /// Output directory for saved images
+        #[arg(long, default_value = ".")]
+        output: String,
+        /// Restrict operations to a Safari profile name parsed from the window title
+        #[arg(long)]
+        profile: Option<String>,
+    },
+
+    /// Get the video download URL from a Gemini conversation
+    AiVideoUrl {
+        /// Conversation URL
+        url: String,
+        /// Restrict operations to a Safari profile name parsed from the window title
+        #[arg(long)]
+        profile: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1073,6 +1094,34 @@ fn main() {
                     Ok(result) => {
                         println!("{}", serde_json::to_string_pretty(&result).unwrap());
                         eprintln!("conversation read");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            SafariAction::AiSaveImages { url, output, profile } => {
+                match cueward_adapter_macos::safari::gemini_save_images(&url, &output, profile.as_deref()) {
+                    Ok(paths) => {
+                        println!("{}", serde_json::to_string_pretty(&paths).unwrap());
+                        eprintln!("{} image(s) saved", paths.len());
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            SafariAction::AiVideoUrl { url, profile } => {
+                match cueward_adapter_macos::safari::gemini_get_video_url(&url, profile.as_deref()) {
+                    Ok(Some(video_url)) => {
+                        println!("{}", serde_json::to_string_pretty(&serde_json::json!({ "url": video_url })).unwrap());
+                        eprintln!("video URL found");
+                    }
+                    Ok(None) => {
+                        eprintln!("no video found in conversation");
+                        process::exit(1);
                     }
                     Err(e) => {
                         eprintln!("error: {e}");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -548,6 +548,12 @@ fn build_gemini_ai_action(
     prompt: Option<&str>,
     auto_confirm: bool,
 ) -> Result<GeminiAiAction, &'static str> {
+    if auto_confirm
+        && !matches!((&mode, prompt), (Some(GeminiMode::DeepResearch), Some(_)))
+    {
+        return Err("--auto-confirm requires --mode deep-research and --prompt");
+    }
+
     match (mode, prompt) {
         (Some(GeminiMode::DeepResearch), Some(prompt)) => {
             Ok(GeminiAiAction::DeepResearchPlan(prompt.to_string(), auto_confirm))
@@ -1393,6 +1399,18 @@ mod tests {
         assert_eq!(
             build_gemini_ai_action(None, None, false),
             Err("--mode or --prompt is required for Gemini Safari AI workflow")
+        );
+    }
+
+    #[test]
+    fn build_gemini_ai_action_rejects_invalid_auto_confirm_usage() {
+        assert_eq!(
+            build_gemini_ai_action(Some(GeminiMode::Image), None, true),
+            Err("--auto-confirm requires --mode deep-research and --prompt")
+        );
+        assert_eq!(
+            build_gemini_ai_action(None, Some("hi"), true),
+            Err("--auto-confirm requires --mode deep-research and --prompt")
         );
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -899,8 +899,8 @@ fn main() {
                     process::exit(1);
                 }
             },
-            SafariAction::Read { selector, .. } => {
-                match cueward_adapter_macos::safari::read(selector.as_deref()) {
+            SafariAction::Read { selector, profile } => {
+                match cueward_adapter_macos::safari::read(selector.as_deref(), profile.as_deref()) {
                     Ok(result) => {
                         println!("{}", serde_json::to_string_pretty(&result).unwrap());
                         eprintln!("read page content");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -283,6 +283,16 @@ enum SafariAction {
         /// Prompt to send in a later workflow stage
         #[arg(long)]
         prompt: Option<String>,
+        /// Automatically confirm the Deep Research plan when available
+        #[arg(long, default_value_t = false)]
+        auto_confirm: bool,
+    },
+
+    /// Poll an in-progress Safari AI workflow
+    AiPoll {
+        /// Timeout in seconds
+        #[arg(long, default_value = "900")]
+        timeout: u64,
     },
 }
 
@@ -530,13 +540,18 @@ enum GeminiAiAction {
     ModeOnly(GeminiMode),
     PromptOnly(String),
     ModeThenPrompt(GeminiMode, String),
+    DeepResearchPlan(String, bool),
 }
 
 fn build_gemini_ai_action(
     mode: Option<GeminiMode>,
     prompt: Option<&str>,
+    auto_confirm: bool,
 ) -> Result<GeminiAiAction, &'static str> {
     match (mode, prompt) {
+        (Some(GeminiMode::DeepResearch), Some(prompt)) => {
+            Ok(GeminiAiAction::DeepResearchPlan(prompt.to_string(), auto_confirm))
+        }
         (Some(mode), Some(prompt)) => Ok(GeminiAiAction::ModeThenPrompt(mode, prompt.to_string())),
         (Some(mode), None) => Ok(GeminiAiAction::ModeOnly(mode)),
         (None, Some(prompt)) => Ok(GeminiAiAction::PromptOnly(prompt.to_string())),
@@ -897,9 +912,10 @@ fn main() {
                 provider,
                 mode,
                 prompt,
+                auto_confirm,
             } => match provider {
                 SafariAiProvider::Gemini => {
-                    let action = match build_gemini_ai_action(mode, prompt.as_deref()) {
+                    let action = match build_gemini_ai_action(mode, prompt.as_deref(), auto_confirm) {
                         Ok(action) => action,
                         Err(err) => {
                             eprintln!("error: {err}");
@@ -953,6 +969,21 @@ fn main() {
                                 }
                             }
                         }
+                        GeminiAiAction::DeepResearchPlan(prompt, auto_confirm) => {
+                            match cueward_adapter_macos::safari::start_gemini_deep_research(
+                                &prompt,
+                                auto_confirm,
+                            ) {
+                                Ok(result) => {
+                                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                                    eprintln!("gemini deep research state ready");
+                                }
+                                Err(e) => {
+                                    eprintln!("error: {e}");
+                                    process::exit(1);
+                                }
+                            }
+                        }
                     }
                 }
                 SafariAiProvider::Chatgpt => {
@@ -960,6 +991,19 @@ fn main() {
                     process::exit(1);
                 }
             },
+                        SafariAction::AiPoll { timeout } => {
+                match cueward_adapter_macos::safari::poll_gemini_deep_research(timeout) {
+                    Ok(result) => {
+                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("gemini deep research polled");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+
         },
 
         Command::Notes { action } => match action {
@@ -1292,11 +1336,13 @@ mod tests {
                         provider,
                         mode,
                         prompt,
+                        auto_confirm,
                     },
             } => {
                 assert_eq!(provider, SafariAiProvider::Gemini);
                 assert_eq!(mode, Some(GeminiMode::DeepResearch));
                 assert_eq!(prompt, Some("研究議題".to_string()));
+                assert!(!auto_confirm);
             }
             _ => panic!("unexpected command"),
         }
@@ -1322,11 +1368,13 @@ mod tests {
                         provider,
                         mode,
                         prompt,
+                        auto_confirm,
                     },
             } => {
                 assert_eq!(provider, SafariAiProvider::Gemini);
                 assert_eq!(mode, None);
                 assert_eq!(prompt, Some("哈囉".to_string()));
+                assert!(!auto_confirm);
             }
             _ => panic!("unexpected command"),
         }
@@ -1335,16 +1383,70 @@ mod tests {
     #[test]
     fn build_gemini_ai_action_allows_mode_and_prompt_together() {
         assert_eq!(
-            build_gemini_ai_action(Some(GeminiMode::DeepResearch), Some("研究主題")).unwrap(),
-            GeminiAiAction::ModeThenPrompt(GeminiMode::DeepResearch, "研究主題".to_string())
+            build_gemini_ai_action(Some(GeminiMode::DeepResearch), Some("研究主題"), false).unwrap(),
+            GeminiAiAction::DeepResearchPlan("研究主題".to_string(), false)
         );
     }
 
     #[test]
     fn build_gemini_ai_action_requires_mode_or_prompt() {
         assert_eq!(
-            build_gemini_ai_action(None, None),
+            build_gemini_ai_action(None, None, false),
             Err("--mode or --prompt is required for Gemini Safari AI workflow")
         );
+    }
+
+    #[test]
+    fn cli_parses_gemini_deep_research_auto_confirm_command() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "gemini",
+            "--mode",
+            "deep-research",
+            "--prompt",
+            "研究主題",
+            "--auto-confirm",
+        ])
+        .expect("parse deep research command");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        mode,
+                        prompt,
+                        auto_confirm,
+                    },
+            } => {
+                assert_eq!(provider, SafariAiProvider::Gemini);
+                assert_eq!(mode, Some(GeminiMode::DeepResearch));
+                assert_eq!(prompt, Some("研究主題".to_string()));
+                assert!(auto_confirm);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_safari_ai_poll_command() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "ai-poll",
+            "--timeout",
+            "120",
+        ])
+        .expect("parse ai-poll command");
+
+        match cli.command {
+            Command::Safari {
+                action: SafariAction::AiPoll { timeout },
+            } => assert_eq!(timeout, 120),
+            _ => panic!("unexpected command"),
+        }
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -978,6 +978,9 @@ fn main() {
                             };
                             match gemini_action {
                                 GeminiAiAction::PromptOnly(prompt) => {
+                                    if let Err(e) = cueward_adapter_macos::safari::ensure_gemini_home(p) {
+                                        eprintln!("error: {e}"); process::exit(1);
+                                    }
                                     match cueward_adapter_macos::safari::send_gemini_prompt(&prompt, p) {
                                         Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("gemini response ready"); }
                                         Err(e) => { eprintln!("error: {e}"); process::exit(1); }

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -43,6 +43,17 @@
 - [x] cueward plan（建立 Reminders 提醒事項）
 - [x] cueward ocr（Vision Framework OCR，支援圖片 + PDF）
 
+## Phase 7：Safari AI Provider Automation
+- [x] URL-based mode navigation (bypasses DOM clicking entirely)
+- [x] execCommand('insertText') for prompt input (no focus stealing)
+- [x] Deep Research: full flow (prompt → plan → confirm via "ok" → poll → report)
+- [x] Image generation: prompt → canvas → base64 → PNG save
+- [x] Video/Music: prompt → browser-native download via `<a download>`
+- [x] Conversation list/read from sidebar
+- [x] Provider-based CLI structure (`--provider gemini/chatgpt`)
+- [ ] ChatGPT provider implementation
+- [ ] Grok provider implementation
+
 ## Phase 6+（未來）
 - [ ] 靈動島 Notch UI
 - [ ] Windows adapter


### PR DESCRIPTION
## Summary

- Replace fragile DOM clicking with URL-based navigation for all Gemini modes (`/deepresearch`, `/image`, `/veo`, `/music`, `/canvas`)
- Use `execCommand('insertText')` + button click for prompt submission — no system focus stealing, works in background
- Deep Research confirmation sends `"ok"` as text instead of finding UI buttons, leveraging Gemini's LLM intent understanding
- Add conversation list, read, image save (canvas → PNG), and media download (browser-native `<a download>`)
- Unify CLI under `safari ai --provider <provider> <action>` structure for multi-provider support

close #34 

## New CLI Commands

| Command | Description |
|---------|-------------|
| `safari ai --provider gemini prompt --prompt "..." [--mode ...] [--auto-confirm]` | Send prompt |
| `safari ai --provider gemini mode <mode>` | Switch mode |
| `safari ai --provider gemini list` | List conversations |
| `safari ai --provider gemini read <url>` | Read conversation text |
| `safari ai --provider gemini poll` | Poll in-progress workflow |
| `safari ai --provider gemini save-images <url>` | Save images as PNG |
| `safari ai --provider gemini save-media <url>` | Download video/music |

## What was removed

~200 lines of DOM manipulation code: tool menu clicking, AX fallback, mode selector, new chat button detection.

## Test plan

- [x] All 61 unit tests pass, zero warnings
- [x] Live tested: Deep Research full flow (prompt → plan → confirm → report retrieval)
- [x] Live tested: Image generation + PNG save (1024x559, 871KB)
- [x] Live tested: Video download (2.1MB MP4)
- [x] Live tested: Music download (4.4MB MP4)
- [x] Live tested: Conversation list + read (37KB report)
- [x] Verified no focus stealing during background execution
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
