### PR TITLE
[codex] Add ChatGPT conversation list extraction

### DIFF
--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -1061,6 +1061,49 @@ pub fn gemini_list_conversations(
     Ok(items)
 }
 
+fn chatgpt_list_conversations_js() -> String {
+    r#"(() => {
+        const nav = document.querySelector('nav[aria-label="聊天歷程紀錄"]');
+        if (!nav) return JSON.stringify([]);
+        const recentButton = Array.from(nav.querySelectorAll("button"))
+          .find((button) => (button.innerText || button.textContent || "").trim() === "最近");
+        if (recentButton && recentButton.getAttribute("aria-expanded") === "false") {
+          recentButton.click();
+        }
+        const items = Array.from(nav.querySelectorAll('a[href^="/c/"]'));
+        const convos = [];
+        const seen = new Set();
+        for (const a of items) {
+          const href = a.getAttribute("href") || "";
+          const title = (a.innerText || a.textContent || a.getAttribute("aria-label") || "").trim();
+          if (!href || !title || seen.has(href)) continue;
+          seen.add(href);
+          convos.push({ title, url: "https://chatgpt.com" + href });
+        }
+        return JSON.stringify(convos);
+    })()"#
+        .to_string()
+}
+
+pub fn chatgpt_list_conversations(
+    profile_filter: Option<&str>,
+) -> Result<Vec<SafariConversation>, MacosError> {
+    let js = chatgpt_list_conversations_js();
+    let deadline = Instant::now() + Duration::from_secs(10);
+
+    while Instant::now() < deadline {
+        let raw = execute_js_for_profile(&js, profile_filter, "safari_chatgpt_list_conversations")?;
+        let items: Vec<SafariConversation> = serde_json::from_str(&raw)
+            .map_err(|e| MacosError::Other(format!("failed to parse conversations: {e}")))?;
+        if !items.is_empty() {
+            return Ok(items);
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+
+    Ok(Vec::new())
+}
+
 pub fn gemini_read_conversation(
     url: &str,
     profile_filter: Option<&str>,
@@ -2180,6 +2223,7 @@ mod tests {
         build_close_script, build_exec_script, build_gemini_fill_input_js, build_gemini_go_home_js,
         build_open_script, build_tab_return_block, build_tabs_script, chatgpt_image_extract_js,
         chatgpt_image_list_js, chatgpt_image_result_is_ready, chatgpt_response_extract_js,
+        chatgpt_list_conversations_js,
         chatgpt_should_return_empty_complete_result, extract_profile, gemini_deep_research_poll_js,
         gemini_response_extract_js, parse_chatgpt_image_payload, parse_deep_research_payload,
         parse_tab_line, parse_tabs_output, scroll_read_detects_new_content,
@@ -2384,6 +2428,16 @@ mod tests {
         assert!(script.contains("conversation_url"));
         assert!(script.contains("window.location.href"));
         assert!(script.contains("complete"));
+    }
+
+    #[test]
+    fn chatgpt_list_script_targets_history_nav_links() {
+        let script = chatgpt_list_conversations_js();
+
+        assert!(script.contains("nav[aria-label=\"聊天歷程紀錄\"]"));
+        assert!(script.contains("a[href^=\"/c/\"]"));
+        assert!(script.contains("https://chatgpt.com"));
+        assert!(script.contains("最近"));
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1310,9 +1310,21 @@ fn main() {
                                 }
                             }
                         }
+                        SafariAiAction::List => {
+                            match cueward_adapter_macos::safari::chatgpt_list_conversations(p) {
+                                Ok(convos) => {
+                                    print_external("safari/ai/chatgpt/list", &serde_json::to_string_pretty(&convos).unwrap());
+                                    eprintln!("{} conversation(s)", convos.len());
+                                }
+                                Err(e) => {
+                                    eprintln!("error: {e}");
+                                    process::exit(1);
+                                }
+                            }
+                        }
                         _ => {
                             eprintln!(
-                                "error: ChatGPT currently supports only prompt and save-images"
+                                "error: ChatGPT currently supports prompt, list, and save-images"
                             );
                             process::exit(1);
                         }
@@ -1914,6 +1926,26 @@ mod tests {
                     },
             } => {
                 assert_eq!(provider, SafariAiProvider::Gemini);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_chatgpt_list() {
+        let cli = Cli::try_parse_from(["cueward", "safari", "ai", "--provider", "chatgpt", "list"])
+            .expect("parse");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        action: SafariAiAction::List,
+                        ..
+                    },
+            } => {
+                assert_eq!(provider, SafariAiProvider::Chatgpt);
             }
             _ => panic!("unexpected command"),
         }


### PR DESCRIPTION
## What changed
- added ChatGPT conversation list extraction for `safari ai --provider chatgpt list`
- implemented a ChatGPT-specific DOM query against `nav[aria-label="聊天歷程紀錄"]`
- extracted conversation title/url pairs from the `最近` section using `/c/...` links
- wired the new list action into the CLI path for the ChatGPT provider
- added coverage for CLI parsing and the ChatGPT list selector strategy

## Why
Issue #54 needed ChatGPT conversation listing, but the sidebar DOM differs from Gemini and initial exploration through the wrong container (`aside`) missed the actual history list.

## Impact
Users can now list recent ChatGPT conversations from Safari automation through the existing provider-based CLI surface.

## Validation
- `cargo test -p cueward-adapter-macos safari`
- `cargo test`
- `cargo run -- safari ai --provider chatgpt --profile Ryugu list`

## Notes
The implemented path reads from the left history nav rather than the search modal, because the actual recent conversation links are rendered in `nav[aria-label="聊天歷程紀錄"]` under the `最近` section.