### PR TITLE
feat: Grok Safari AI provider (#42)

### DIFF
--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -902,6 +902,10 @@ fn should_skip_chatgpt_response(trimmed: &str, prompt: &str) -> bool {
     trimmed.is_empty() || trimmed == prompt.trim()
 }
 
+fn should_skip_grok_response(trimmed: &str, prompt: &str) -> bool {
+    trimmed.is_empty() || trimmed == prompt.trim()
+}
+
 fn gemini_mode_slug(mode: GeminiMode) -> &'static str {
     match mode {
         GeminiMode::Image => "image",
@@ -936,6 +940,14 @@ fn build_chatgpt_go_home_js() -> String {
         .to_string()
 }
 
+fn build_grok_go_home_js() -> String {
+    r#"(function() {
+        window.location.href = "https://grok.com/";
+        return "true";
+    })()"#
+        .to_string()
+}
+
 pub fn ensure_gemini_home(profile_filter: Option<&str>) -> Result<(), MacosError> {
     with_safari_session(|| {
         let _ = execute_js_for_profile(
@@ -954,6 +966,18 @@ pub fn ensure_chatgpt_home(profile_filter: Option<&str>) -> Result<(), MacosErro
             &build_chatgpt_go_home_js(),
             profile_filter,
             "safari_chatgpt_go_home",
+        )?;
+        thread::sleep(Duration::from_millis(2500));
+        Ok(())
+    })
+}
+
+pub fn ensure_grok_home(profile_filter: Option<&str>) -> Result<(), MacosError> {
+    with_safari_session(|| {
+        let _ = execute_js_for_profile(
+            &build_grok_go_home_js(),
+            profile_filter,
+            "safari_grok_go_home",
         )?;
         thread::sleep(Duration::from_millis(2500));
         Ok(())
@@ -1029,6 +1053,26 @@ fn build_chatgpt_fill_input_js(prompt: &str) -> String {
     )
 }
 
+fn build_grok_fill_input_js(prompt: &str) -> String {
+    let prompt = escape_js_string(prompt);
+    format!(
+        r##"(() => {{
+            const input = document.querySelector(
+              "textarea, textarea[placeholder], div[contenteditable='true'][role='textbox'], div[contenteditable='true']"
+            );
+            if (!input) throw new Error("grok input not found");
+            input.focus();
+            if ("value" in input) {{
+              input.value = "";
+            }} else {{
+              input.textContent = "";
+            }}
+            document.execCommand("insertText", false, "{prompt}");
+            return "true";
+        }})()"##
+    )
+}
+
 fn wait_and_click_send(profile_filter: Option<&str>) -> Result<(), MacosError> {
     let js = &build_gemini_click_send_js();
     let deadline = Instant::now() + Duration::from_secs(5);
@@ -1087,12 +1131,49 @@ fn build_chatgpt_click_send_js() -> String {
         .to_string()
 }
 
+fn build_grok_click_send_js() -> String {
+    r#"(() => {
+        const sendLabels = ["Send", "Ask Grok", "提交", "傳送", "送出"];
+        const buttons = [...document.querySelectorAll('button,[role="button"]')];
+        for (const button of buttons) {
+          const label = [
+            button.getAttribute("aria-label"),
+            button.getAttribute("title"),
+            button.getAttribute("data-testid"),
+            button.innerText,
+            button.textContent
+          ].filter(Boolean).join(" ");
+          if (!sendLabels.some((v) => label.includes(v))) continue;
+          if (button.disabled || button.getAttribute("aria-disabled") == "true") return "disabled";
+          button.click();
+          return "true";
+        }
+        return "false";
+    })()"#
+        .to_string()
+}
+
 fn wait_and_click_chatgpt_send(profile_filter: Option<&str>) -> Result<(), MacosError> {
     let js = &build_chatgpt_click_send_js();
     let deadline = Instant::now() + Duration::from_secs(5);
     while Instant::now() < deadline {
         thread::sleep(Duration::from_millis(200));
         let result = execute_js_for_profile(js, profile_filter, "safari_chatgpt_wait_send")?;
+        if result.trim() == "true" {
+            return Ok(());
+        }
+    }
+    Err(MacosError::Other(
+        "send button not found or disabled after 5s".to_string(),
+    ))
+}
+
+fn wait_and_click_grok_send(profile_filter: Option<&str>) -> Result<(), MacosError> {
+    let js = &build_grok_click_send_js();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(200));
+        let result = execute_js_for_profile(js, profile_filter, "safari_grok_wait_send")?;
         if result.trim() == "true" {
             return Ok(());
         }
@@ -1178,6 +1259,57 @@ fn chatgpt_response_extract_js() -> String {
           ].filter(Boolean).join(" "))
           .join(" ");
         const isRunning = /Stop generating|Stop streaming|停止生成|停止串流/.test(controls);
+
+        return JSON.stringify({
+          status: response ? (isRunning ? "running" : "complete") : "running",
+          response,
+          conversation_url: getConversationUrl()
+        });
+    })()"#
+        .to_string()
+}
+
+fn grok_response_extract_js() -> String {
+    r#"(() => {
+        const getConversationUrl = () => {
+          const url = window.location.href || "";
+          if (/grok\.com\/share\//i.test(url)) return url;
+          if (/grok\.com\/c\//i.test(url)) return url;
+          if (/grok\.com\/history/i.test(url)) return url;
+          return null;
+        };
+        const extractText = (node) => (node?.innerText || node?.textContent || "").trim();
+        const selectors = [
+          'article',
+          '[data-testid*="message"]',
+          '[data-testid*="conversation"]',
+          'main .prose',
+          'main article'
+        ];
+
+        let response = "";
+        for (const selector of selectors) {
+          const nodes = [...document.querySelectorAll(selector)];
+          for (let i = nodes.length - 1; i >= 0; i--) {
+            const text = extractText(nodes[i]);
+            if (text) {
+              response = text;
+              break;
+            }
+          }
+          if (response) break;
+        }
+
+        const controls = [...document.querySelectorAll('button,[role="button"]')]
+          .map((button) => [
+            button.getAttribute("aria-label"),
+            button.getAttribute("title"),
+            button.getAttribute("data-testid"),
+            button.innerText,
+            button.textContent
+          ].filter(Boolean).join(" "))
+          .join(" ");
+        const isRunning = /Stop|停止|Thinking|Generating/.test(controls);
 
         return JSON.stringify({
           status: response ? (isRunning ? "running" : "complete") : "running",
@@ -1420,6 +1552,26 @@ fn chatgpt_list_conversations_js() -> String {
         .to_string()
 }
 
+fn grok_list_conversations_js() -> String {
+    r#"(() => {
+        const items = Array.from(document.querySelectorAll('a[href^="/c/"], a.peer\\/menu-button[href^="/c/"]'));
+        const convos = [];
+        const seen = new Set();
+        for (const a of items) {
+          const href = a.getAttribute("href") || "";
+          const title = (a.innerText || a.textContent || a.getAttribute("aria-label") || "").trim();
+          if (!href || !title) continue;
+          const url = href.startsWith("http") ? href : "https://grok.com" + href;
+          if (!/grok\.com\/c\//i.test(url)) continue;
+          if (seen.has(url)) continue;
+          seen.add(url);
+          convos.push({ title, url });
+        }
+        return JSON.stringify(convos);
+    })()"#
+        .to_string()
+}
+
 pub fn chatgpt_list_conversations(
     profile_filter: Option<&str>,
 ) -> Result<Vec<SafariConversation>, MacosError> {
@@ -1430,6 +1582,28 @@ pub fn chatgpt_list_conversations(
         while Instant::now() < deadline {
             let raw =
                 execute_js_for_profile(&js, profile_filter, "safari_chatgpt_list_conversations")?;
+            let items: Vec<SafariConversation> = serde_json::from_str(&raw)
+                .map_err(|e| MacosError::Other(format!("failed to parse conversations: {e}")))?;
+            if !items.is_empty() {
+                return Ok(items);
+            }
+            thread::sleep(Duration::from_millis(500));
+        }
+
+        Ok(Vec::new())
+    })
+}
+
+pub fn grok_list_conversations(
+    profile_filter: Option<&str>,
+) -> Result<Vec<SafariConversation>, MacosError> {
+    with_safari_session(|| {
+        let js = grok_list_conversations_js();
+        let deadline = Instant::now() + Duration::from_secs(10);
+
+        while Instant::now() < deadline {
+            let raw =
+                execute_js_for_profile(&js, profile_filter, "safari_grok_list_conversations")?;
             let items: Vec<SafariConversation> = serde_json::from_str(&raw)
                 .map_err(|e| MacosError::Other(format!("failed to parse conversations: {e}")))?;
             if !items.is_empty() {
@@ -1478,6 +1652,70 @@ pub fn gemini_read_conversation(
             status: status.to_string(),
             response: response.to_string(),
             conversation_url: None,
+        })
+    })
+}
+
+pub fn grok_read_conversation(
+    url: &str,
+    profile_filter: Option<&str>,
+) -> Result<SafariAiResponseResult, MacosError> {
+    with_safari_session(|| {
+        let nav_js = format!(
+            r#"(function() {{ window.location.href = "{url}"; return "true"; }})()"#,
+            url = escape_js_string(url),
+        );
+        let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_grok_read_navigate")?;
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let response_js = grok_response_extract_js();
+        let mut last_response = String::new();
+        let mut last_conversation_url: Option<String> = None;
+
+        while Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(750));
+            let payload =
+                execute_js_for_profile(&response_js, profile_filter, "safari_grok_read_response")?;
+            let value: Value = serde_json::from_str(&payload).map_err(|e| {
+                MacosError::Other(format!("failed to parse grok response payload: {e}"))
+            })?;
+
+            let status = value
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("running");
+            let response = value
+                .get("response")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim();
+            let conversation_url = value
+                .get("conversation_url")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+
+            if conversation_url.is_some() {
+                last_conversation_url = conversation_url.clone();
+            }
+            if !response.is_empty() {
+                last_response = response.to_string();
+            }
+
+            if status == "complete" && !response.is_empty() {
+                return Ok(SafariAiResponseResult {
+                    provider: "grok".to_string(),
+                    status: "complete".to_string(),
+                    response: response.to_string(),
+                    conversation_url: conversation_url.or_else(|| last_conversation_url.clone()),
+                });
+            }
+        }
+
+        Ok(SafariAiResponseResult {
+            provider: "grok".to_string(),
+            status: "timeout".to_string(),
+            response: last_response,
+            conversation_url: last_conversation_url,
         })
     })
 }
@@ -2526,6 +2764,82 @@ pub fn send_chatgpt_prompt(
     })
 }
 
+pub fn send_grok_prompt(
+    prompt: &str,
+    profile_filter: Option<&str>,
+) -> Result<SafariAiResponseResult, MacosError> {
+    with_safari_session(|| {
+        let filled = execute_js_for_profile(
+            &build_grok_fill_input_js(prompt),
+            profile_filter,
+            "safari_grok_prompt_fill",
+        )?;
+        if filled.trim() != "true" {
+            return Err(MacosError::Other(format!(
+                "failed to fill Grok input: {filled}"
+            )));
+        }
+
+        wait_and_click_grok_send(profile_filter)?;
+
+        let deadline = Instant::now() + Duration::from_secs(120);
+        let response_js = grok_response_extract_js();
+        let mut last_response = String::new();
+        let mut last_conversation_url: Option<String> = None;
+
+        while Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(750));
+            let payload =
+                execute_js_for_profile(&response_js, profile_filter, "safari_grok_response")?;
+            let value: Value = serde_json::from_str(&payload).map_err(|e| {
+                MacosError::Other(format!("failed to parse grok response payload: {e}"))
+            })?;
+
+            let status = value
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("running");
+            let response = value
+                .get("response")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim();
+            let conversation_url = value
+                .get("conversation_url")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            if conversation_url.is_some() {
+                last_conversation_url = conversation_url.clone();
+            }
+
+            let should_skip = should_skip_grok_response(response, prompt);
+            if !should_skip {
+                last_response = response.to_string();
+            }
+
+            if status == "complete" {
+                return Ok(SafariAiResponseResult {
+                    provider: "grok".to_string(),
+                    status: "complete".to_string(),
+                    response: if should_skip {
+                        last_response.clone()
+                    } else {
+                        response.to_string()
+                    },
+                    conversation_url: conversation_url.or_else(|| last_conversation_url.clone()),
+                });
+            }
+        }
+
+        Ok(SafariAiResponseResult {
+            provider: "grok".to_string(),
+            status: "timeout".to_string(),
+            response: last_response,
+            conversation_url: last_conversation_url,
+        })
+    })
+}
+
 pub fn send_chatgpt_image_prompt(
     prompt: &str,
     profile_filter: Option<&str>,
@@ -2630,17 +2944,19 @@ mod tests {
         SafariAutomationSession, SafariLockFile, SafariScrollReadSnapshot, TAB_SEPARATOR,
         acquire_safari_lock, build_active_tab_script, build_chatgpt_click_send_js,
         build_chatgpt_fill_input_js, build_chatgpt_go_home_js, build_close_script,
-        build_exec_script, build_gemini_fill_input_js, build_gemini_go_home_js, build_open_script,
-        build_tab_return_block, build_tabs_script, chatgpt_image_extract_js, chatgpt_image_list_js,
-        chatgpt_image_result_is_ready, chatgpt_list_conversations_js, chatgpt_response_extract_js,
-        chatgpt_should_return_empty_complete_result, compute_next_safari_operation,
-        extract_profile, gemini_deep_research_poll_js, gemini_response_extract_js,
+        build_exec_script, build_gemini_fill_input_js, build_gemini_go_home_js,
+        build_grok_click_send_js, build_grok_fill_input_js, build_grok_go_home_js,
+        build_open_script, build_tab_return_block, build_tabs_script, chatgpt_image_extract_js,
+        chatgpt_image_list_js, chatgpt_image_result_is_ready, chatgpt_list_conversations_js,
+        chatgpt_response_extract_js, chatgpt_should_return_empty_complete_result,
+        compute_next_safari_operation, extract_profile, gemini_deep_research_poll_js,
+        gemini_response_extract_js, grok_list_conversations_js, grok_response_extract_js,
         is_safari_rate_limited, parse_chatgpt_image_payload, parse_deep_research_payload,
         parse_tab_line, parse_tabs_output, read_safari_lock, release_safari_lock,
         safari_automation_state, safari_rate_limit_backoff, scroll_read_detects_new_content,
         scroll_read_new_content_blocks, scroll_read_poll_js, scroll_read_snapshot_blocks,
         selector_click_js, selector_fill_js, selector_text_js, should_skip_chatgpt_response,
-        should_skip_gemini_response, x_extract_feed_js, x_search_url,
+        should_skip_gemini_response, should_skip_grok_response, x_extract_feed_js, x_search_url,
     };
     use std::fs;
     use std::time::{Duration, Instant};
@@ -2841,6 +3157,52 @@ mod tests {
         assert!(script.contains("conversation_url"));
         assert!(script.contains("window.location.href"));
         assert!(script.contains("complete"));
+    }
+
+    #[test]
+    fn grok_go_home_script_targets_root_page() {
+        let script = build_grok_go_home_js();
+
+        assert!(script.contains("https://grok.com/"));
+        assert!(script.contains("window.location.href"));
+    }
+
+    #[test]
+    fn grok_fill_input_script_targets_prompt_editor() {
+        let script = build_grok_fill_input_js("hello from grok");
+
+        assert!(script.contains("textarea"));
+        assert!(script.contains("contenteditable='true'"));
+        assert!(script.contains("hello from grok"));
+    }
+
+    #[test]
+    fn grok_click_send_script_checks_accessible_labels() {
+        let script = build_grok_click_send_js();
+
+        assert!(script.contains("Ask Grok"));
+        assert!(script.contains("提交"));
+        assert!(script.contains("aria-label"));
+        assert!(script.contains("data-testid"));
+    }
+
+    #[test]
+    fn grok_response_extract_script_returns_response_and_conversation_url() {
+        let script = grok_response_extract_js();
+
+        assert!(script.contains("grok\\.com\\/share\\/"));
+        assert!(script.contains("conversation_url"));
+        assert!(script.contains("window.location.href"));
+        assert!(script.contains("complete"));
+    }
+
+    #[test]
+    fn grok_list_script_targets_share_and_history_links() {
+        let script = grok_list_conversations_js();
+
+        assert!(script.contains("a[href^=\"/c/\"]"));
+        assert!(script.contains("a.peer\\\\/menu-button[href^=\"/c/\"]"));
+        assert!(script.contains("https://grok.com"));
     }
 
     #[test]
@@ -3062,6 +3424,12 @@ mod tests {
     fn should_skip_chatgpt_response_trims_prompt_whitespace() {
         assert!(should_skip_chatgpt_response("hello", "  hello  "));
         assert!(!should_skip_chatgpt_response("world", "  hello  "));
+    }
+
+    #[test]
+    fn should_skip_grok_response_trims_prompt_whitespace() {
+        assert!(should_skip_grok_response("hello", "  hello  "));
+        assert!(!should_skip_grok_response("world", "  hello  "));
     }
 
     #[test]

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -1133,7 +1133,7 @@ fn build_chatgpt_click_send_js() -> String {
 
 fn build_grok_click_send_js() -> String {
     r#"(() => {
-        const sendLabels = ["Send", "Ask Grok", "提交", "傳送", "送出"];
+        const sendLabels = ["send", "ask grok", "提交", "傳送", "送出"];
         const buttons = [...document.querySelectorAll('button,[role="button"]')];
         for (const button of buttons) {
           const label = [
@@ -1142,7 +1142,7 @@ fn build_grok_click_send_js() -> String {
             button.getAttribute("data-testid"),
             button.innerText,
             button.textContent
-          ].filter(Boolean).join(" ");
+          ].filter(Boolean).join(" ").toLowerCase();
           if (!sendLabels.some((v) => label.includes(v))) continue;
           if (button.disabled || button.getAttribute("aria-disabled") == "true") return "disabled";
           button.click();
@@ -1309,7 +1309,7 @@ fn grok_response_extract_js() -> String {
             button.textContent
           ].filter(Boolean).join(" "))
           .join(" ");
-        const isRunning = /Stop|停止|Thinking|Generating/.test(controls);
+        const isRunning = /Stop|停止|Thinking|Generating/i.test(controls);
 
         return JSON.stringify({
           status: response ? (isRunning ? "running" : "complete") : "running",
@@ -1666,6 +1666,7 @@ pub fn grok_read_conversation(
             url = escape_js_string(url),
         );
         let _ = execute_js_for_profile(&nav_js, profile_filter, "safari_grok_read_navigate")?;
+        thread::sleep(Duration::from_millis(3000));
 
         let deadline = Instant::now() + Duration::from_secs(30);
         let response_js = grok_response_extract_js();
@@ -3180,7 +3181,7 @@ mod tests {
     fn grok_click_send_script_checks_accessible_labels() {
         let script = build_grok_click_send_js();
 
-        assert!(script.contains("Ask Grok"));
+        assert!(script.contains("ask grok"));
         assert!(script.contains("提交"));
         assert!(script.contains("aria-label"));
         assert!(script.contains("data-testid"));

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -1304,12 +1304,11 @@ fn grok_response_extract_js() -> String {
           .map((button) => [
             button.getAttribute("aria-label"),
             button.getAttribute("title"),
-            button.getAttribute("data-testid"),
             button.innerText,
             button.textContent
           ].filter(Boolean).join(" "))
           .join(" ");
-        const isRunning = /Stop|停止|Thinking|Generating/i.test(controls);
+        const isRunning = /Stop generating|Stop responding|停止生成|停止回應|Thinking\.\.\.|Generating/i.test(controls);
 
         return JSON.stringify({
           status: response ? (isRunning ? "running" : "complete") : "running",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -198,6 +198,7 @@ enum NotesAction {
 enum SafariAiProvider {
     Gemini,
     Chatgpt,
+    Grok,
     Threads,
     X,
 }
@@ -1394,6 +1395,77 @@ fn main() {
                             process::exit(1);
                         }
                     },
+                    SafariAiProvider::Grok => match action {
+                        SafariAiAction::Prompt {
+                            prompt,
+                            mode,
+                            auto_confirm,
+                        } => {
+                            if auto_confirm {
+                                eprintln!("error: Grok prompt does not support --auto-confirm");
+                                process::exit(1);
+                            }
+                            if mode.is_some() {
+                                eprintln!("error: Grok prompt does not support --mode yet");
+                                process::exit(1);
+                            }
+                            if let Err(e) = cueward_adapter_macos::safari::ensure_grok_home(p) {
+                                eprintln!("error: {e}");
+                                process::exit(1);
+                            }
+                            match cueward_adapter_macos::safari::send_grok_prompt(&prompt, p) {
+                                Ok(r) => {
+                                    print_external(
+                                        "safari/ai/grok",
+                                        &serde_json::to_string_pretty(&r).unwrap(),
+                                    );
+                                    eprintln!("grok response ready");
+                                }
+                                Err(e) => {
+                                    eprintln!("error: {e}");
+                                    process::exit(1);
+                                }
+                            }
+                        }
+                        SafariAiAction::List => {
+                            if let Err(e) = cueward_adapter_macos::safari::ensure_grok_home(p) {
+                                eprintln!("error: {e}");
+                                process::exit(1);
+                            }
+                            match cueward_adapter_macos::safari::grok_list_conversations(p) {
+                                Ok(convos) => {
+                                    print_external(
+                                        "safari/ai/grok/list",
+                                        &serde_json::to_string_pretty(&convos).unwrap(),
+                                    );
+                                    eprintln!("{} conversation(s)", convos.len());
+                                }
+                                Err(e) => {
+                                    eprintln!("error: {e}");
+                                    process::exit(1);
+                                }
+                            }
+                        }
+                        SafariAiAction::Read { url } => {
+                            match cueward_adapter_macos::safari::grok_read_conversation(&url, p) {
+                                Ok(r) => {
+                                    print_external(
+                                        "safari/ai/grok/read",
+                                        &serde_json::to_string_pretty(&r).unwrap(),
+                                    );
+                                    eprintln!("conversation read");
+                                }
+                                Err(e) => {
+                                    eprintln!("error: {e}");
+                                    process::exit(1);
+                                }
+                            }
+                        }
+                        _ => {
+                            eprintln!("error: Grok currently supports only prompt, list, and read");
+                            process::exit(1);
+                        }
+                    },
                     SafariAiProvider::Threads => match action {
                         SafariAiAction::List => {
                             match cueward_adapter_macos::safari::threads_extract_feed(p) {
@@ -2054,6 +2126,92 @@ mod tests {
                     },
             } => {
                 assert_eq!(provider, SafariAiProvider::Gemini);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_grok_prompt_only() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "grok",
+            "prompt",
+            "--prompt",
+            "哈囉 Grok",
+        ])
+        .expect("parse");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        action:
+                            SafariAiAction::Prompt {
+                                prompt,
+                                mode,
+                                auto_confirm,
+                            },
+                        ..
+                    },
+            } => {
+                assert_eq!(provider, SafariAiProvider::Grok);
+                assert_eq!(prompt, "哈囉 Grok");
+                assert_eq!(mode, None);
+                assert!(!auto_confirm);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_grok_list() {
+        let cli = Cli::try_parse_from(["cueward", "safari", "ai", "--provider", "grok", "list"])
+            .expect("parse");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        action: SafariAiAction::List,
+                        ..
+                    },
+            } => {
+                assert_eq!(provider, SafariAiProvider::Grok);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_grok_read() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "ai",
+            "--provider",
+            "grok",
+            "read",
+            "https://grok.com/c/abc",
+        ])
+        .expect("parse");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Ai {
+                        provider,
+                        action: SafariAiAction::Read { url },
+                        ..
+                    },
+            } => {
+                assert_eq!(provider, SafariAiProvider::Grok);
+                assert_eq!(url, "https://grok.com/c/abc");
             }
             _ => panic!("unexpected command"),
         }


### PR DESCRIPTION
## Summary

- 新增 Grok Safari AI provider（prompt、list、read）
- JS 選擇器支援 textarea + contenteditable 雙 fallback
- send 按鈕多語言匹配（Send、Ask Grok、提交、傳送）
- response extract 偵測 running/complete 狀態
- conversation list 解析 `/c/` 路徑
- 全包 `with_safari_session()` 吃 rate limit + lock

## Test plan

- [x] `grok_go_home` script 測試
- [x] `grok_fill_input` script 測試
- [x] `grok_click_send` script 測試
- [x] `grok_response_extract` script 測試
- [x] `grok_list_conversations` script 測試
- [x] `should_skip_grok_response` 測試
- [x] CLI parsing 測試（prompt、list、read）

Closes #42
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
