### PR TITLE
[codex] Add ChatGPT Safari chat workflow

### DIFF
--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -94,6 +94,8 @@ pub struct SafariAiResponseResult {
     pub provider: String,
     pub status: String,
     pub response: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_url: Option<String>,
 }
 
 #[derive(Debug, Serialize, serde::Deserialize, PartialEq, Eq)]
@@ -174,7 +176,6 @@ fn extract_profile(window_name: &str, active_tab_title: &str) -> Option<String> 
         .filter(|profile| !profile.is_empty())
         .map(ToOwned::to_owned)
 }
-
 
 fn target_window_block(profile_filter: Option<&str>) -> String {
     match profile_filter {
@@ -336,7 +337,6 @@ fn build_active_tab_script(profile_filter: Option<&str>) -> String {
         tab_return = tab_return,
     )
 }
-
 
 fn build_exec_script_for_profile(js_code: &str, profile_filter: Option<&str>) -> String {
     let js_expr = escape_body(js_code);
@@ -512,11 +512,20 @@ fn gemini_mode_placeholders(mode: GeminiMode) -> &'static [&'static str] {
         ],
         GeminiMode::DeepResearch => &["你想研究什麼？", "What do you want to research?"],
         GeminiMode::Video => &["描述影片", "Describe the video", "Describe your video"],
-        GeminiMode::Music => &["描述音樂", "描述要創作的音樂", "Describe the music", "Describe the music you"],
+        GeminiMode::Music => &[
+            "描述音樂",
+            "描述要創作的音樂",
+            "Describe the music",
+            "Describe the music you",
+        ],
     }
 }
 
 fn should_skip_gemini_response(trimmed: &str, prompt: &str) -> bool {
+    trimmed.is_empty() || trimmed == prompt.trim()
+}
+
+fn should_skip_chatgpt_response(trimmed: &str, prompt: &str) -> bool {
     trimmed.is_empty() || trimmed == prompt.trim()
 }
 
@@ -538,10 +547,17 @@ fn gemini_mode_url(mode: GeminiMode) -> &'static str {
     }
 }
 
-
 fn build_gemini_go_home_js() -> String {
     r#"(function() {
         window.location.href = "https://gemini.google.com/app";
+        return "true";
+    })()"#
+        .to_string()
+}
+
+fn build_chatgpt_go_home_js() -> String {
+    r#"(function() {
+        window.location.href = "https://chatgpt.com/";
         return "true";
     })()"#
         .to_string()
@@ -552,6 +568,16 @@ pub fn ensure_gemini_home(profile_filter: Option<&str>) -> Result<(), MacosError
         &build_gemini_go_home_js(),
         profile_filter,
         "safari_gemini_go_home",
+    )?;
+    thread::sleep(Duration::from_millis(2500));
+    Ok(())
+}
+
+pub fn ensure_chatgpt_home(profile_filter: Option<&str>) -> Result<(), MacosError> {
+    let _ = execute_js_for_profile(
+        &build_chatgpt_go_home_js(),
+        profile_filter,
+        "safari_chatgpt_go_home",
     )?;
     thread::sleep(Duration::from_millis(2500));
     Ok(())
@@ -606,6 +632,26 @@ fn build_gemini_fill_input_js(prompt: &str) -> String {
     )
 }
 
+fn build_chatgpt_fill_input_js(prompt: &str) -> String {
+    let prompt = escape_js_string(prompt);
+    format!(
+        r##"(() => {{
+            const input = document.querySelector(
+              "#prompt-textarea, textarea[data-id], div[contenteditable='true'][role='textbox'], div[contenteditable='true']"
+            );
+            if (!input) throw new Error("chatgpt input not found");
+            input.focus();
+            if ("value" in input) {{
+              input.value = "";
+            }} else {{
+              input.textContent = "";
+            }}
+            document.execCommand("insertText", false, "{prompt}");
+            return "true";
+        }})()"##
+    )
+}
+
 fn wait_and_click_send(profile_filter: Option<&str>) -> Result<(), MacosError> {
     let js = &build_gemini_click_send_js();
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -616,7 +662,9 @@ fn wait_and_click_send(profile_filter: Option<&str>) -> Result<(), MacosError> {
             return Ok(());
         }
     }
-    Err(MacosError::Other("send button not found or disabled after 5s".to_string()))
+    Err(MacosError::Other(
+        "send button not found or disabled after 5s".to_string(),
+    ))
 }
 
 fn build_gemini_click_send_js() -> String {
@@ -640,6 +688,42 @@ fn build_gemini_click_send_js() -> String {
         .to_string()
 }
 
+fn build_chatgpt_click_send_js() -> String {
+    r#"(() => {
+        const sendLabels = ["Send prompt", "Send message", "傳送訊息", "傳送提示"];
+        const buttons = [...document.querySelectorAll('button,[role="button"]')];
+        for (const button of buttons) {
+          const label = [
+            button.getAttribute("aria-label"),
+            button.getAttribute("title"),
+            button.getAttribute("data-testid"),
+            button.innerText,
+            button.textContent
+          ].filter(Boolean).join(" ");
+          if (!sendLabels.some((v) => label.includes(v))) continue;
+          if (button.disabled || button.getAttribute("aria-disabled") == "true") return "disabled";
+          button.click();
+          return "true";
+        }
+        return "false";
+    })()"#
+        .to_string()
+}
+
+fn wait_and_click_chatgpt_send(profile_filter: Option<&str>) -> Result<(), MacosError> {
+    let js = &build_chatgpt_click_send_js();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(200));
+        let result = execute_js_for_profile(js, profile_filter, "safari_chatgpt_wait_send")?;
+        if result.trim() == "true" {
+            return Ok(());
+        }
+    }
+    Err(MacosError::Other(
+        "send button not found or disabled after 5s".to_string(),
+    ))
+}
 
 fn gemini_deep_research_poll_js() -> String {
     r#"(() => {
@@ -682,6 +766,51 @@ fn gemini_deep_research_poll_js() -> String {
         .to_string()
 }
 
+fn chatgpt_response_extract_js() -> String {
+    r#"(() => {
+        const getConversationUrl = () => {
+          const url = window.location.href || "";
+          return /chatgpt\.com\/c\/[a-z0-9-]+/i.test(url) ? url : null;
+        };
+        const extractText = (node) => (node?.innerText || node?.textContent || "").trim();
+        const selectors = [
+          '[data-message-author-role="assistant"]',
+          'article[data-testid^="conversation-turn-"]',
+          'main article'
+        ];
+
+        let response = "";
+        for (const selector of selectors) {
+          const nodes = [...document.querySelectorAll(selector)];
+          for (let i = nodes.length - 1; i >= 0; i--) {
+            const text = extractText(nodes[i]);
+            if (text) {
+              response = text;
+              break;
+            }
+          }
+          if (response) break;
+        }
+
+        const controls = [...document.querySelectorAll('button,[role="button"]')]
+          .map((button) => [
+            button.getAttribute("aria-label"),
+            button.getAttribute("title"),
+            button.innerText,
+            button.textContent
+          ].filter(Boolean).join(" "))
+          .join(" ");
+        const isRunning = /Stop generating|Stop streaming|停止生成|停止串流/.test(controls);
+
+        return JSON.stringify({
+          status: response ? (isRunning ? "running" : "complete") : "running",
+          response,
+          conversation_url: getConversationUrl()
+        });
+    })()"#
+        .to_string()
+}
+
 fn get_gemini_conversation_url(profile_filter: Option<&str>) -> Result<String, MacosError> {
     let js = r#"(() => {
         const url = window.location.href || "";
@@ -696,7 +825,23 @@ fn get_gemini_conversation_url(profile_filter: Option<&str>) -> Result<String, M
     Ok(url.to_string())
 }
 
-pub fn gemini_list_conversations(profile_filter: Option<&str>) -> Result<Vec<SafariConversation>, MacosError> {
+fn get_chatgpt_conversation_url(profile_filter: Option<&str>) -> Result<String, MacosError> {
+    let js = r#"(() => {
+        const url = window.location.href || "";
+        if (url.match(/chatgpt\.com\/c\/[a-z0-9-]+/i)) return url;
+        return "";
+    })()"#;
+    let url = execute_js_for_profile(js, profile_filter, "safari_chatgpt_conversation_url")?;
+    let url = url.trim();
+    if url.is_empty() {
+        return Err(MacosError::Other("no conversation URL found".to_string()));
+    }
+    Ok(url.to_string())
+}
+
+pub fn gemini_list_conversations(
+    profile_filter: Option<&str>,
+) -> Result<Vec<SafariConversation>, MacosError> {
     let js = r#"(() => {
         const items = document.querySelectorAll('a[href*="/app/"]');
         const convos = [];
@@ -740,12 +885,16 @@ pub fn gemini_read_conversation(
     let raw = execute_js_for_profile(read_js, profile_filter, "safari_gemini_read_content")?;
     let value: serde_json::Value = serde_json::from_str(&raw)
         .map_err(|e| MacosError::Other(format!("failed to parse read result: {e}")))?;
-    let status = value.get("status").and_then(|v| v.as_str()).unwrap_or("error");
+    let status = value
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("error");
     let response = value.get("response").and_then(|v| v.as_str()).unwrap_or("");
     Ok(SafariAiResponseResult {
         provider: "gemini".to_string(),
         status: status.to_string(),
         response: response.to_string(),
+        conversation_url: None,
     })
 }
 
@@ -805,14 +954,15 @@ pub fn gemini_save_images(
             continue;
         }
 
-        let bytes = engine.decode(b64).map_err(|e| {
-            MacosError::Other(format!("base64 decode failed for image {i}: {e}"))
-        })?;
+        let bytes = engine
+            .decode(b64)
+            .map_err(|e| MacosError::Other(format!("base64 decode failed for image {i}: {e}")))?;
 
         let filename = format!("gemini_image_{i}.png");
         let filepath = out_path.join(&filename);
-        std::fs::write(&filepath, &bytes)
-            .map_err(|e| MacosError::Other(format!("failed to write {}: {e}", filepath.display())))?;
+        std::fs::write(&filepath, &bytes).map_err(|e| {
+            MacosError::Other(format!("failed to write {}: {e}", filepath.display()))
+        })?;
         saved.push(filepath.to_string_lossy().into_owned());
     }
 
@@ -846,12 +996,16 @@ pub fn gemini_save_media(
     let raw = execute_js_for_profile(js, profile_filter, "safari_gemini_media_download")?;
     let value: serde_json::Value = serde_json::from_str(&raw)
         .map_err(|e| MacosError::Other(format!("failed to parse media result: {e}")))?;
-    let status = value.get("status").and_then(|v| v.as_str()).unwrap_or("error");
+    let status = value
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("error");
     let response = value.get("response").and_then(|v| v.as_str()).unwrap_or("");
     Ok(SafariAiResponseResult {
         provider: "gemini".to_string(),
         status: status.to_string(),
         response: response.to_string(),
+        conversation_url: None,
     })
 }
 
@@ -943,11 +1097,18 @@ pub fn close(index: Option<usize>) -> Result<SafariCloseResult, MacosError> {
 }
 
 pub fn source(profile_filter: Option<&str>) -> Result<SafariSourceResult, MacosError> {
-    let result = execute_js_for_profile("document.documentElement.outerHTML", profile_filter, "safari_source")?;
+    let result = execute_js_for_profile(
+        "document.documentElement.outerHTML",
+        profile_filter,
+        "safari_source",
+    )?;
     Ok(SafariSourceResult { html: result })
 }
 
-pub fn read(selector: Option<&str>, profile_filter: Option<&str>) -> Result<SafariReadResult, MacosError> {
+pub fn read(
+    selector: Option<&str>,
+    profile_filter: Option<&str>,
+) -> Result<SafariReadResult, MacosError> {
     let js = match selector {
         Some(selector) => selector_text_js(selector),
         None => "(document.body.innerText ?? \"\").trim()".to_string(),
@@ -1014,8 +1175,9 @@ pub fn wait(selector: &str, timeout_seconds: u64) -> Result<SafariWaitResult, Ma
 }
 
 fn parse_deep_research_payload(payload: &str) -> Result<SafariDeepResearchResult, MacosError> {
-    let value: Value = serde_json::from_str(payload)
-        .map_err(|error| MacosError::Other(format!("invalid deep research payload: {error}: {payload}")))?;
+    let value: Value = serde_json::from_str(payload).map_err(|error| {
+        MacosError::Other(format!("invalid deep research payload: {error}: {payload}"))
+    })?;
     let status = value
         .get("status")
         .and_then(Value::as_str)
@@ -1037,8 +1199,14 @@ fn parse_deep_research_payload(payload: &str) -> Result<SafariDeepResearchResult
         mode: "deep-research".to_string(),
         status: status.to_string(),
         conversation_url: None,
-        plan: value.get("plan").and_then(Value::as_str).map(ToOwned::to_owned),
-        response: value.get("response").and_then(Value::as_str).map(ToOwned::to_owned),
+        plan: value
+            .get("plan")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        response: value
+            .get("response")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
         actions,
     })
 }
@@ -1048,9 +1216,7 @@ pub fn prepare_gemini_mode(
     profile_filter: Option<&str>,
 ) -> Result<SafariAiReadyResult, MacosError> {
     let url = gemini_mode_url(mode);
-    let nav_js = format!(
-        r#"(function() {{ window.location.href = "{url}"; return "true"; }})()"#,
-    );
+    let nav_js = format!(r#"(function() {{ window.location.href = "{url}"; return "true"; }})()"#,);
     let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_gemini_mode_navigate")?;
     thread::sleep(Duration::from_millis(2500));
 
@@ -1075,7 +1241,6 @@ pub fn prepare_gemini_mode(
     })
 }
 
-
 pub fn start_gemini_deep_research(
     prompt: &str,
     auto_confirm: bool,
@@ -1089,7 +1254,9 @@ pub fn start_gemini_deep_research(
         "safari_gemini_deep_research_fill",
     )?;
     if filled.trim() != "true" {
-        return Err(MacosError::Other(format!("failed to fill deep research input: {filled}")));
+        return Err(MacosError::Other(format!(
+            "failed to fill deep research input: {filled}"
+        )));
     }
 
     wait_and_click_send(profile_filter)?;
@@ -1132,7 +1299,8 @@ pub fn poll_gemini_deep_research(
     let js = gemini_deep_research_poll_js();
 
     while Instant::now() < deadline {
-        let payload = execute_js_for_profile(&js, profile_filter, "safari_gemini_deep_research_poll")?;
+        let payload =
+            execute_js_for_profile(&js, profile_filter, "safari_gemini_deep_research_poll")?;
         let result = parse_deep_research_payload(&payload)?;
         match result.status.as_str() {
             "plan_ready" | "complete" => return Ok(result),
@@ -1141,7 +1309,7 @@ pub fn poll_gemini_deep_research(
                 return Err(MacosError::Other(format!(
                     "unknown deep research status: {}",
                     result.status
-                )))
+                )));
             }
         }
 
@@ -1169,7 +1337,9 @@ pub fn send_gemini_prompt(
         "safari_gemini_prompt_fill",
     )?;
     if filled.trim() != "true" {
-        return Err(MacosError::Other(format!("failed to fill Gemini input: {filled}")));
+        return Err(MacosError::Other(format!(
+            "failed to fill Gemini input: {filled}"
+        )));
     }
 
     wait_and_click_send(profile_filter)?;
@@ -1194,6 +1364,7 @@ pub fn send_gemini_prompt(
                     provider: "gemini".to_string(),
                     status: "complete".to_string(),
                     response: trimmed.to_string(),
+                    conversation_url: None,
                 });
             }
         } else {
@@ -1207,12 +1378,78 @@ pub fn send_gemini_prompt(
             provider: "gemini".to_string(),
             status: "timeout".to_string(),
             response: last_text,
+            conversation_url: None,
         });
     }
 
     Err(MacosError::Other(
         "timeout waiting for Gemini response".to_string(),
     ))
+}
+
+pub fn send_chatgpt_prompt(
+    prompt: &str,
+    profile_filter: Option<&str>,
+) -> Result<SafariAiResponseResult, MacosError> {
+    let filled = execute_js_for_profile(
+        &build_chatgpt_fill_input_js(prompt),
+        profile_filter,
+        "safari_chatgpt_prompt_fill",
+    )?;
+    if filled.trim() != "true" {
+        return Err(MacosError::Other(format!(
+            "failed to fill ChatGPT input: {filled}"
+        )));
+    }
+
+    wait_and_click_chatgpt_send(profile_filter)?;
+
+    let deadline = Instant::now() + Duration::from_secs(120);
+    let response_js = chatgpt_response_extract_js();
+
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(750));
+        let payload =
+            execute_js_for_profile(&response_js, profile_filter, "safari_chatgpt_response")?;
+        let value: Value = serde_json::from_str(&payload).map_err(|e| {
+            MacosError::Other(format!("failed to parse chatgpt response payload: {e}"))
+        })?;
+
+        let status = value
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("running");
+        let response = value
+            .get("response")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+        if should_skip_chatgpt_response(response, prompt) {
+            continue;
+        }
+
+        let conversation_url = value
+            .get("conversation_url")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .or_else(|| get_chatgpt_conversation_url(profile_filter).ok());
+
+        if status == "complete" {
+            return Ok(SafariAiResponseResult {
+                provider: "chatgpt".to_string(),
+                status: "complete".to_string(),
+                response: response.to_string(),
+                conversation_url,
+            });
+        }
+    }
+
+    Ok(SafariAiResponseResult {
+        provider: "chatgpt".to_string(),
+        status: "timeout".to_string(),
+        response: String::new(),
+        conversation_url: get_chatgpt_conversation_url(profile_filter).ok(),
+    })
 }
 
 fn execute_js(js_code: &str, context: &str) -> Result<String, MacosError> {
@@ -1224,20 +1461,23 @@ fn execute_js_for_profile(
     profile_filter: Option<&str>,
     context: &str,
 ) -> Result<String, MacosError> {
-    let stdout = run_capture(&build_exec_script_for_profile(js_code, profile_filter), context)?;
+    let stdout = run_capture(
+        &build_exec_script_for_profile(js_code, profile_filter),
+        context,
+    )?;
     Ok(decode_field(stdout.trim()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        TAB_SEPARATOR, build_active_tab_script, build_close_script,
-        build_exec_script, build_gemini_fill_input_js, build_gemini_go_home_js,
-        build_open_script,
-        build_tab_return_block, build_tabs_script, extract_profile, gemini_deep_research_poll_js,
-        gemini_response_extract_js, parse_deep_research_payload, parse_tab_line,
-        parse_tabs_output, selector_click_js, selector_fill_js, selector_text_js,
-        should_skip_gemini_response,
+        TAB_SEPARATOR, build_active_tab_script, build_chatgpt_click_send_js,
+        build_chatgpt_fill_input_js, build_chatgpt_go_home_js, build_close_script,
+        build_exec_script, build_gemini_fill_input_js, build_gemini_go_home_js, build_open_script,
+        build_tab_return_block, build_tabs_script, chatgpt_response_extract_js, extract_profile,
+        gemini_deep_research_poll_js, gemini_response_extract_js, parse_deep_research_payload,
+        parse_tab_line, parse_tabs_output, selector_click_js, selector_fill_js, selector_text_js,
+        should_skip_chatgpt_response, should_skip_gemini_response,
     };
 
     #[test]
@@ -1369,13 +1609,42 @@ mod tests {
     }
 
     #[test]
+    fn chatgpt_go_home_script_targets_new_chat() {
+        let script = build_chatgpt_go_home_js();
+
+        assert!(script.contains("chatgpt.com"));
+        assert!(script.contains("window.location.href"));
+    }
+
+    #[test]
+    fn chatgpt_fill_input_script_targets_prompt_textarea() {
+        let script = build_chatgpt_fill_input_js("hello from chatgpt");
+
+        assert!(script.contains("#prompt-textarea"));
+        assert!(script.contains("hello from chatgpt"));
+        assert!(script.contains("execCommand"));
+    }
+
+    #[test]
+    fn chatgpt_click_send_script_checks_accessible_labels() {
+        let script = build_chatgpt_click_send_js();
+
+        assert!(script.contains("Send prompt"));
+        assert!(script.contains("Send message"));
+        assert!(script.contains("button.disabled"));
+    }
+
+    #[test]
     fn parse_deep_research_payload_reads_plan_and_actions() {
         let payload = r#"{"status":"plan_ready","plan":"Outline","actions":["confirm","edit"]}"#;
         let result = parse_deep_research_payload(payload).expect("parse payload");
 
         assert_eq!(result.status, "plan_ready");
         assert_eq!(result.plan.as_deref(), Some("Outline"));
-        assert_eq!(result.actions, vec!["confirm".to_string(), "edit".to_string()]);
+        assert_eq!(
+            result.actions,
+            vec!["confirm".to_string(), "edit".to_string()]
+        );
     }
 
     #[test]
@@ -1399,8 +1668,24 @@ mod tests {
     }
 
     #[test]
+    fn chatgpt_response_extract_script_returns_response_and_conversation_url() {
+        let script = chatgpt_response_extract_js();
+
+        assert!(script.contains("article"));
+        assert!(script.contains("conversation_url"));
+        assert!(script.contains("window.location.href"));
+        assert!(script.contains("complete"));
+    }
+
+    #[test]
     fn should_skip_gemini_response_trims_prompt_whitespace() {
         assert!(should_skip_gemini_response("hello", "  hello  "));
         assert!(!should_skip_gemini_response("world", "  hello  "));
+    }
+
+    #[test]
+    fn should_skip_chatgpt_response_trims_prompt_whitespace() {
+        assert!(should_skip_chatgpt_response("hello", "  hello  "));
+        assert!(!should_skip_chatgpt_response("world", "  hello  "));
     }
 }

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -825,20 +825,6 @@ fn get_gemini_conversation_url(profile_filter: Option<&str>) -> Result<String, M
     Ok(url.to_string())
 }
 
-fn get_chatgpt_conversation_url(profile_filter: Option<&str>) -> Result<String, MacosError> {
-    let js = r#"(() => {
-        const url = window.location.href || "";
-        if (url.match(/chatgpt\.com\/c\/[a-z0-9-]+/i)) return url;
-        return "";
-    })()"#;
-    let url = execute_js_for_profile(js, profile_filter, "safari_chatgpt_conversation_url")?;
-    let url = url.trim();
-    if url.is_empty() {
-        return Err(MacosError::Other("no conversation URL found".to_string()));
-    }
-    Ok(url.to_string())
-}
-
 pub fn gemini_list_conversations(
     profile_filter: Option<&str>,
 ) -> Result<Vec<SafariConversation>, MacosError> {
@@ -1406,6 +1392,8 @@ pub fn send_chatgpt_prompt(
 
     let deadline = Instant::now() + Duration::from_secs(120);
     let response_js = chatgpt_response_extract_js();
+    let mut last_response = String::new();
+    let mut last_conversation_url: Option<String> = None;
 
     while Instant::now() < deadline {
         thread::sleep(Duration::from_millis(750));
@@ -1424,22 +1412,30 @@ pub fn send_chatgpt_prompt(
             .and_then(Value::as_str)
             .unwrap_or("")
             .trim();
-        if should_skip_chatgpt_response(response, prompt) {
-            continue;
-        }
 
         let conversation_url = value
             .get("conversation_url")
             .and_then(Value::as_str)
-            .map(ToOwned::to_owned)
-            .or_else(|| get_chatgpt_conversation_url(profile_filter).ok());
+            .map(ToOwned::to_owned);
+        if conversation_url.is_some() {
+            last_conversation_url = conversation_url.clone();
+        }
+
+        let should_skip = should_skip_chatgpt_response(response, prompt);
+        if !should_skip {
+            last_response = response.to_string();
+        }
 
         if status == "complete" {
             return Ok(SafariAiResponseResult {
                 provider: "chatgpt".to_string(),
                 status: "complete".to_string(),
-                response: response.to_string(),
-                conversation_url,
+                response: if should_skip {
+                    last_response.clone()
+                } else {
+                    response.to_string()
+                },
+                conversation_url: conversation_url.or_else(|| last_conversation_url.clone()),
             });
         }
     }
@@ -1447,8 +1443,8 @@ pub fn send_chatgpt_prompt(
     Ok(SafariAiResponseResult {
         provider: "chatgpt".to_string(),
         status: "timeout".to_string(),
-        response: String::new(),
-        conversation_url: get_chatgpt_conversation_url(profile_filter).ok(),
+        response: last_response,
+        conversation_url: last_conversation_url,
     })
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -601,16 +601,15 @@ fn build_gemini_ai_action(
     prompt: Option<&str>,
     auto_confirm: bool,
 ) -> Result<GeminiAiAction, &'static str> {
-    if auto_confirm
-        && !matches!((&mode, prompt), (Some(GeminiMode::DeepResearch), Some(_)))
-    {
+    if auto_confirm && !matches!((&mode, prompt), (Some(GeminiMode::DeepResearch), Some(_))) {
         return Err("--auto-confirm requires --mode deep-research and --prompt");
     }
 
     match (mode, prompt) {
-        (Some(GeminiMode::DeepResearch), Some(prompt)) => {
-            Ok(GeminiAiAction::DeepResearchPlan(prompt.to_string(), auto_confirm))
-        }
+        (Some(GeminiMode::DeepResearch), Some(prompt)) => Ok(GeminiAiAction::DeepResearchPlan(
+            prompt.to_string(),
+            auto_confirm,
+        )),
         (Some(mode), Some(prompt)) => Ok(GeminiAiAction::ModeThenPrompt(mode, prompt.to_string())),
         (Some(mode), None) => Ok(GeminiAiAction::ModeOnly(mode)),
         (None, Some(prompt)) => Ok(GeminiAiAction::PromptOnly(prompt.to_string())),
@@ -857,34 +856,38 @@ fn main() {
                     }
                 }
             }
-            SafariAction::Active { profile } => match cueward_adapter_macos::safari::active(profile.as_deref()) {
-                Ok(tab) => {
-                    println!("{}", serde_json::to_string_pretty(&tab).unwrap());
-                    if tab.is_some() {
-                        eprintln!("active tab");
-                    } else {
-                        eprintln!("no Safari window");
+            SafariAction::Active { profile } => {
+                match cueward_adapter_macos::safari::active(profile.as_deref()) {
+                    Ok(tab) => {
+                        println!("{}", serde_json::to_string_pretty(&tab).unwrap());
+                        if tab.is_some() {
+                            eprintln!("active tab");
+                        } else {
+                            eprintln!("no Safari window");
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
                     }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
-                }
-            },
-            SafariAction::Open { url, profile } => match cueward_adapter_macos::safari::open(&url, profile.as_deref()) {
-                Ok(tab) => {
-                    println!("{}", serde_json::to_string_pretty(&tab).unwrap());
-                    if tab.is_some() {
-                        eprintln!("opened tab");
-                    } else {
-                        eprintln!("no Safari window");
+            }
+            SafariAction::Open { url, profile } => {
+                match cueward_adapter_macos::safari::open(&url, profile.as_deref()) {
+                    Ok(tab) => {
+                        println!("{}", serde_json::to_string_pretty(&tab).unwrap());
+                        if tab.is_some() {
+                            eprintln!("opened tab");
+                        } else {
+                            eprintln!("no Safari window");
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
                     }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
-                }
-            },
+            }
             SafariAction::Close { index } => match cueward_adapter_macos::safari::close(index) {
                 Ok(result) => {
                     println!("{}", serde_json::to_string_pretty(&result).unwrap());
@@ -911,26 +914,30 @@ fn main() {
                     }
                 }
             }
-            SafariAction::Source { profile } => match cueward_adapter_macos::safari::source(profile.as_deref()) {
-                Ok(result) => {
-                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                    eprintln!("read page source");
+            SafariAction::Source { profile } => {
+                match cueward_adapter_macos::safari::source(profile.as_deref()) {
+                    Ok(result) => {
+                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("read page source");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
                 }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
+            }
+            SafariAction::Exec { js_code, profile } => {
+                match cueward_adapter_macos::safari::exec(&js_code, profile.as_deref()) {
+                    Ok(result) => {
+                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("executed javascript");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
                 }
-            },
-            SafariAction::Exec { js_code, profile } => match cueward_adapter_macos::safari::exec(&js_code, profile.as_deref()) {
-                Ok(result) => {
-                    println!("{}", serde_json::to_string_pretty(&result).unwrap());
-                    eprintln!("executed javascript");
-                }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    process::exit(1);
-                }
-            },
+            }
             SafariAction::Click { selector } => {
                 match cueward_adapter_macos::safari::click(&selector) {
                     Ok(result) => {
@@ -967,16 +974,30 @@ fn main() {
                     }
                 }
             }
-            SafariAction::Ai { provider, profile, action } => {
+            SafariAction::Ai {
+                provider,
+                profile,
+                action,
+            } => {
                 let p = profile.as_deref();
                 match provider {
-                    SafariAiProvider::Gemini => match action {
-                        SafariAiAction::Prompt { prompt, mode, auto_confirm } => {
-                            let gemini_action = match build_gemini_ai_action(mode, Some(&prompt), auto_confirm) {
-                                Ok(a) => a,
-                                Err(err) => { eprintln!("error: {err}"); process::exit(1); }
-                            };
-                            match gemini_action {
+                    SafariAiProvider::Gemini => {
+                        match action {
+                            SafariAiAction::Prompt {
+                                prompt,
+                                mode,
+                                auto_confirm,
+                            } => {
+                                let gemini_action =
+                                    match build_gemini_ai_action(mode, Some(&prompt), auto_confirm)
+                                    {
+                                        Ok(a) => a,
+                                        Err(err) => {
+                                            eprintln!("error: {err}");
+                                            process::exit(1);
+                                        }
+                                    };
+                                match gemini_action {
                                 GeminiAiAction::PromptOnly(prompt) => {
                                     if let Err(e) = cueward_adapter_macos::safari::ensure_gemini_home(p) {
                                         eprintln!("error: {e}"); process::exit(1);
@@ -1003,51 +1024,132 @@ fn main() {
                                 }
                                 GeminiAiAction::ModeOnly(_) => unreachable!(),
                             }
-                        }
-                        SafariAiAction::Mode { mode } => {
-                            match cueward_adapter_macos::safari::prepare_gemini_mode(to_adapter_gemini_mode(mode), p) {
-                                Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("gemini mode ready"); }
-                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
+                            }
+                            SafariAiAction::Mode { mode } => {
+                                match cueward_adapter_macos::safari::prepare_gemini_mode(
+                                    to_adapter_gemini_mode(mode),
+                                    p,
+                                ) {
+                                    Ok(r) => {
+                                        println!("{}", serde_json::to_string_pretty(&r).unwrap());
+                                        eprintln!("gemini mode ready");
+                                    }
+                                    Err(e) => {
+                                        eprintln!("error: {e}");
+                                        process::exit(1);
+                                    }
+                                }
+                            }
+                            SafariAiAction::List => {
+                                match cueward_adapter_macos::safari::gemini_list_conversations(p) {
+                                    Ok(convos) => {
+                                        println!(
+                                            "{}",
+                                            serde_json::to_string_pretty(&convos).unwrap()
+                                        );
+                                        eprintln!("{} conversation(s)", convos.len());
+                                    }
+                                    Err(e) => {
+                                        eprintln!("error: {e}");
+                                        process::exit(1);
+                                    }
+                                }
+                            }
+                            SafariAiAction::Read { url } => {
+                                match cueward_adapter_macos::safari::gemini_read_conversation(
+                                    &url, p,
+                                ) {
+                                    Ok(r) => {
+                                        println!("{}", serde_json::to_string_pretty(&r).unwrap());
+                                        eprintln!("conversation read");
+                                    }
+                                    Err(e) => {
+                                        eprintln!("error: {e}");
+                                        process::exit(1);
+                                    }
+                                }
+                            }
+                            SafariAiAction::Poll { timeout } => {
+                                match cueward_adapter_macos::safari::poll_gemini_deep_research(
+                                    timeout, p,
+                                ) {
+                                    Ok(r) => {
+                                        println!("{}", serde_json::to_string_pretty(&r).unwrap());
+                                        eprintln!("polled");
+                                    }
+                                    Err(e) => {
+                                        eprintln!("error: {e}");
+                                        process::exit(1);
+                                    }
+                                }
+                            }
+                            SafariAiAction::SaveImages { url, output } => {
+                                match cueward_adapter_macos::safari::gemini_save_images(
+                                    &url, &output, p,
+                                ) {
+                                    Ok(paths) => {
+                                        println!(
+                                            "{}",
+                                            serde_json::to_string_pretty(&paths).unwrap()
+                                        );
+                                        eprintln!("{} image(s) saved", paths.len());
+                                    }
+                                    Err(e) => {
+                                        eprintln!("error: {e}");
+                                        process::exit(1);
+                                    }
+                                }
+                            }
+                            SafariAiAction::SaveMedia { url } => {
+                                match cueward_adapter_macos::safari::gemini_save_media(&url, p) {
+                                    Ok(r) => {
+                                        println!("{}", serde_json::to_string_pretty(&r).unwrap());
+                                        eprintln!("media download triggered");
+                                    }
+                                    Err(e) => {
+                                        eprintln!("error: {e}");
+                                        process::exit(1);
+                                    }
+                                }
                             }
                         }
-                        SafariAiAction::List => {
-                            match cueward_adapter_macos::safari::gemini_list_conversations(p) {
-                                Ok(convos) => { println!("{}", serde_json::to_string_pretty(&convos).unwrap()); eprintln!("{} conversation(s)", convos.len()); }
-                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
+                    }
+                    SafariAiProvider::Chatgpt => match action {
+                        SafariAiAction::Prompt {
+                            prompt,
+                            mode,
+                            auto_confirm,
+                        } => {
+                            if mode.is_some() {
+                                eprintln!("error: ChatGPT prompt does not support --mode yet");
+                                process::exit(1);
+                            }
+                            if auto_confirm {
+                                eprintln!("error: ChatGPT prompt does not support --auto-confirm");
+                                process::exit(1);
+                            }
+                            if let Err(e) = cueward_adapter_macos::safari::ensure_chatgpt_home(p) {
+                                eprintln!("error: {e}");
+                                process::exit(1);
+                            }
+                            match cueward_adapter_macos::safari::send_chatgpt_prompt(&prompt, p) {
+                                Ok(r) => {
+                                    println!("{}", serde_json::to_string_pretty(&r).unwrap());
+                                    eprintln!("chatgpt response ready");
+                                }
+                                Err(e) => {
+                                    eprintln!("error: {e}");
+                                    process::exit(1);
+                                }
                             }
                         }
-                        SafariAiAction::Read { url } => {
-                            match cueward_adapter_macos::safari::gemini_read_conversation(&url, p) {
-                                Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("conversation read"); }
-                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
-                            }
-                        }
-                        SafariAiAction::Poll { timeout } => {
-                            match cueward_adapter_macos::safari::poll_gemini_deep_research(timeout, p) {
-                                Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("polled"); }
-                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
-                            }
-                        }
-                        SafariAiAction::SaveImages { url, output } => {
-                            match cueward_adapter_macos::safari::gemini_save_images(&url, &output, p) {
-                                Ok(paths) => { println!("{}", serde_json::to_string_pretty(&paths).unwrap()); eprintln!("{} image(s) saved", paths.len()); }
-                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
-                            }
-                        }
-                        SafariAiAction::SaveMedia { url } => {
-                            match cueward_adapter_macos::safari::gemini_save_media(&url, p) {
-                                Ok(r) => { println!("{}", serde_json::to_string_pretty(&r).unwrap()); eprintln!("media download triggered"); }
-                                Err(e) => { eprintln!("error: {e}"); process::exit(1); }
-                            }
+                        _ => {
+                            eprintln!("error: ChatGPT currently supports only prompt");
+                            process::exit(1);
                         }
                     },
-                    SafariAiProvider::Chatgpt => {
-                        eprintln!("error: ChatGPT not implemented yet");
-                        process::exit(1);
-                    }
                 }
             }
-
         },
 
         Command::Notes { action } => match action {
@@ -1360,15 +1462,8 @@ mod tests {
 
     #[test]
     fn cli_parses_safari_exec_with_profile() {
-        let cli = Cli::try_parse_from([
-            "cueward",
-            "safari",
-            "exec",
-            "--profile",
-            "Ryugu",
-            "1+1",
-        ])
-        .expect("parse safari exec with profile");
+        let cli = Cli::try_parse_from(["cueward", "safari", "exec", "--profile", "Ryugu", "1+1"])
+            .expect("parse safari exec with profile");
 
         match cli.command {
             Command::Safari {
@@ -1381,17 +1476,10 @@ mod tests {
         }
     }
 
-
     #[test]
     fn cli_parses_safari_active_with_profile() {
-        let cli = Cli::try_parse_from([
-            "cueward",
-            "safari",
-            "active",
-            "--profile",
-            "Ryugu",
-        ])
-        .expect("parse safari active with profile");
+        let cli = Cli::try_parse_from(["cueward", "safari", "active", "--profile", "Ryugu"])
+            .expect("parse safari active with profile");
 
         match cli.command {
             Command::Safari {
@@ -1404,12 +1492,33 @@ mod tests {
     #[test]
     fn cli_parses_gemini_prompt_with_mode() {
         let cli = Cli::try_parse_from([
-            "cueward", "safari", "ai", "--provider", "gemini",
-            "prompt", "--prompt", "研究議題", "--mode", "deep-research",
-        ]).expect("parse");
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "gemini",
+            "prompt",
+            "--prompt",
+            "研究議題",
+            "--mode",
+            "deep-research",
+        ])
+        .expect("parse");
 
         match cli.command {
-            Command::Safari { action: SafariAction::Ai { provider, action: SafariAiAction::Prompt { prompt, mode, auto_confirm }, .. } } => {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        action:
+                            SafariAiAction::Prompt {
+                                prompt,
+                                mode,
+                                auto_confirm,
+                            },
+                        ..
+                    },
+            } => {
                 assert_eq!(provider, SafariAiProvider::Gemini);
                 assert_eq!(prompt, "研究議題");
                 assert_eq!(mode, Some(GeminiMode::DeepResearch));
@@ -1422,12 +1531,25 @@ mod tests {
     #[test]
     fn cli_parses_gemini_prompt_only() {
         let cli = Cli::try_parse_from([
-            "cueward", "safari", "ai", "--provider", "gemini",
-            "prompt", "--prompt", "哈囉",
-        ]).expect("parse");
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "gemini",
+            "prompt",
+            "--prompt",
+            "哈囉",
+        ])
+        .expect("parse");
 
         match cli.command {
-            Command::Safari { action: SafariAction::Ai { action: SafariAiAction::Prompt { prompt, mode, .. }, .. } } => {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        action: SafariAiAction::Prompt { prompt, mode, .. },
+                        ..
+                    },
+            } => {
                 assert_eq!(prompt, "哈囉");
                 assert_eq!(mode, None);
             }
@@ -1436,14 +1558,67 @@ mod tests {
     }
 
     #[test]
-    fn cli_parses_gemini_auto_confirm() {
+    fn cli_parses_chatgpt_prompt_only() {
         let cli = Cli::try_parse_from([
-            "cueward", "safari", "ai", "--provider", "gemini",
-            "prompt", "--prompt", "研究主題", "--mode", "deep-research", "--auto-confirm",
-        ]).expect("parse");
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "chatgpt",
+            "prompt",
+            "--prompt",
+            "哈囉 ChatGPT",
+        ])
+        .expect("parse");
 
         match cli.command {
-            Command::Safari { action: SafariAction::Ai { action: SafariAiAction::Prompt { auto_confirm, .. }, .. } } => {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        action:
+                            SafariAiAction::Prompt {
+                                prompt,
+                                mode,
+                                auto_confirm,
+                            },
+                        ..
+                    },
+            } => {
+                assert_eq!(provider, SafariAiProvider::Chatgpt);
+                assert_eq!(prompt, "哈囉 ChatGPT");
+                assert_eq!(mode, None);
+                assert!(!auto_confirm);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_gemini_auto_confirm() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "gemini",
+            "prompt",
+            "--prompt",
+            "研究主題",
+            "--mode",
+            "deep-research",
+            "--auto-confirm",
+        ])
+        .expect("parse");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        action: SafariAiAction::Prompt { auto_confirm, .. },
+                        ..
+                    },
+            } => {
                 assert!(auto_confirm);
             }
             _ => panic!("unexpected command"),
@@ -1452,12 +1627,18 @@ mod tests {
 
     #[test]
     fn cli_parses_gemini_list() {
-        let cli = Cli::try_parse_from([
-            "cueward", "safari", "ai", "--provider", "gemini", "list",
-        ]).expect("parse");
+        let cli = Cli::try_parse_from(["cueward", "safari", "ai", "--provider", "gemini", "list"])
+            .expect("parse");
 
         match cli.command {
-            Command::Safari { action: SafariAction::Ai { provider, action: SafariAiAction::List, .. } } => {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        action: SafariAiAction::List,
+                        ..
+                    },
+            } => {
                 assert_eq!(provider, SafariAiProvider::Gemini);
             }
             _ => panic!("unexpected command"),
@@ -1467,12 +1648,25 @@ mod tests {
     #[test]
     fn cli_parses_gemini_poll() {
         let cli = Cli::try_parse_from([
-            "cueward", "safari", "ai", "--provider", "gemini",
-            "poll", "--timeout", "120",
-        ]).expect("parse");
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "gemini",
+            "poll",
+            "--timeout",
+            "120",
+        ])
+        .expect("parse");
 
         match cli.command {
-            Command::Safari { action: SafariAction::Ai { action: SafariAiAction::Poll { timeout }, .. } } => {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        action: SafariAiAction::Poll { timeout },
+                        ..
+                    },
+            } => {
                 assert_eq!(timeout, 120);
             }
             _ => panic!("unexpected command"),
@@ -1482,12 +1676,23 @@ mod tests {
     #[test]
     fn cli_parses_gemini_with_profile() {
         let cli = Cli::try_parse_from([
-            "cueward", "safari", "ai", "--provider", "gemini", "--profile", "Ryugu",
-            "prompt", "--prompt", "hi",
-        ]).expect("parse");
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "gemini",
+            "--profile",
+            "Ryugu",
+            "prompt",
+            "--prompt",
+            "hi",
+        ])
+        .expect("parse");
 
         match cli.command {
-            Command::Safari { action: SafariAction::Ai { profile, .. } } => {
+            Command::Safari {
+                action: SafariAction::Ai { profile, .. },
+            } => {
                 assert_eq!(profile.as_deref(), Some("Ryugu"));
             }
             _ => panic!("unexpected command"),
@@ -1497,7 +1702,8 @@ mod tests {
     #[test]
     fn build_gemini_ai_action_allows_mode_and_prompt_together() {
         assert_eq!(
-            build_gemini_ai_action(Some(GeminiMode::DeepResearch), Some("研究主題"), false).unwrap(),
+            build_gemini_ai_action(Some(GeminiMode::DeepResearch), Some("研究主題"), false)
+                .unwrap(),
             GeminiAiAction::DeepResearchPlan("研究主題".to_string(), false)
         );
     }


### PR DESCRIPTION
## Summary
- add ChatGPT Safari `prompt` workflow for the `chatgpt` provider
- reuse the stable Gemini automation pattern: URL navigation, `execCommand("insertText")`, send-button polling, and response polling
- return `conversation_url` from ChatGPT responses so follow-up work can explicitly continue an existing conversation later

## Why
Issue `#36` is the base chat workflow needed before image generation. We kept this PR scoped to fresh-chat prompt/response support only so `#35` can land separately.

## Validation
- `cargo test -q -p cueward-cli`
- `cargo test -q -p cueward-adapter-macos`
- `cargo run -q -p cueward-cli -- safari ai --provider chatgpt --profile Ryugu prompt --prompt "請只回傳 OK"`

## Notes
- default behavior starts from a fresh ChatGPT chat
- continuing an existing conversation should only happen when a conversation id/url is explicitly provided later

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
