### PR TITLE
[codex] Add ChatGPT Safari image workflow

### DIFF
--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -98,6 +98,22 @@ pub struct SafariAiResponseResult {
     pub conversation_url: Option<String>,
 }
 
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct SafariAiImage {
+    pub url: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct SafariAiImageResult {
+    pub provider: String,
+    pub mode: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_url: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub images: Vec<SafariAiImage>,
+}
+
 #[derive(Debug, Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct SafariConversation {
     pub title: String,
@@ -811,6 +827,114 @@ fn chatgpt_response_extract_js() -> String {
         .to_string()
 }
 
+fn chatgpt_image_list_js() -> String {
+    r#"(() => {
+        const getConversationUrl = () => {
+          const url = window.location.href || "";
+          return /chatgpt\.com\/c\/[a-z0-9-]+/i.test(url) ? url : null;
+        };
+        const candidates = [...document.querySelectorAll("img")]
+          .map((img) => ({
+            alt: img.alt || "",
+            src: img.src || "",
+            width: img.naturalWidth || img.width || 0,
+            height: img.naturalHeight || img.height || 0
+          }))
+          .filter((img) => {
+            if (!img.src) return false;
+            if (!/^https:\/\/chatgpt\.com\/backend-api\/estuary\/content/.test(img.src)) return false;
+            if (img.width < 256 || img.height < 256) return false;
+            return img.alt.includes("已產生圖像") || img.alt.includes("Generated image") || img.alt === "";
+          });
+
+        const deduped = [];
+        const seen = new Set();
+        for (const img of candidates) {
+          if (seen.has(img.src)) continue;
+          seen.add(img.src);
+          deduped.push({ url: img.src });
+        }
+
+        const controls = [...document.querySelectorAll('button,[role="button"]')]
+          .map((button) => [
+            button.getAttribute("aria-label"),
+            button.getAttribute("title"),
+            button.innerText,
+            button.textContent
+          ].filter(Boolean).join(" "))
+          .join(" ");
+        const isRunning = /Stop generating|Stop streaming|停止生成|停止串流/.test(controls);
+
+        return JSON.stringify({
+          status: deduped.length > 0 ? (isRunning ? "running" : "complete") : "running",
+          conversation_url: getConversationUrl(),
+          images: deduped
+        });
+    })()"#
+        .to_string()
+}
+
+fn chatgpt_image_extract_js(index: usize) -> String {
+    format!(
+        r#"(() => {{
+            const urls = [...new Set(
+              [...document.querySelectorAll("img")]
+                .map((img) => img.src || "")
+                .filter((src) => /^https:\/\/chatgpt\.com\/backend-api\/estuary\/content/.test(src))
+            )];
+            const target = urls[{index}];
+            if (!target) return "";
+            const img = [...document.querySelectorAll("img")].find((node) => (node.src || "") === target);
+            if (!img) return "";
+            const canvas = document.createElement("canvas");
+            canvas.width = img.naturalWidth || img.width;
+            canvas.height = img.naturalHeight || img.height;
+            const ctx = canvas.getContext("2d");
+            if (!ctx) return "";
+            ctx.drawImage(img, 0, 0);
+            const dataUrl = canvas.toDataURL("image/png");
+            const idx = dataUrl.indexOf(",");
+            return idx >= 0 ? dataUrl.substring(idx + 1) : "";
+        }})()"#
+    )
+}
+
+fn parse_chatgpt_image_payload(payload: &str) -> Result<SafariAiImageResult, MacosError> {
+    let value: Value = serde_json::from_str(payload).map_err(|error| {
+        MacosError::Other(format!("invalid chatgpt image payload: {error}: {payload}"))
+    })?;
+    let status = value
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("running")
+        .to_string();
+    let conversation_url = value
+        .get("conversation_url")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let images = value
+        .get("images")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get("url").and_then(Value::as_str))
+                .map(|url| SafariAiImage {
+                    url: url.to_string(),
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Ok(SafariAiImageResult {
+        provider: "chatgpt".to_string(),
+        mode: "image".to_string(),
+        status,
+        conversation_url,
+        images,
+    })
+}
+
 fn get_gemini_conversation_url(profile_filter: Option<&str>) -> Result<String, MacosError> {
     let js = r#"(() => {
         const url = window.location.href || "";
@@ -1448,6 +1572,113 @@ pub fn send_chatgpt_prompt(
     })
 }
 
+pub fn send_chatgpt_image_prompt(
+    prompt: &str,
+    profile_filter: Option<&str>,
+) -> Result<SafariAiImageResult, MacosError> {
+    let filled = execute_js_for_profile(
+        &build_chatgpt_fill_input_js(prompt),
+        profile_filter,
+        "safari_chatgpt_image_fill",
+    )?;
+    if filled.trim() != "true" {
+        return Err(MacosError::Other(format!(
+            "failed to fill ChatGPT image prompt: {filled}"
+        )));
+    }
+
+    wait_and_click_chatgpt_send(profile_filter)?;
+
+    let deadline = Instant::now() + Duration::from_secs(180);
+    let image_js = chatgpt_image_list_js();
+    let mut last_result = SafariAiImageResult {
+        provider: "chatgpt".to_string(),
+        mode: "image".to_string(),
+        status: "running".to_string(),
+        conversation_url: None,
+        images: Vec::new(),
+    };
+
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_secs(1));
+        let payload =
+            execute_js_for_profile(&image_js, profile_filter, "safari_chatgpt_image_poll")?;
+        let result = parse_chatgpt_image_payload(&payload)?;
+        if result.conversation_url.is_some() {
+            last_result.conversation_url = result.conversation_url.clone();
+        }
+        if !result.images.is_empty() {
+            last_result.images = result.images.clone();
+        }
+        last_result.status = result.status.clone();
+
+        if result.status == "complete" && !result.images.is_empty() {
+            return Ok(result);
+        }
+    }
+
+    last_result.status = "timeout".to_string();
+    Ok(last_result)
+}
+
+pub fn chatgpt_save_images(
+    conversation_url: &str,
+    output_dir: &str,
+    profile_filter: Option<&str>,
+) -> Result<Vec<String>, MacosError> {
+    let nav_js = format!(
+        r#"(function() {{ window.location.href = "{url}"; return "true"; }})()"#,
+        url = escape_js_string(conversation_url),
+    );
+    let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_chatgpt_save_img_navigate")?;
+    thread::sleep(Duration::from_millis(5000));
+
+    let payload = execute_js_for_profile(
+        &chatgpt_image_list_js(),
+        profile_filter,
+        "safari_chatgpt_img_list",
+    )?;
+    let result = parse_chatgpt_image_payload(&payload)?;
+    if result.images.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let out_path = std::path::Path::new(output_dir);
+    if !out_path.exists() {
+        std::fs::create_dir_all(out_path)
+            .map_err(|e| MacosError::Other(format!("failed to create output dir: {e}")))?;
+    }
+
+    use base64::Engine;
+    let engine = base64::engine::general_purpose::STANDARD;
+    let mut saved = Vec::new();
+
+    for (i, _) in result.images.iter().enumerate() {
+        let b64 = execute_js_for_profile(
+            &chatgpt_image_extract_js(i),
+            profile_filter,
+            "safari_chatgpt_img_extract",
+        )?;
+        let b64 = b64.trim();
+        if b64.is_empty() {
+            continue;
+        }
+
+        let bytes = engine
+            .decode(b64)
+            .map_err(|e| MacosError::Other(format!("base64 decode failed for image {i}: {e}")))?;
+
+        let filename = format!("chatgpt_image_{i}.png");
+        let filepath = out_path.join(&filename);
+        std::fs::write(&filepath, &bytes).map_err(|e| {
+            MacosError::Other(format!("failed to write {}: {e}", filepath.display()))
+        })?;
+        saved.push(filepath.to_string_lossy().into_owned());
+    }
+
+    Ok(saved)
+}
+
 fn execute_js(js_code: &str, context: &str) -> Result<String, MacosError> {
     execute_js_for_profile(js_code, None, context)
 }
@@ -1470,8 +1701,9 @@ mod tests {
         TAB_SEPARATOR, build_active_tab_script, build_chatgpt_click_send_js,
         build_chatgpt_fill_input_js, build_chatgpt_go_home_js, build_close_script,
         build_exec_script, build_gemini_fill_input_js, build_gemini_go_home_js, build_open_script,
-        build_tab_return_block, build_tabs_script, chatgpt_response_extract_js, extract_profile,
-        gemini_deep_research_poll_js, gemini_response_extract_js, parse_deep_research_payload,
+        build_tab_return_block, build_tabs_script, chatgpt_image_extract_js, chatgpt_image_list_js,
+        chatgpt_response_extract_js, extract_profile, gemini_deep_research_poll_js,
+        gemini_response_extract_js, parse_chatgpt_image_payload, parse_deep_research_payload,
         parse_tab_line, parse_tabs_output, selector_click_js, selector_fill_js, selector_text_js,
         should_skip_chatgpt_response, should_skip_gemini_response,
     };
@@ -1671,6 +1903,41 @@ mod tests {
         assert!(script.contains("conversation_url"));
         assert!(script.contains("window.location.href"));
         assert!(script.contains("complete"));
+    }
+
+    #[test]
+    fn chatgpt_image_list_script_reads_generated_images() {
+        let script = chatgpt_image_list_js();
+
+        assert!(script.contains("已產生圖像"));
+        assert!(script.contains("chatgpt\\.com\\/backend-api\\/estuary\\/content"));
+        assert!(script.contains("conversation_url"));
+    }
+
+    #[test]
+    fn chatgpt_image_extract_script_targets_unique_index() {
+        let script = chatgpt_image_extract_js(2);
+
+        assert!(script.contains("new Set"));
+        assert!(script.contains("drawImage"));
+        assert!(script.contains("[2]"));
+    }
+
+    #[test]
+    fn parse_chatgpt_image_payload_reads_images() {
+        let payload = r#"{"status":"complete","conversation_url":"https://chatgpt.com/c/test","images":[{"url":"https://chatgpt.com/backend-api/estuary/content?id=file_123"}]}"#;
+        let result = parse_chatgpt_image_payload(payload).expect("parse payload");
+
+        assert_eq!(result.status, "complete");
+        assert_eq!(
+            result.conversation_url.as_deref(),
+            Some("https://chatgpt.com/c/test")
+        );
+        assert_eq!(result.images.len(), 1);
+        assert_eq!(
+            result.images[0].url,
+            "https://chatgpt.com/backend-api/estuary/content?id=file_123"
+        );
     }
 
     #[test]

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -909,7 +909,7 @@ fn poll_chatgpt_images(
 
         if result.status == "complete" {
             if started_at.elapsed() >= Duration::from_secs(empty_complete_grace_seconds) {
-                return Ok(result);
+                return Ok(last_result);
             }
             continue;
         }

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -844,7 +844,7 @@ fn chatgpt_image_list_js() -> String {
             if (!img.src) return false;
             if (!/^https:\/\/chatgpt\.com\/backend-api\/estuary\/content/.test(img.src)) return false;
             if (img.width < 256 || img.height < 256) return false;
-            return img.alt.includes("已產生圖像") || img.alt.includes("Generated image");
+            return true;
           });
 
         const deduped = [];
@@ -866,7 +866,7 @@ fn chatgpt_image_list_js() -> String {
         const isRunning = /Stop generating|Stop streaming|停止生成|停止串流/.test(controls);
 
         return JSON.stringify({
-          status: deduped.length > 0 ? (isRunning ? "running" : "complete") : "running",
+          status: isRunning ? "running" : "complete",
           conversation_url: getConversationUrl(),
           images: deduped
         });
@@ -876,8 +876,10 @@ fn chatgpt_image_list_js() -> String {
 
 fn poll_chatgpt_images(
     timeout_seconds: u64,
+    empty_complete_grace_seconds: u64,
     profile_filter: Option<&str>,
 ) -> Result<SafariAiImageResult, MacosError> {
+    let started_at = Instant::now();
     let deadline = Instant::now() + Duration::from_secs(timeout_seconds);
     let image_js = chatgpt_image_list_js();
     let mut last_result = SafariAiImageResult {
@@ -904,21 +906,24 @@ fn poll_chatgpt_images(
         if result.status == "complete" && !result.images.is_empty() {
             return Ok(result);
         }
+
+        if result.status == "complete" {
+            if started_at.elapsed() >= Duration::from_secs(empty_complete_grace_seconds) {
+                return Ok(result);
+            }
+            continue;
+        }
     }
 
     last_result.status = "timeout".to_string();
     Ok(last_result)
 }
 
-fn chatgpt_image_extract_js(index: usize) -> String {
+fn chatgpt_image_extract_js(url: &str) -> String {
+    let url = escape_js_string(url);
     format!(
         r#"(() => {{
-            const urls = [...new Set(
-              [...document.querySelectorAll("img")]
-                .map((img) => img.src || "")
-                .filter((src) => /^https:\/\/chatgpt\.com\/backend-api\/estuary\/content/.test(src))
-            )];
-            const target = urls[{index}];
+            const target = "{url}";
             if (!target) return "";
             const img = [...document.querySelectorAll("img")].find((node) => (node.src || "") === target);
             if (!img) return "";
@@ -1624,7 +1629,7 @@ pub fn send_chatgpt_image_prompt(
     }
 
     wait_and_click_chatgpt_send(profile_filter)?;
-    poll_chatgpt_images(180, profile_filter)
+    poll_chatgpt_images(180, 3, profile_filter)
 }
 
 pub fn chatgpt_save_images(
@@ -1637,7 +1642,7 @@ pub fn chatgpt_save_images(
         url = escape_js_string(conversation_url),
     );
     let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_chatgpt_save_img_navigate")?;
-    let result = poll_chatgpt_images(30, profile_filter)?;
+    let result = poll_chatgpt_images(30, 8, profile_filter)?;
     if result.images.is_empty() {
         return Ok(Vec::new());
     }
@@ -1651,10 +1656,16 @@ pub fn chatgpt_save_images(
     use base64::Engine;
     let engine = base64::engine::general_purpose::STANDARD;
     let mut saved = Vec::new();
+    let filename_prefix = result
+        .conversation_url
+        .as_deref()
+        .and_then(|url| url.rsplit('/').next())
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or("chatgpt");
 
-    for (i, _) in result.images.iter().enumerate() {
+    for (i, image) in result.images.iter().enumerate() {
         let b64 = execute_js_for_profile(
-            &chatgpt_image_extract_js(i),
+            &chatgpt_image_extract_js(&image.url),
             profile_filter,
             "safari_chatgpt_img_extract",
         )?;
@@ -1667,7 +1678,7 @@ pub fn chatgpt_save_images(
             .decode(b64)
             .map_err(|e| MacosError::Other(format!("base64 decode failed for image {i}: {e}")))?;
 
-        let filename = format!("chatgpt_image_{i}.png");
+        let filename = format!("{filename_prefix}_image_{i}.png");
         let filepath = out_path.join(&filename);
         std::fs::write(&filepath, &bytes).map_err(|e| {
             MacosError::Other(format!("failed to write {}: {e}", filepath.display()))
@@ -1908,18 +1919,18 @@ mod tests {
     fn chatgpt_image_list_script_reads_generated_images() {
         let script = chatgpt_image_list_js();
 
-        assert!(script.contains("已產生圖像"));
         assert!(script.contains("chatgpt\\.com\\/backend-api\\/estuary\\/content"));
         assert!(script.contains("conversation_url"));
+        assert!(script.contains("img.width < 256"));
     }
 
     #[test]
-    fn chatgpt_image_extract_script_targets_unique_index() {
-        let script = chatgpt_image_extract_js(2);
+    fn chatgpt_image_extract_script_targets_url() {
+        let script = chatgpt_image_extract_js("https://example.com/img.png");
 
-        assert!(script.contains("new Set"));
+        assert!(script.contains("https://example.com/img.png"));
         assert!(script.contains("drawImage"));
-        assert!(script.contains("[2]"));
+        assert!(!script.contains("new Set"));
     }
 
     #[test]

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -844,7 +844,7 @@ fn chatgpt_image_list_js() -> String {
             if (!img.src) return false;
             if (!/^https:\/\/chatgpt\.com\/backend-api\/estuary\/content/.test(img.src)) return false;
             if (img.width < 256 || img.height < 256) return false;
-            return img.alt.includes("已產生圖像") || img.alt.includes("Generated image") || img.alt === "";
+            return img.alt.includes("已產生圖像") || img.alt.includes("Generated image");
           });
 
         const deduped = [];
@@ -872,6 +872,42 @@ fn chatgpt_image_list_js() -> String {
         });
     })()"#
         .to_string()
+}
+
+fn poll_chatgpt_images(
+    timeout_seconds: u64,
+    profile_filter: Option<&str>,
+) -> Result<SafariAiImageResult, MacosError> {
+    let deadline = Instant::now() + Duration::from_secs(timeout_seconds);
+    let image_js = chatgpt_image_list_js();
+    let mut last_result = SafariAiImageResult {
+        provider: "chatgpt".to_string(),
+        mode: "image".to_string(),
+        status: "running".to_string(),
+        conversation_url: None,
+        images: Vec::new(),
+    };
+
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_secs(1));
+        let payload =
+            execute_js_for_profile(&image_js, profile_filter, "safari_chatgpt_image_poll")?;
+        let result = parse_chatgpt_image_payload(&payload)?;
+        if result.conversation_url.is_some() {
+            last_result.conversation_url = result.conversation_url.clone();
+        }
+        if !result.images.is_empty() {
+            last_result.images = result.images.clone();
+        }
+        last_result.status = result.status.clone();
+
+        if result.status == "complete" && !result.images.is_empty() {
+            return Ok(result);
+        }
+    }
+
+    last_result.status = "timeout".to_string();
+    Ok(last_result)
 }
 
 fn chatgpt_image_extract_js(index: usize) -> String {
@@ -1588,37 +1624,7 @@ pub fn send_chatgpt_image_prompt(
     }
 
     wait_and_click_chatgpt_send(profile_filter)?;
-
-    let deadline = Instant::now() + Duration::from_secs(180);
-    let image_js = chatgpt_image_list_js();
-    let mut last_result = SafariAiImageResult {
-        provider: "chatgpt".to_string(),
-        mode: "image".to_string(),
-        status: "running".to_string(),
-        conversation_url: None,
-        images: Vec::new(),
-    };
-
-    while Instant::now() < deadline {
-        thread::sleep(Duration::from_secs(1));
-        let payload =
-            execute_js_for_profile(&image_js, profile_filter, "safari_chatgpt_image_poll")?;
-        let result = parse_chatgpt_image_payload(&payload)?;
-        if result.conversation_url.is_some() {
-            last_result.conversation_url = result.conversation_url.clone();
-        }
-        if !result.images.is_empty() {
-            last_result.images = result.images.clone();
-        }
-        last_result.status = result.status.clone();
-
-        if result.status == "complete" && !result.images.is_empty() {
-            return Ok(result);
-        }
-    }
-
-    last_result.status = "timeout".to_string();
-    Ok(last_result)
+    poll_chatgpt_images(180, profile_filter)
 }
 
 pub fn chatgpt_save_images(
@@ -1631,14 +1637,7 @@ pub fn chatgpt_save_images(
         url = escape_js_string(conversation_url),
     );
     let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_chatgpt_save_img_navigate")?;
-    thread::sleep(Duration::from_millis(5000));
-
-    let payload = execute_js_for_profile(
-        &chatgpt_image_list_js(),
-        profile_filter,
-        "safari_chatgpt_img_list",
-    )?;
-    let result = parse_chatgpt_image_payload(&payload)?;
+    let result = poll_chatgpt_images(30, profile_filter)?;
     if result.images.is_empty() {
         return Ok(Vec::new());
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1120,10 +1120,6 @@ fn main() {
                             mode,
                             auto_confirm,
                         } => {
-                            if mode.is_some() {
-                                eprintln!("error: ChatGPT prompt does not support --mode yet");
-                                process::exit(1);
-                            }
                             if auto_confirm {
                                 eprintln!("error: ChatGPT prompt does not support --auto-confirm");
                                 process::exit(1);
@@ -1132,10 +1128,56 @@ fn main() {
                                 eprintln!("error: {e}");
                                 process::exit(1);
                             }
-                            match cueward_adapter_macos::safari::send_chatgpt_prompt(&prompt, p) {
-                                Ok(r) => {
-                                    println!("{}", serde_json::to_string_pretty(&r).unwrap());
-                                    eprintln!("chatgpt response ready");
+                            match mode {
+                                None => match cueward_adapter_macos::safari::send_chatgpt_prompt(
+                                    &prompt, p,
+                                ) {
+                                    Ok(r) => {
+                                        println!("{}", serde_json::to_string_pretty(&r).unwrap());
+                                        eprintln!("chatgpt response ready");
+                                    }
+                                    Err(e) => {
+                                        eprintln!("error: {e}");
+                                        process::exit(1);
+                                    }
+                                },
+                                Some(GeminiMode::Image) => {
+                                    match cueward_adapter_macos::safari::send_chatgpt_image_prompt(
+                                        &prompt, p,
+                                    ) {
+                                        Ok(r) => {
+                                            println!(
+                                                "{}",
+                                                serde_json::to_string_pretty(&r).unwrap()
+                                            );
+                                            eprintln!("chatgpt image response ready");
+                                        }
+                                        Err(e) => {
+                                            eprintln!("error: {e}");
+                                            process::exit(1);
+                                        }
+                                    }
+                                }
+                                Some(other) => {
+                                    let mode_name = other
+                                        .to_possible_value()
+                                        .map(|v| v.get_name().to_string())
+                                        .unwrap_or_else(|| "unknown".to_string());
+                                    eprintln!(
+                                        "error: ChatGPT prompt does not support --mode {} yet",
+                                        mode_name
+                                    );
+                                    process::exit(1);
+                                }
+                            }
+                        }
+                        SafariAiAction::SaveImages { url, output } => {
+                            match cueward_adapter_macos::safari::chatgpt_save_images(
+                                &url, &output, p,
+                            ) {
+                                Ok(paths) => {
+                                    println!("{}", serde_json::to_string_pretty(&paths).unwrap());
+                                    eprintln!("{} image(s) saved", paths.len());
                                 }
                                 Err(e) => {
                                     eprintln!("error: {e}");
@@ -1144,7 +1186,9 @@ fn main() {
                             }
                         }
                         _ => {
-                            eprintln!("error: ChatGPT currently supports only prompt");
+                            eprintln!(
+                                "error: ChatGPT currently supports only prompt and save-images"
+                            );
                             process::exit(1);
                         }
                     },
@@ -1588,6 +1632,45 @@ mod tests {
                 assert_eq!(provider, SafariAiProvider::Chatgpt);
                 assert_eq!(prompt, "哈囉 ChatGPT");
                 assert_eq!(mode, None);
+                assert!(!auto_confirm);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_chatgpt_prompt_with_image_mode() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "chatgpt",
+            "prompt",
+            "--prompt",
+            "畫一隻貓",
+            "--mode",
+            "image",
+        ])
+        .expect("parse");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        action:
+                            SafariAiAction::Prompt {
+                                prompt,
+                                mode,
+                                auto_confirm,
+                            },
+                        ..
+                    },
+            } => {
+                assert_eq!(provider, SafariAiProvider::Chatgpt);
+                assert_eq!(prompt, "畫一隻貓");
+                assert_eq!(mode, Some(GeminiMode::Image));
                 assert!(!auto_confirm);
             }
             _ => panic!("unexpected command"),


### PR DESCRIPTION
## Summary
- add ChatGPT `prompt --mode image` workflow in the Safari provider
- detect generated images from the conversation DOM and return unique image URLs with `conversation_url`
- add ChatGPT `save-images` support to export generated images as PNG files

## Why
Issue `#35` depends on the base chat workflow from `#36`, which is already merged. This PR keeps the image flow isolated so chat and image automation stay reviewable separately.

## Validation
- `cargo test -q -p cueward-cli`
- `cargo test -q -p cueward-adapter-macos`
- `cargo run -q -p cueward-cli -- safari ai --provider chatgpt --profile Ryugu prompt --prompt "請產生一張 64x64 的藍色圓形圖示" --mode image`
- `cargo run -q -p cueward-cli -- safari ai --provider chatgpt --profile Ryugu save-images https://chatgpt.com/c/69daeb14-67f0-83a3-94bd-1e43963fff88 --output /tmp/cueward-chatgpt-images-1775954698`

## Notes
- live inspection showed ChatGPT image outputs are exposed as direct `https://chatgpt.com/backend-api/estuary/content?...` URLs rather than `blob:` URLs in this flow
- implementation deduplicates repeated DOM `<img>` entries before returning or saving images

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
