### PR TITLE
feat: safari --tab targeting (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ cueward safari click "#submit"
 cueward safari fill "textarea" "hello from cueward"
 cueward safari wait ".result" --timeout 30
 
+# Target a specific tab by index or URL/title match
+cueward safari read --tab "gemini.google.com" --profile Ryugu
+cueward safari exec "document.title" --tab 2
+cueward safari source --tab "ChatGPT"
+
 # Scroll the page
 cueward safari scroll down
 cueward safari scroll up --amount 1000

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -1239,6 +1239,54 @@ pub fn open(url: &str, profile_filter: Option<&str>) -> Result<Option<SafariTab>
     }))
 }
 
+/// Focus a specific tab by index or by matching URL/title substring.
+/// This sets the matched tab as the current tab so subsequent operations target it.
+pub fn focus_tab(
+    tab_selector: &str,
+    profile_filter: Option<&str>,
+) -> Result<SafariTab, MacosError> {
+    let all_tabs = tabs(profile_filter)?;
+    if all_tabs.is_empty() {
+        return Err(MacosError::Other("no Safari tabs found".to_string()));
+    }
+
+    // Try parsing as index first
+    let matched = if let Ok(index) = tab_selector.parse::<usize>() {
+        all_tabs.into_iter().find(|t| t.index == index)
+    } else {
+        // Match by URL or title substring
+        let query = tab_selector.to_lowercase();
+        all_tabs
+            .into_iter()
+            .find(|t| t.url.to_lowercase().contains(&query) || t.title.to_lowercase().contains(&query))
+    };
+
+    let tab = matched.ok_or_else(|| {
+        MacosError::Other(format!("no tab matching '{tab_selector}'"))
+    })?;
+
+    // Set as current tab
+    let script = format!(
+        r#"
+        tell application "Safari"
+            repeat with w in every window
+                if (id of w) is {window_id} then
+                    set current tab of w to tab {one_based} of w
+                    set index of w to 1
+                    return "true"
+                end if
+            end repeat
+            return "false"
+        end tell
+        "#,
+        window_id = tab.window_id,
+        one_based = tab.index + 1,
+    );
+    run_capture(&script, "safari_focus_tab")?;
+
+    Ok(tab)
+}
+
 pub fn close(index: Option<usize>) -> Result<SafariCloseResult, MacosError> {
     let stdout = run_capture(&build_close_script(index), "safari_close")?;
     Ok(SafariCloseResult {

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -1250,9 +1250,9 @@ pub fn focus_tab(
         return Err(MacosError::Other("no Safari tabs found".to_string()));
     }
 
-    // Try parsing as index first
+    // Try parsing as index first (position in the flat tab list)
     let matched = if let Ok(index) = tab_selector.parse::<usize>() {
-        all_tabs.into_iter().find(|t| t.index == index)
+        all_tabs.into_iter().nth(index)
     } else {
         // Match by URL or title substring
         let query = tab_selector.to_lowercase();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -297,6 +297,9 @@ enum SafariAction {
         /// Restrict operations to a Safari profile
         #[arg(long)]
         profile: Option<String>,
+        /// Target a specific tab by index or URL/title substring
+        #[arg(long)]
+        tab: Option<String>,
     },
 
     /// Close multiple tabs, optionally filtered by profile and/or URL pattern
@@ -317,6 +320,9 @@ enum SafariAction {
         /// Restrict operations to a Safari profile name parsed from the window title
         #[arg(long)]
         profile: Option<String>,
+        /// Target a specific tab by index or URL/title substring
+        #[arg(long)]
+        tab: Option<String>,
     },
 
     /// Read the full HTML source of the current active tab
@@ -324,6 +330,9 @@ enum SafariAction {
         /// Restrict operations to a Safari profile name parsed from the window title
         #[arg(long)]
         profile: Option<String>,
+        /// Target a specific tab by index or URL/title substring
+        #[arg(long)]
+        tab: Option<String>,
     },
 
     /// Execute JavaScript in the current active tab
@@ -333,6 +342,9 @@ enum SafariAction {
         /// Restrict operations to a Safari profile name parsed from the window title
         #[arg(long)]
         profile: Option<String>,
+        /// Target a specific tab by index or URL/title substring
+        #[arg(long)]
+        tab: Option<String>,
     },
 
     /// Click an element in the current active tab
@@ -924,7 +936,12 @@ fn main() {
                     process::exit(1);
                 }
             },
-            SafariAction::Scroll { direction, amount, profile } => {
+            SafariAction::Scroll { direction, amount, profile, tab } => {
+                if let Some(ref t) = tab {
+                    if let Err(e) = cueward_adapter_macos::safari::focus_tab(t, profile.as_deref()) {
+                        eprintln!("error: {e}"); process::exit(1);
+                    }
+                }
                 match cueward_adapter_macos::safari::scroll(&direction, amount, profile.as_deref()) {
                     Ok(result) => {
                         println!("{}", serde_json::to_string_pretty(&result).unwrap());
@@ -948,7 +965,12 @@ fn main() {
                     }
                 }
             }
-            SafariAction::Read { selector, profile } => {
+            SafariAction::Read { selector, profile, tab } => {
+                if let Some(ref t) = tab {
+                    if let Err(e) = cueward_adapter_macos::safari::focus_tab(t, profile.as_deref()) {
+                        eprintln!("error: {e}"); process::exit(1);
+                    }
+                }
                 match cueward_adapter_macos::safari::read(selector.as_deref(), profile.as_deref()) {
                     Ok(result) => {
                         println!("{}", serde_json::to_string_pretty(&result).unwrap());
@@ -960,7 +982,12 @@ fn main() {
                     }
                 }
             }
-            SafariAction::Source { profile } => {
+            SafariAction::Source { profile, tab } => {
+                if let Some(ref t) = tab {
+                    if let Err(e) = cueward_adapter_macos::safari::focus_tab(t, profile.as_deref()) {
+                        eprintln!("error: {e}"); process::exit(1);
+                    }
+                }
                 match cueward_adapter_macos::safari::source(profile.as_deref()) {
                     Ok(result) => {
                         println!("{}", serde_json::to_string_pretty(&result).unwrap());
@@ -972,7 +999,12 @@ fn main() {
                     }
                 }
             }
-            SafariAction::Exec { js_code, profile } => {
+            SafariAction::Exec { js_code, profile, tab } => {
+                if let Some(ref t) = tab {
+                    if let Err(e) = cueward_adapter_macos::safari::focus_tab(t, profile.as_deref()) {
+                        eprintln!("error: {e}"); process::exit(1);
+                    }
+                }
                 match cueward_adapter_macos::safari::exec(&js_code, profile.as_deref()) {
                     Ok(result) => {
                         println!("{}", serde_json::to_string_pretty(&result).unwrap());
@@ -1557,7 +1589,7 @@ mod tests {
 
         match cli.command {
             Command::Safari {
-                action: SafariAction::Exec { js_code, profile },
+                action: SafariAction::Exec { js_code, profile, .. },
             } => {
                 assert_eq!(js_code, "1+1");
                 assert_eq!(profile.as_deref(), Some("Ryugu"));


### PR DESCRIPTION
## Summary

- Add `focus_tab()` to switch to a specific tab by index or URL/title substring match
- `--tab` flag added to `read`, `exec`, `source`, `scroll` commands
- Works with `--profile` for precise tab targeting
- Closes #32

## Usage

```bash
# By URL match
cueward safari read --tab "gemini.google.com" --profile Ryugu

# By title match
cueward safari exec "document.title" --tab "ChatGPT"

# By index
cueward safari source --tab 2
```

## Test plan

- [x] 71 unit tests pass, zero warnings
- [x] Build succeeds
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
