### PR TITLE
feat: scroll-and-read pipeline for infinite scroll pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
 name = "cueward-adapter-macos"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "chrono",
  "cueward-core",
  "rusqlite",

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -42,6 +42,20 @@ pub struct SafariReadResult {
     pub content: String,
 }
 
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct SafariScrollReadChunk {
+    pub iteration: u64,
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct SafariScrollReadResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selector: Option<String>,
+    pub times: u64,
+    pub chunks: Vec<SafariScrollReadChunk>,
+}
+
 #[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct SafariSourceResult {
     pub html: String,
@@ -1409,7 +1423,13 @@ pub fn focus_tab(
         window_id = tab.window_id,
         one_based = tab.index + 1,
     );
-    run_capture(&script, "safari_focus_tab")?;
+    let result = run_capture(&script, "safari_focus_tab")?;
+    if result.trim() != "true" {
+        return Err(MacosError::Other(format!(
+            "failed to focus tab '{}'",
+            tab_selector
+        )));
+    }
 
     Ok(tab)
 }
@@ -1487,6 +1507,68 @@ pub fn read(
     })
 }
 
+fn block_fingerprint(text: &str) -> String {
+    text.chars().take(120).collect()
+}
+
+fn scroll_read_new_content_blocks(content: &str, seen: &[String]) -> Vec<String> {
+    let seen_fps: Vec<String> = seen.iter().map(|s| block_fingerprint(s)).collect();
+    let mut new_blocks = Vec::new();
+    let mut new_fps = Vec::new();
+    for block in content
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|block| !block.is_empty())
+    {
+        let fp = block_fingerprint(block);
+        if seen_fps.iter().any(|existing| *existing == fp)
+            || new_fps.iter().any(|existing: &String| *existing == fp)
+        {
+            continue;
+        }
+        new_fps.push(fp);
+        new_blocks.push(block.to_string());
+    }
+    new_blocks
+}
+
+fn scroll_read_snapshot_blocks(
+    snapshot: &SafariScrollReadSnapshot,
+    seen: &[String],
+) -> Vec<String> {
+    if !snapshot.blocks.is_empty() {
+        let seen_fps: Vec<String> = seen.iter().map(|s| block_fingerprint(s)).collect();
+        let mut new_blocks = Vec::new();
+        let mut new_fps = Vec::new();
+        for block in &snapshot.blocks {
+            let trimmed = block.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let fp = block_fingerprint(trimmed);
+            if seen_fps.iter().any(|existing| *existing == fp)
+                || new_fps.iter().any(|existing: &String| *existing == fp)
+            {
+                continue;
+            }
+            new_fps.push(fp);
+            new_blocks.push(trimmed.to_string());
+        }
+        return new_blocks;
+    }
+
+    scroll_read_new_content_blocks(&snapshot.content, seen)
+}
+
+fn scroll_read_detects_new_content(
+    previous_text: &str,
+    previous_count: usize,
+    current_text: &str,
+    current_count: usize,
+) -> bool {
+    current_count > previous_count || current_text.trim() != previous_text.trim()
+}
+
 pub fn exec(js_code: &str, profile_filter: Option<&str>) -> Result<SafariEvalResult, MacosError> {
     let result = execute_js_for_profile(js_code, profile_filter, "safari_exec")?;
     Ok(SafariEvalResult { result })
@@ -1547,6 +1629,14 @@ pub struct SafariScrollResult {
     pub scroll_y: i64,
 }
 
+#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+struct SafariScrollReadSnapshot {
+    item_count: usize,
+    content: String,
+    #[serde(default)]
+    blocks: Vec<String>,
+}
+
 pub fn scroll(
     direction: &str,
     amount: Option<i64>,
@@ -1566,6 +1656,139 @@ pub fn scroll(
     Ok(SafariScrollResult {
         scroll_x: value.get("x").and_then(|v| v.as_i64()).unwrap_or(0),
         scroll_y: value.get("y").and_then(|v| v.as_i64()).unwrap_or(0),
+    })
+}
+
+fn scroll_read_poll_js(selector: Option<&str>) -> String {
+    let scope_expr = match selector {
+        Some(selector) => format!(
+            "document.querySelector(\"{}\")",
+            escape_js_string(selector)
+        ),
+        None => "document.body".to_string(),
+    };
+    format!(
+        r#"(() => {{
+            const scope = {scope_expr};
+            if (!scope) return JSON.stringify({{ item_count: 0, content: "", blocks: [] }});
+            const text = (scope.innerText || scope.textContent || "").trim();
+            const isVisible = (node) => {{
+              const rect = node.getBoundingClientRect();
+              return rect.bottom > 0 && rect.top < window.innerHeight;
+            }};
+            // Phase 1: semantic selectors (Reddit, etc.)
+            let itemNodes = [
+              ...scope.querySelectorAll("shreddit-post"),
+              ...scope.querySelectorAll("[data-testid='post-container']"),
+              ...scope.querySelectorAll("article"),
+              ...scope.querySelectorAll("[role='article']")
+            ];
+            // Phase 2: heuristic fallback for CSR sites (Threads, X, etc.)
+            if (itemNodes.length === 0) {{
+              const MIN_TEXT = 50;
+              const MAX_TEXT = 3000;
+              itemNodes = [...scope.querySelectorAll("div")].filter(el => {{
+                const t = (el.innerText || "").trim();
+                if (t.length < MIN_TEXT || t.length > MAX_TEXT) return false;
+                // Skip wrappers: if any direct child div holds >80% of this text, it's a wrapper
+                const kids = el.querySelectorAll(":scope > div");
+                for (const c of kids) {{
+                  if ((c.innerText || "").trim().length > t.length * 0.8) return false;
+                }}
+                return true;
+              }});
+            }}
+            const visibleItemNodes = itemNodes.filter(isVisible);
+            const blocks = [];
+            const seen = new Set();
+            for (const node of visibleItemNodes) {{
+              const block = (node.innerText || node.textContent || "").trim();
+              if (!block || block.length < 20) continue;
+              const key = block.slice(0, 120);
+              if (seen.has(key)) continue;
+              seen.add(key);
+              blocks.push(block);
+            }}
+            const itemCount = visibleItemNodes.length
+              || scope.querySelectorAll("li").length
+              || scope.children.length
+              || 0;
+            return JSON.stringify({{
+              item_count: itemCount,
+              content: text,
+              blocks
+            }});
+        }})()"#
+    )
+}
+
+fn parse_scroll_read_snapshot(payload: &str) -> Result<SafariScrollReadSnapshot, MacosError> {
+    serde_json::from_str(payload)
+        .map_err(|error| MacosError::Other(format!("invalid scroll/read payload: {error}: {payload}")))
+}
+
+fn poll_scroll_read_snapshot(
+    selector: Option<&str>,
+    previous: &SafariScrollReadSnapshot,
+    profile_filter: Option<&str>,
+    timeout: Duration,
+) -> Result<SafariScrollReadSnapshot, MacosError> {
+    let deadline = Instant::now() + timeout;
+    let js = scroll_read_poll_js(selector);
+
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(500));
+        let payload = execute_js_for_profile(&js, profile_filter, "safari_scroll_read_poll")?;
+        let snapshot = parse_scroll_read_snapshot(&payload)?;
+        if scroll_read_detects_new_content(
+            &previous.content,
+            previous.item_count,
+            &snapshot.content,
+            snapshot.item_count,
+        ) {
+            return Ok(snapshot);
+        }
+    }
+
+    let payload = execute_js_for_profile(&js, profile_filter, "safari_scroll_read_poll")?;
+    parse_scroll_read_snapshot(&payload)
+}
+
+pub fn scroll_and_read(
+    times: u64,
+    amount: Option<i64>,
+    selector: Option<&str>,
+    profile_filter: Option<&str>,
+) -> Result<SafariScrollReadResult, MacosError> {
+    let js = scroll_read_poll_js(selector);
+    let payload = execute_js_for_profile(&js, profile_filter, "safari_scroll_read_initial")?;
+    let mut snapshot = parse_scroll_read_snapshot(&payload)?;
+    let mut seen = scroll_read_snapshot_blocks(&snapshot, &[]);
+    let mut chunks = Vec::new();
+
+    for iteration in 1..=times {
+        scroll("down", amount, profile_filter)?;
+        snapshot = poll_scroll_read_snapshot(
+            selector,
+            &snapshot,
+            profile_filter,
+            Duration::from_secs(5),
+        )?;
+        let new_blocks = scroll_read_snapshot_blocks(&snapshot, &seen);
+        if new_blocks.is_empty() {
+            continue;
+        }
+        seen.extend(new_blocks.iter().cloned());
+        chunks.push(SafariScrollReadChunk {
+            iteration,
+            content: new_blocks.join("\n\n"),
+        });
+    }
+
+    Ok(SafariScrollReadResult {
+        selector: selector.map(ToOwned::to_owned),
+        times,
+        chunks,
     })
 }
 
@@ -1952,14 +2175,16 @@ fn execute_js_for_profile(
 #[cfg(test)]
 mod tests {
     use super::{
-        SafariAiImage, SafariAiImageResult, TAB_SEPARATOR, build_active_tab_script,
+        SafariAiImage, SafariAiImageResult, SafariScrollReadSnapshot, TAB_SEPARATOR, build_active_tab_script,
         build_chatgpt_click_send_js, build_chatgpt_fill_input_js, build_chatgpt_go_home_js,
         build_close_script, build_exec_script, build_gemini_fill_input_js, build_gemini_go_home_js,
         build_open_script, build_tab_return_block, build_tabs_script, chatgpt_image_extract_js,
         chatgpt_image_list_js, chatgpt_image_result_is_ready, chatgpt_response_extract_js,
         chatgpt_should_return_empty_complete_result, extract_profile, gemini_deep_research_poll_js,
         gemini_response_extract_js, parse_chatgpt_image_payload, parse_deep_research_payload,
-        parse_tab_line, parse_tabs_output, selector_click_js, selector_fill_js, selector_text_js,
+        parse_tab_line, parse_tabs_output, scroll_read_detects_new_content,
+        scroll_read_poll_js, scroll_read_new_content_blocks, scroll_read_snapshot_blocks,
+        selector_click_js, selector_fill_js, selector_text_js,
         should_skip_chatgpt_response, should_skip_gemini_response,
     };
     use std::time::Duration;
@@ -2285,6 +2510,79 @@ mod tests {
             Duration::from_secs(8),
             3
         ));
+    }
+
+    #[test]
+    fn scroll_read_dedup_keeps_only_new_blocks() {
+        let seen = vec!["alpha".to_string(), "beta".to_string()];
+        let content = "alpha\n\nbeta\n\ngamma\n\ndelta\n\ngamma";
+
+        let blocks = scroll_read_new_content_blocks(content, &seen);
+
+        assert_eq!(blocks, vec!["gamma".to_string(), "delta".to_string()]);
+    }
+
+    #[test]
+    fn scroll_read_change_detection_uses_count_or_text() {
+        assert!(scroll_read_detects_new_content("same", 2, "same", 3));
+        assert!(scroll_read_detects_new_content("before", 2, "after", 2));
+        assert!(!scroll_read_detects_new_content("same", 2, "same", 2));
+    }
+
+    #[test]
+    fn scroll_read_snapshot_blocks_prefers_structured_blocks() {
+        let snapshot = SafariScrollReadSnapshot {
+            item_count: 2,
+            content: "alpha\n\nbeta\n\ngamma".to_string(),
+            blocks: vec!["alpha".to_string(), "gamma".to_string()],
+        };
+
+        let blocks = scroll_read_snapshot_blocks(&snapshot, &["alpha".to_string()]);
+
+        assert_eq!(blocks, vec!["gamma".to_string()]);
+    }
+
+    #[test]
+    fn scroll_read_poll_script_exposes_count_and_text() {
+        let script = scroll_read_poll_js(Some("main"));
+
+        assert!(script.contains("item_count"));
+        assert!(script.contains("content"));
+        assert!(script.contains("blocks"));
+        assert!(script.contains("querySelectorAll(\"article\")"));
+        assert!(script.contains("document.querySelector(\"main\")"));
+    }
+
+    #[test]
+    fn scroll_read_poll_script_uses_visible_items() {
+        let script = scroll_read_poll_js(None);
+
+        assert!(script.contains("getBoundingClientRect"));
+        assert!(script.contains("window.innerHeight"));
+        assert!(script.contains("rect.bottom > 0"));
+    }
+
+    #[test]
+    fn scroll_read_poll_script_has_heuristic_fallback() {
+        let script = scroll_read_poll_js(None);
+
+        // Should fall back to div heuristic when no semantic selectors match
+        assert!(script.contains("itemNodes.length === 0"));
+        assert!(script.contains("querySelectorAll(\"div\")"));
+    }
+
+    #[test]
+    fn scroll_read_fingerprint_dedup_handles_suffix_changes() {
+        // CSR sites may re-render with slightly different suffixes.
+        // Fingerprint uses first 120 chars, so blocks sharing a long prefix get deduped.
+        let long_prefix = "a]".repeat(61); // 122 chars — first 120 identical
+        let seen = vec![format!("{long_prefix}ORIGINAL_SUFFIX")];
+        let content = format!("{long_prefix}UPDATED_SUFFIX\n\ngenuinely new block");
+
+        let blocks = scroll_read_new_content_blocks(&content, &seen);
+
+        // First block matches by prefix fingerprint, should be deduped
+        assert_eq!(blocks, vec!["genuinely new block".to_string()]);
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -304,6 +304,25 @@ enum SafariAction {
         tab: Option<String>,
     },
 
+    /// Scroll repeatedly and return only newly loaded content
+    ScrollAndRead {
+        /// Number of scroll/read iterations
+        #[arg(long, default_value = "1")]
+        times: u64,
+        /// Pixels to scroll each iteration
+        #[arg(long)]
+        amount: Option<i64>,
+        /// Restrict operations to a Safari profile
+        #[arg(long)]
+        profile: Option<String>,
+        /// Target a specific tab by index or URL/title substring
+        #[arg(long)]
+        tab: Option<String>,
+        /// Optional CSS selector to scope the read area
+        #[arg(long)]
+        selector: Option<String>,
+    },
+
     /// Close multiple tabs, optionally filtered by profile and/or URL pattern
     CloseTabs {
         /// Restrict to a Safari profile name
@@ -958,6 +977,28 @@ fn main() {
                     Ok(result) => {
                         println!("{}", serde_json::to_string_pretty(&result).unwrap());
                         eprintln!("scrolled {direction}");
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        process::exit(1);
+                    }
+                }
+            }
+            SafariAction::ScrollAndRead { times, amount, profile, tab, selector } => {
+                if let Some(ref t) = tab {
+                    if let Err(e) = cueward_adapter_macos::safari::focus_tab(t, profile.as_deref()) {
+                        eprintln!("error: {e}"); process::exit(1);
+                    }
+                }
+                match cueward_adapter_macos::safari::scroll_and_read(
+                    times,
+                    amount,
+                    selector.as_deref(),
+                    profile.as_deref(),
+                ) {
+                    Ok(result) => {
+                        print_external("safari/scroll-and-read", &serde_json::to_string_pretty(&result).unwrap());
+                        eprintln!("scroll/read pipeline complete");
                     }
                     Err(e) => {
                         eprintln!("error: {e}");
@@ -1643,6 +1684,42 @@ mod tests {
             Command::Safari {
                 action: SafariAction::Active { profile },
             } => assert_eq!(profile.as_deref(), Some("Ryugu")),
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_scroll_and_read() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "scroll-and-read",
+            "--tab",
+            "x.com",
+            "--profile",
+            "Ryugu",
+            "--times",
+            "3",
+        ])
+        .expect("parse scroll-and-read");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::ScrollAndRead {
+                        tab,
+                        profile,
+                        times,
+                        amount,
+                        selector,
+                    },
+            } => {
+                assert_eq!(tab.as_deref(), Some("x.com"));
+                assert_eq!(profile.as_deref(), Some("Ryugu"));
+                assert_eq!(times, 3);
+                assert_eq!(amount, None);
+                assert_eq!(selector, None);
+            }
             _ => panic!("unexpected command"),
         }
     }

--- a/docs/plans/2026-04-12-scroll-read-pipeline.md
+++ b/docs/plans/2026-04-12-scroll-read-pipeline.md
@@ -1,0 +1,135 @@
+# Scroll Read Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `safari scroll-and-read` pipeline for infinite-scroll pages that scrolls, waits for new content, reads page text, and returns only newly discovered content across iterations.
+
+**Architecture:** Keep the first version generic. Add a new CLI command that delegates to a Safari adapter pipeline built from small pure helpers: one helper decides whether content changed enough to count as new, another dedups newly read blocks across iterations. Use DOM text/item count polling instead of provider-specific extractor coupling so `#49` can land independently of `#48`.
+
+**Tech Stack:** Rust, clap, serde_json, Safari JavaScript injection, cargo test
+
+---
+
+### Task 1: Add CLI coverage for `scroll-and-read`
+
+**Files:**
+- Modify: `crates/cli/src/main.rs`
+- Test: `crates/cli/src/main.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a CLI parse test for:
+`cueward safari scroll-and-read --tab x.com --profile Ryugu --times 3`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test cli_parses_scroll_and_read -- --exact`
+Expected: FAIL because the subcommand does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the new `SafariAction::ScrollAndRead` clap variant with:
+- `--profile`
+- `--tab`
+- `--times`
+- `--amount`
+- optional `--selector`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test cli_parses_scroll_and_read -- --exact`
+Expected: PASS
+
+### Task 2: Lock pipeline helper behavior with pure tests
+
+**Files:**
+- Modify: `crates/adapter-macos/src/safari.rs`
+- Test: `crates/adapter-macos/src/safari.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add pure tests for:
+- dedup keeps only unseen text blocks
+- change detection treats larger DOM counts as newly loaded content
+- fallback text comparison still detects new content when counts are unchanged
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+`cargo test safari::tests::scroll_read_dedup_keeps_only_new_blocks -- --exact`
+`cargo test safari::tests::scroll_read_change_detection_uses_count_or_text -- --exact`
+Expected: FAIL because helpers do not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add focused helpers for:
+- normalizing/deduping text blocks
+- deciding whether a poll result contains newly loaded content
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run the two tests above again.
+Expected: PASS
+
+### Task 3: Implement Safari adapter pipeline
+
+**Files:**
+- Modify: `crates/adapter-macos/src/safari.rs`
+- Test: `crates/adapter-macos/src/safari.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a JS string-level test showing the poll script emits both a content count and page text snapshot for change detection.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test safari::tests::scroll_read_poll_script_exposes_count_and_text -- --exact`
+Expected: FAIL because no such poll script exists.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implement:
+- a Safari JS poll snippet returning item count + body/selector text
+- `scroll_and_read(...)` pipeline:
+  - optional tab focus
+  - initial baseline read
+  - repeat N times:
+    - scroll
+    - poll until count/text changes or timeout
+    - read current content snapshot
+    - return only newly discovered blocks
+
+- [ ] **Step 4: Run targeted tests to verify it passes**
+
+Run:
+`cargo test safari::tests::scroll_read_poll_script_exposes_count_and_text -- --exact`
+`cargo test safari::tests::scroll_read_dedup_keeps_only_new_blocks -- --exact`
+`cargo test safari::tests::scroll_read_change_detection_uses_count_or_text -- --exact`
+Expected: PASS
+
+### Task 4: Wire CLI to adapter and verify end-to-end command surface
+
+**Files:**
+- Modify: `crates/cli/src/main.rs`
+- Modify: `crates/adapter-macos/src/safari.rs`
+
+- [ ] **Step 1: Implement command handling**
+
+Wire `SafariAction::ScrollAndRead` to the new adapter function and print structured JSON via `print_external`.
+
+- [ ] **Step 2: Run focused verification**
+
+Run:
+`cargo test -p cueward-adapter-macos safari`
+`cargo test -p cueward cli_parses_scroll_and_read -- --exact`
+
+- [ ] **Step 3: Run broader package verification**
+
+Run:
+`cargo test -p cueward-adapter-macos`
+
+- [ ] **Step 4: Review diff**
+
+Run:
+`git diff -- crates/cli/src/main.rs crates/adapter-macos/src/safari.rs docs/plans/2026-04-12-scroll-read-pipeline.md`
+


### PR DESCRIPTION
## Summary

- 新增 `safari scroll-and-read` 指令，支援 infinite scroll 頁面的連續捲動讀取
- Codex 完成基礎架構（CLI、poll JS、dedup 純函數、測試），我接手修復 CSR 頁面抓不到內容的問題

## 問題

Codex 原始的 poll JS 只找 `article`、`[role="article"]`、`shreddit-post` 等 semantic 標籤。Threads 和 X 這類 CSR 框架用 obfuscated CSS class + 純 `div` 結構，全部命中 0，導致 chunks 永遠為空。

## 修復

- **Heuristic fallback**：semantic selector 命中 0 時，改找 50-3000 字元的 leaf-ish div（排除任何直接子 div 佔自身文字 80% 以上的 wrapper）
- **Fingerprint dedup**：用前 120 字元做指紋比對，不再全文 match，CSR rerender 微調不會破壞 dedup

## 測試

- 83 個測試全過（含 7 個新增的 scroll-read 測試）
- 實測 Threads（@coskeeper）和 Reddit 都能正確抓到新內容

## Test plan

- [ ] `cargo test` 全過
- [ ] `cueward safari scroll-and-read --tab "threads.com" --profile Ryugu --times 3` 有 chunks
- [ ] `cueward safari scroll-and-read --tab "reddit.com" --profile Ryugu --times 2` 有 chunks
- [ ] Reddit 走 semantic path（shreddit-post），Threads 走 heuristic path

Closes #49
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
