### PR TITLE
[codex] Stabilize ChatGPT save-images polling

### DIFF
--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -101,9 +101,11 @@ pub struct SafariAiResponseResult {
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct SafariAiImage {
     pub url: String,
+    #[serde(default)]
+    pub loaded: bool,
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct SafariAiImageResult {
     pub provider: String,
     pub mode: String,
@@ -850,7 +852,8 @@ fn chatgpt_image_list_js() -> String {
             alt: img.alt || "",
             src: img.src || "",
             width: img.naturalWidth || img.width || 0,
-            height: img.naturalHeight || img.height || 0
+            height: img.naturalHeight || img.height || 0,
+            loaded: Boolean(img.complete && img.naturalWidth > 0 && img.naturalHeight > 0)
           }))
           .filter((img) => {
             if (!img.src) return false;
@@ -864,7 +867,7 @@ fn chatgpt_image_list_js() -> String {
         for (const img of candidates) {
           if (seen.has(img.src)) continue;
           seen.add(img.src);
-          deduped.push({ url: img.src });
+          deduped.push({ url: img.src, loaded: img.loaded });
         }
 
         const controls = [...document.querySelectorAll('button,[role="button"]')]
@@ -915,15 +918,16 @@ fn poll_chatgpt_images(
         }
         last_result.status = result.status.clone();
 
-        if result.status == "complete" && !result.images.is_empty() {
+        if chatgpt_image_result_is_ready(&result) {
             return Ok(result);
         }
 
-        if result.status == "complete" {
-            if started_at.elapsed() >= Duration::from_secs(empty_complete_grace_seconds) {
-                return Ok(last_result);
-            }
-            continue;
+        if chatgpt_should_return_empty_complete_result(
+            &result,
+            started_at.elapsed(),
+            empty_complete_grace_seconds,
+        ) {
+            return Ok(last_result);
         }
     }
 
@@ -952,6 +956,22 @@ fn chatgpt_image_extract_js(url: &str) -> String {
     )
 }
 
+fn chatgpt_image_result_is_ready(result: &SafariAiImageResult) -> bool {
+    result.status == "complete"
+        && !result.images.is_empty()
+        && result.images.iter().all(|image| image.loaded)
+}
+
+fn chatgpt_should_return_empty_complete_result(
+    result: &SafariAiImageResult,
+    elapsed: Duration,
+    empty_complete_grace_seconds: u64,
+) -> bool {
+    result.status == "complete"
+        && result.images.is_empty()
+        && elapsed >= Duration::from_secs(empty_complete_grace_seconds)
+}
+
 fn parse_chatgpt_image_payload(payload: &str) -> Result<SafariAiImageResult, MacosError> {
     let value: Value = serde_json::from_str(payload).map_err(|error| {
         MacosError::Other(format!("invalid chatgpt image payload: {error}: {payload}"))
@@ -971,9 +991,13 @@ fn parse_chatgpt_image_payload(payload: &str) -> Result<SafariAiImageResult, Mac
         .map(|items| {
             items
                 .iter()
-                .filter_map(|item| item.get("url").and_then(Value::as_str))
-                .map(|url| SafariAiImage {
-                    url: url.to_string(),
+                .filter_map(|item| {
+                    let url = item.get("url")?.as_str()?;
+                    let loaded = item.get("loaded").and_then(Value::as_bool).unwrap_or(false);
+                    Some(SafariAiImage {
+                        url: url.to_string(),
+                        loaded,
+                    })
                 })
                 .collect::<Vec<_>>()
         })
@@ -1172,7 +1196,9 @@ pub fn gemini_save_media(
     })
 }
 
-pub fn threads_extract_feed(profile_filter: Option<&str>) -> Result<Vec<SocialFeedPost>, MacosError> {
+pub fn threads_extract_feed(
+    profile_filter: Option<&str>,
+) -> Result<Vec<SocialFeedPost>, MacosError> {
     // Auto-focus to Threads tab
     let _ = focus_tab("threads.com", profile_filter);
 
@@ -1358,14 +1384,13 @@ pub fn focus_tab(
     } else {
         // Match by URL or title substring
         let query = tab_selector.to_lowercase();
-        all_tabs
-            .into_iter()
-            .find(|t| t.url.to_lowercase().contains(&query) || t.title.to_lowercase().contains(&query))
+        all_tabs.into_iter().find(|t| {
+            t.url.to_lowercase().contains(&query) || t.title.to_lowercase().contains(&query)
+        })
     };
 
-    let tab = matched.ok_or_else(|| {
-        MacosError::Other(format!("no tab matching '{tab_selector}'"))
-    })?;
+    let tab =
+        matched.ok_or_else(|| MacosError::Other(format!("no tab matching '{tab_selector}'")))?;
 
     // Set as current tab
     let script = format!(
@@ -1397,7 +1422,10 @@ pub fn close(index: Option<usize>) -> Result<SafariCloseResult, MacosError> {
     })
 }
 
-pub fn close_tabs(profile_filter: Option<&str>, url_pattern: Option<&str>) -> Result<usize, MacosError> {
+pub fn close_tabs(
+    profile_filter: Option<&str>,
+    url_pattern: Option<&str>,
+) -> Result<usize, MacosError> {
     let all_tabs = tabs(profile_filter)?;
     let to_close: Vec<&SafariTab> = all_tabs
         .iter()
@@ -1924,15 +1952,17 @@ fn execute_js_for_profile(
 #[cfg(test)]
 mod tests {
     use super::{
-        TAB_SEPARATOR, build_active_tab_script, build_chatgpt_click_send_js,
-        build_chatgpt_fill_input_js, build_chatgpt_go_home_js, build_close_script,
-        build_exec_script, build_gemini_fill_input_js, build_gemini_go_home_js, build_open_script,
-        build_tab_return_block, build_tabs_script, chatgpt_image_extract_js, chatgpt_image_list_js,
-        chatgpt_response_extract_js, extract_profile, gemini_deep_research_poll_js,
+        SafariAiImage, SafariAiImageResult, TAB_SEPARATOR, build_active_tab_script,
+        build_chatgpt_click_send_js, build_chatgpt_fill_input_js, build_chatgpt_go_home_js,
+        build_close_script, build_exec_script, build_gemini_fill_input_js, build_gemini_go_home_js,
+        build_open_script, build_tab_return_block, build_tabs_script, chatgpt_image_extract_js,
+        chatgpt_image_list_js, chatgpt_image_result_is_ready, chatgpt_response_extract_js,
+        chatgpt_should_return_empty_complete_result, extract_profile, gemini_deep_research_poll_js,
         gemini_response_extract_js, parse_chatgpt_image_payload, parse_deep_research_payload,
         parse_tab_line, parse_tabs_output, selector_click_js, selector_fill_js, selector_text_js,
         should_skip_chatgpt_response, should_skip_gemini_response,
     };
+    use std::time::Duration;
 
     #[test]
     fn extract_profile_from_window_name() {
@@ -2141,6 +2171,14 @@ mod tests {
     }
 
     #[test]
+    fn chatgpt_image_list_script_includes_loaded_signal() {
+        let script = chatgpt_image_list_js();
+
+        assert!(script.contains("img.complete"));
+        assert!(script.contains("loaded"));
+    }
+
+    #[test]
     fn chatgpt_image_extract_script_targets_url() {
         let script = chatgpt_image_extract_js("https://example.com/img.png");
 
@@ -2164,6 +2202,89 @@ mod tests {
             result.images[0].url,
             "https://chatgpt.com/backend-api/estuary/content?id=file_123"
         );
+    }
+
+    #[test]
+    fn parse_chatgpt_image_payload_reads_loaded_state() {
+        let payload = r#"{"status":"complete","conversation_url":"https://chatgpt.com/c/test","images":[{"url":"https://chatgpt.com/backend-api/estuary/content?id=file_123","loaded":true},{"url":"https://chatgpt.com/backend-api/estuary/content?id=file_456","loaded":false}]}"#;
+        let result = parse_chatgpt_image_payload(payload).expect("parse payload");
+
+        assert_eq!(result.images.len(), 2);
+        assert!(result.images[0].loaded);
+        assert!(!result.images[1].loaded);
+    }
+
+    #[test]
+    fn chatgpt_image_result_requires_all_images_to_be_ready() {
+        let unloaded = SafariAiImageResult {
+            provider: "chatgpt".to_string(),
+            mode: "image".to_string(),
+            status: "complete".to_string(),
+            conversation_url: Some("https://chatgpt.com/c/test".to_string()),
+            images: vec![SafariAiImage {
+                url: "https://chatgpt.com/backend-api/estuary/content?id=file_123".to_string(),
+                loaded: false,
+            }],
+        };
+        let mixed = SafariAiImageResult {
+            images: vec![
+                SafariAiImage {
+                    url: "https://chatgpt.com/backend-api/estuary/content?id=file_123".to_string(),
+                    loaded: true,
+                },
+                SafariAiImage {
+                    url: "https://chatgpt.com/backend-api/estuary/content?id=file_456".to_string(),
+                    loaded: false,
+                },
+            ],
+            ..unloaded.clone()
+        };
+        let loaded = SafariAiImageResult {
+            images: vec![
+                SafariAiImage {
+                    url: "https://chatgpt.com/backend-api/estuary/content?id=file_123".to_string(),
+                    loaded: true,
+                },
+                SafariAiImage {
+                    url: "https://chatgpt.com/backend-api/estuary/content?id=file_456".to_string(),
+                    loaded: true,
+                },
+            ],
+            ..unloaded.clone()
+        };
+
+        assert!(!chatgpt_image_result_is_ready(&unloaded));
+        assert!(!chatgpt_image_result_is_ready(&mixed));
+        assert!(chatgpt_image_result_is_ready(&loaded));
+    }
+
+    #[test]
+    fn chatgpt_empty_complete_grace_only_applies_without_images() {
+        let complete_without_images = SafariAiImageResult {
+            provider: "chatgpt".to_string(),
+            mode: "image".to_string(),
+            status: "complete".to_string(),
+            conversation_url: Some("https://chatgpt.com/c/test".to_string()),
+            images: Vec::new(),
+        };
+        let complete_with_unloaded_images = SafariAiImageResult {
+            images: vec![SafariAiImage {
+                url: "https://chatgpt.com/backend-api/estuary/content?id=file_123".to_string(),
+                loaded: false,
+            }],
+            ..complete_without_images.clone()
+        };
+
+        assert!(chatgpt_should_return_empty_complete_result(
+            &complete_without_images,
+            Duration::from_secs(8),
+            3
+        ));
+        assert!(!chatgpt_should_return_empty_complete_result(
+            &complete_with_unloaded_images,
+            Duration::from_secs(8),
+            3
+        ));
     }
 
     #[test]

--- a/docs/plans/2026-04-12-chatgpt-save-images-stability.md
+++ b/docs/plans/2026-04-12-chatgpt-save-images-stability.md
@@ -1,0 +1,116 @@
+# ChatGPT Save Images Stability Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `safari ai --provider chatgpt save-images` wait until generated images are actually loaded before extraction, so downloads stop failing due to premature capture.
+
+**Architecture:** Extend the ChatGPT image poll payload with a minimal loaded-state signal derived from DOM image readiness, then gate completion on at least one loaded image instead of any matching image node. Keep the existing command shape and save flow intact so this stays a small regression fix rather than a broader pipeline rewrite.
+
+**Tech Stack:** Rust, serde_json, Safari JavaScript injection, cargo test
+
+---
+
+### Task 1: Add regression coverage for loaded image state
+
+**Files:**
+- Modify: `crates/adapter-macos/src/safari.rs`
+- Test: `crates/adapter-macos/src/safari.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a parser-level regression test showing that image payloads can carry `loaded: false/true`, and that the parsed image preserves the flag.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test parse_chatgpt_image_payload_reads_loaded_state -- --exact`
+Expected: FAIL because `SafariAiImage` does not yet include the loaded field.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Extend `SafariAiImage` and `parse_chatgpt_image_payload()` to read and preserve the boolean loaded flag, defaulting to `false` when absent.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test parse_chatgpt_image_payload_reads_loaded_state -- --exact`
+Expected: PASS
+
+### Task 2: Tighten poll completion condition
+
+**Files:**
+- Modify: `crates/adapter-macos/src/safari.rs`
+- Test: `crates/adapter-macos/src/safari.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a small pure-function test covering the intended completion rule:
+- `complete + unloaded images` should not count as ready
+- `complete + at least one loaded image` should count as ready
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test chatgpt_image_result_requires_loaded_images_to_be_ready -- --exact`
+Expected: FAIL because the readiness helper does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Introduce a tiny helper for readiness and use it inside `poll_chatgpt_images()`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test chatgpt_image_result_requires_loaded_images_to_be_ready -- --exact`
+Expected: PASS
+
+### Task 3: Emit loaded state from Safari DOM polling
+
+**Files:**
+- Modify: `crates/adapter-macos/src/safari.rs`
+- Test: `crates/adapter-macos/src/safari.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a string-level test for `chatgpt_image_list_js()` that asserts the script includes image completion signals such as `img.complete` and/or `naturalWidth`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test chatgpt_image_list_script_includes_loaded_signal -- --exact`
+Expected: FAIL because the current script only emits URL and dimensions.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update the JS payload to emit `loaded` based on image readiness, and dedupe while preserving that field.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test chatgpt_image_list_script_includes_loaded_signal -- --exact`
+Expected: PASS
+
+### Task 4: Verify targeted regression path
+
+**Files:**
+- Modify: none
+- Test: existing adapter tests
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+`cargo test parse_chatgpt_image_payload_reads_loaded_state -- --exact`
+`cargo test chatgpt_image_result_requires_loaded_images_to_be_ready -- --exact`
+`cargo test chatgpt_image_list_script_includes_loaded_signal -- --exact`
+
+Expected: all PASS
+
+- [ ] **Step 2: Run broader adapter verification**
+
+Run: `cargo test safari`
+Expected: existing Safari adapter tests stay green
+
+- [ ] **Step 3: Review diff**
+
+Run: `git diff -- crates/adapter-macos/src/safari.rs docs/plans/2026-04-12-chatgpt-save-images-stability.md`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/adapter-macos/src/safari.rs docs/plans/2026-04-12-chatgpt-save-images-stability.md
+git commit -m "fix: wait for loaded ChatGPT images before saving"
+```


### PR DESCRIPTION
## What changed
- added a loaded-state signal to the ChatGPT Safari image poll payload
- changed readiness logic so `save-images` waits for at least one fully loaded image before extraction
- added regression tests covering payload parsing, readiness gating, and emitted DOM signals
- included a short implementation plan document for this fix

## Why
`save-images` could start extraction as soon as matching image nodes appeared in the DOM, even if the underlying image had not finished loading yet. That made saves flaky and sometimes produced empty or failed captures.

## Impact
ChatGPT image saves should be more stable without changing the CLI surface or the broader save flow.

## Validation
- `cargo test -p cueward-adapter-macos safari`
- `cargo test -p cueward-adapter-macos`

## Root cause
The poller treated DOM presence as readiness. The missing piece was an explicit loaded-state check derived from the image element itself.