### PR TITLE
feat: safari scroll + batch close-tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ cueward safari exec "document.title"
 cueward safari click "#submit"
 cueward safari fill "textarea" "hello from cueward"
 cueward safari wait ".result" --timeout 30
+
+# Scroll the page
+cueward safari scroll down
+cueward safari scroll up --amount 1000
+cueward safari scroll top
+cueward safari scroll bottom --profile Ryugu
+
+# Close multiple tabs by profile or URL pattern
+cueward safari close-tabs --profile Ryugu --url "gemini.google.com"
+cueward safari close-tabs --profile Ryugu  # close all tabs in profile
 ```
 
 ### Safari AI

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -1257,8 +1257,8 @@ pub fn close_tabs(profile_filter: Option<&str>, url_pattern: Option<&str>) -> Re
         })
         .collect();
 
-    let count = to_close.len();
     // Close from last to first to avoid index shifting
+    let mut closed = 0;
     for tab in to_close.iter().rev() {
         let script = format!(
             r#"
@@ -1277,10 +1277,12 @@ pub fn close_tabs(profile_filter: Option<&str>, url_pattern: Option<&str>) -> Re
             window_id = tab.window_id,
             tab_index = tab.index,
         );
-        let _ = run_capture(&script, "safari_close_tab");
+        if run_capture(&script, "safari_close_tab").is_ok() {
+            closed += 1;
+        }
     }
 
-    Ok(count)
+    Ok(closed)
 }
 
 pub fn source(profile_filter: Option<&str>) -> Result<SafariSourceResult, MacosError> {
@@ -1372,7 +1374,7 @@ pub fn scroll(
     amount: Option<i64>,
     profile_filter: Option<&str>,
 ) -> Result<SafariScrollResult, MacosError> {
-    let pixels = amount.unwrap_or(500);
+    let pixels = amount.unwrap_or(500).unsigned_abs();
     let js = match direction {
         "down" => format!("(function(){{ window.scrollBy(0, {pixels}); return JSON.stringify({{ x: Math.round(window.scrollX), y: Math.round(window.scrollY) }}); }})()"),
         "up" => format!("(function(){{ window.scrollBy(0, -{pixels}); return JSON.stringify({{ x: Math.round(window.scrollX), y: Math.round(window.scrollY) }}); }})()"),

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -1247,6 +1247,42 @@ pub fn close(index: Option<usize>) -> Result<SafariCloseResult, MacosError> {
     })
 }
 
+pub fn close_tabs(profile_filter: Option<&str>, url_pattern: Option<&str>) -> Result<usize, MacosError> {
+    let all_tabs = tabs(profile_filter)?;
+    let to_close: Vec<&SafariTab> = all_tabs
+        .iter()
+        .filter(|tab| match url_pattern {
+            Some(pattern) => tab.url.contains(pattern),
+            None => true,
+        })
+        .collect();
+
+    let count = to_close.len();
+    // Close from last to first to avoid index shifting
+    for tab in to_close.iter().rev() {
+        let script = format!(
+            r#"
+            tell application "Safari"
+                repeat with w in every window
+                    if (id of w) is {window_id} then
+                        set tabIdx to {tab_index} + 1
+                        if tabIdx ≤ (count of tabs of w) then
+                            close tab tabIdx of w
+                        end if
+                        exit repeat
+                    end if
+                end repeat
+            end tell
+            "#,
+            window_id = tab.window_id,
+            tab_index = tab.index,
+        );
+        let _ = run_capture(&script, "safari_close_tab");
+    }
+
+    Ok(count)
+}
+
 pub fn source(profile_filter: Option<&str>) -> Result<SafariSourceResult, MacosError> {
     let result = execute_js_for_profile(
         "document.documentElement.outerHTML",
@@ -1323,6 +1359,34 @@ pub fn wait(selector: &str, timeout_seconds: u64) -> Result<SafariWaitResult, Ma
         }
         thread::sleep(Duration::from_millis(250));
     }
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct SafariScrollResult {
+    pub scroll_x: i64,
+    pub scroll_y: i64,
+}
+
+pub fn scroll(
+    direction: &str,
+    amount: Option<i64>,
+    profile_filter: Option<&str>,
+) -> Result<SafariScrollResult, MacosError> {
+    let pixels = amount.unwrap_or(500);
+    let js = match direction {
+        "down" => format!("(function(){{ window.scrollBy(0, {pixels}); return JSON.stringify({{ x: Math.round(window.scrollX), y: Math.round(window.scrollY) }}); }})()"),
+        "up" => format!("(function(){{ window.scrollBy(0, -{pixels}); return JSON.stringify({{ x: Math.round(window.scrollX), y: Math.round(window.scrollY) }}); }})()"),
+        "top" => "(function(){ window.scrollTo(0, 0); return JSON.stringify({ x: 0, y: 0 }); })()".to_string(),
+        "bottom" => "(function(){ window.scrollTo(0, document.body.scrollHeight); return JSON.stringify({ x: Math.round(window.scrollX), y: Math.round(window.scrollY) }); })()".to_string(),
+        _ => return Err(MacosError::Other(format!("unknown scroll direction: {direction}. Use: up, down, top, bottom"))),
+    };
+    let raw = execute_js_for_profile(&js, profile_filter, "safari_scroll")?;
+    let value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| MacosError::Other(format!("failed to parse scroll result: {e}")))?;
+    Ok(SafariScrollResult {
+        scroll_x: value.get("x").and_then(|v| v.as_i64()).unwrap_or(0),
+        scroll_y: value.get("y").and_then(|v| v.as_i64()).unwrap_or(0),
+    })
 }
 
 fn parse_deep_research_payload(payload: &str) -> Result<SafariDeepResearchResult, MacosError> {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -287,6 +287,28 @@ enum SafariAction {
         index: Option<usize>,
     },
 
+    /// Scroll the current page
+    Scroll {
+        /// Direction: up, down, top, bottom
+        direction: String,
+        /// Pixels to scroll (default 500, ignored for top/bottom)
+        #[arg(long)]
+        amount: Option<i64>,
+        /// Restrict operations to a Safari profile
+        #[arg(long)]
+        profile: Option<String>,
+    },
+
+    /// Close multiple tabs, optionally filtered by profile and/or URL pattern
+    CloseTabs {
+        /// Restrict to a Safari profile name
+        #[arg(long)]
+        profile: Option<String>,
+        /// Only close tabs whose URL contains this string
+        #[arg(long)]
+        url: Option<String>,
+    },
+
     /// Read page content from the current active tab
     Read {
         /// Optional CSS selector to extract a specific element's text
@@ -902,6 +924,30 @@ fn main() {
                     process::exit(1);
                 }
             },
+            SafariAction::Scroll { direction, amount, profile } => {
+                match cueward_adapter_macos::safari::scroll(&direction, amount, profile.as_deref()) {
+                    Ok(result) => {
+                        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("scrolled {direction}");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            SafariAction::CloseTabs { profile, url } => {
+                match cueward_adapter_macos::safari::close_tabs(profile.as_deref(), url.as_deref()) {
+                    Ok(count) => {
+                        println!("{}", serde_json::to_string_pretty(&serde_json::json!({ "closed": count })).unwrap());
+                        eprintln!("{count} tab(s) closed");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
             SafariAction::Read { selector, profile } => {
                 match cueward_adapter_macos::safari::read(selector.as_deref(), profile.as_deref()) {
                     Ok(result) => {


### PR DESCRIPTION
## Summary

- `safari scroll <direction>` — up/down/top/bottom with optional --amount and --profile
- `safari close-tabs` — batch close tabs filtered by --profile and/or --url pattern
- Closes #30 (scroll support)

## New Commands

```bash
# Scroll
cueward safari scroll down
cueward safari scroll up --amount 1000
cueward safari scroll top --profile Ryugu

# Batch close
cueward safari close-tabs --profile Ryugu --url "gemini.google.com"
cueward safari close-tabs --profile Ryugu
```

## Test plan

- [x] 71 unit tests pass, zero warnings
- [x] Live tested scroll down with --profile
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
