### PR TITLE
[codex] add safari bookmarks cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .DS_Store
 .termdock/
+.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,12 +315,14 @@ dependencies = [
  "base64",
  "chrono",
  "cueward-core",
+ "plist",
  "rusqlite",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -813,6 +815,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ cueward safari bookmarks list --profile Ryugu
 # Traverse nested bookmark folders inside a profile
 cueward safari bookmarks list --profile Ryugu --folder "Work/AI Tools"
 
+# Folder paths use "/" as the separator; folder titles containing "/" are not supported
+# in this first version
+
 # Search bookmarks recursively from the root or a profile folder
 cueward safari bookmarks search "claude"
 cueward safari bookmarks search "claude" --profile Ryugu --folder "Work"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ cueward safari scroll bottom --profile Ryugu
 # Close multiple tabs by profile or URL pattern
 cueward safari close-tabs --profile Ryugu --url "gemini.google.com"
 cueward safari close-tabs --profile Ryugu  # close all tabs in profile
+
+# List bookmark/folder items from the Safari bookmarks root
+cueward safari bookmarks list
+
+# Scope bookmarks to a specific Safari profile folder
+cueward safari bookmarks list --profile Ryugu
+
+# Traverse nested bookmark folders inside a profile
+cueward safari bookmarks list --profile Ryugu --folder "Work/AI Tools"
+
+# Search bookmarks recursively from the root or a profile folder
+cueward safari bookmarks search "claude"
+cueward safari bookmarks search "claude" --profile Ryugu --folder "Work"
+
+# Add a bookmark into a nested folder inside a profile
+cueward safari bookmarks add --title "Claude" --url "https://claude.ai" --profile Ryugu --folder "Work/AI Tools"
+
+# Delete by exact title + URL within a profile folder
+cueward safari bookmarks delete --title "Claude" --url "https://claude.ai" --profile Ryugu --folder "Work/AI Tools"
 ```
 
 ### Safari AI

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -15,7 +15,9 @@ rusqlite = { version = "0.35", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+plist = "1"
 tempfile = "3"
 sha2 = "0.10"
 base64 = "0.22"
 urlencoding = "2"
+uuid = { version = "1", features = ["v4"] }

--- a/crates/adapter-macos/src/bookmarks.rs
+++ b/crates/adapter-macos/src/bookmarks.rs
@@ -163,10 +163,16 @@ mod tests {
                 }),
                 BookmarkNode::Folder(BookmarkFolder {
                     title: "Personal".to_string(),
-                    children: vec![BookmarkNode::Bookmark(BookmarkEntry {
-                        title: "Blog".to_string(),
-                        url: "https://example.com/blog".to_string(),
-                    })],
+                    children: vec![
+                        BookmarkNode::Bookmark(BookmarkEntry {
+                            title: "Blog".to_string(),
+                            url: "https://example.com/blog".to_string(),
+                        }),
+                        BookmarkNode::Bookmark(BookmarkEntry {
+                            title: "CAFÉ".to_string(),
+                            url: "https://example.com/cafe".to_string(),
+                        }),
+                    ],
                 }),
             ],
         }
@@ -199,6 +205,15 @@ mod tests {
 
         assert_eq!(items.len(), 2);
         assert_eq!(items[0].title.as_deref(), Some("Claude"));
+    }
+
+    #[test]
+    fn bookmarks_search_handles_non_ascii_case_folding() {
+        let tree = sample_bookmarks_tree();
+        let items = search_items(&tree, "café", Some("Personal")).expect("search");
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title.as_deref(), Some("CAFÉ"));
     }
 
     #[test]

--- a/crates/adapter-macos/src/bookmarks.rs
+++ b/crates/adapter-macos/src/bookmarks.rs
@@ -193,6 +193,15 @@ mod tests {
     }
 
     #[test]
+    fn bookmarks_folder_lookup_is_case_insensitive() {
+        let tree = sample_bookmarks_tree();
+        let items = list_items_in_folder(&tree, Some("work/ai tools")).expect("list folder");
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].title.as_deref(), Some("Claude"));
+    }
+
+    #[test]
     fn bookmarks_reject_invalid_folder_path_segments() {
         let err = parse_folder_path("Work//AI").expect_err("empty segment should fail");
 

--- a/crates/adapter-macos/src/bookmarks.rs
+++ b/crates/adapter-macos/src/bookmarks.rs
@@ -1,0 +1,341 @@
+use crate::MacosError;
+use crate::safari_guard::with_safari_session;
+use serde::Serialize;
+use std::path::PathBuf;
+
+#[path = "bookmarks/plist_io.rs"]
+mod plist_io;
+#[path = "bookmarks/tree_ops.rs"]
+mod tree_ops;
+
+use self::plist_io::{add_bookmark_to_path, delete_bookmark_from_path, load_tree_from_path};
+use self::tree_ops::{list_items_in_folder, search_items};
+
+#[cfg(test)]
+use self::plist_io::save_tree_to_path;
+#[cfg(test)]
+use self::tree_ops::{
+    BookmarkEntry, BookmarkFolder, BookmarkNode, BookmarkTree, add_bookmark, delete_bookmark,
+    parse_folder_path,
+};
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SafariBookmarkItemKind {
+    Folder,
+    Bookmark,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct SafariBookmarkItem {
+    pub kind: SafariBookmarkItemKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    pub folder_path: String,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct SafariBookmarksListResult {
+    pub folder_path: String,
+    pub items: Vec<SafariBookmarkItem>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct SafariBookmarksSearchResult {
+    pub query: String,
+    pub items: Vec<SafariBookmarkItem>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct SafariBookmarkMutationResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted: Option<bool>,
+    pub bookmark: SafariBookmarkItem,
+}
+
+/// List direct bookmark or folder items under the root or a specific folder path.
+pub fn list_bookmarks(folder: Option<&str>) -> Result<SafariBookmarksListResult, MacosError> {
+    with_safari_session(|| {
+        let tree = load_tree_from_path(&safari_bookmarks_path()?)?;
+        Ok(SafariBookmarksListResult {
+            folder_path: folder.unwrap_or_default().to_string(),
+            items: list_items_in_folder(&tree, folder)?,
+        })
+    })
+}
+
+/// Search bookmarks recursively from the root or a specific folder path.
+pub fn search_bookmarks(
+    query: &str,
+    folder: Option<&str>,
+) -> Result<SafariBookmarksSearchResult, MacosError> {
+    with_safari_session(|| {
+        let tree = load_tree_from_path(&safari_bookmarks_path()?)?;
+        Ok(SafariBookmarksSearchResult {
+            query: query.to_string(),
+            items: search_items(&tree, query, folder)?,
+        })
+    })
+}
+
+/// Add a bookmark to the root or a specific folder path.
+pub fn add_bookmark_cli(
+    title: &str,
+    url: &str,
+    folder: Option<&str>,
+) -> Result<SafariBookmarkMutationResult, MacosError> {
+    with_safari_session(|| {
+        let bookmark = add_bookmark_to_path(&safari_bookmarks_path()?, folder, title, url)?;
+        Ok(SafariBookmarkMutationResult {
+            created: Some(true),
+            deleted: None,
+            bookmark,
+        })
+    })
+}
+
+/// Delete a bookmark from the root or a specific folder path by exact title + URL.
+pub fn delete_bookmark_cli(
+    title: &str,
+    url: &str,
+    folder: Option<&str>,
+) -> Result<SafariBookmarkMutationResult, MacosError> {
+    with_safari_session(|| {
+        let bookmark = delete_bookmark_from_path(&safari_bookmarks_path()?, folder, title, url)?;
+        Ok(SafariBookmarkMutationResult {
+            created: None,
+            deleted: Some(true),
+            bookmark,
+        })
+    })
+}
+
+fn safari_bookmarks_path() -> Result<PathBuf, MacosError> {
+    let home = std::env::var("HOME")
+        .map_err(|_| MacosError::Other("HOME environment variable must be set".to_string()))?;
+    let path = PathBuf::from(home).join("Library/Safari/Bookmarks.plist");
+    if !path.exists() {
+        return Err(MacosError::Other("bookmarks plist not found".to_string()));
+    }
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BookmarkEntry, BookmarkFolder, BookmarkNode, BookmarkTree, add_bookmark, delete_bookmark,
+        list_items_in_folder, load_tree_from_path, parse_folder_path, save_tree_to_path,
+        search_items,
+    };
+    use tempfile::tempdir;
+
+    fn sample_bookmarks_tree() -> BookmarkTree {
+        BookmarkTree {
+            children: vec![
+                BookmarkNode::Folder(BookmarkFolder {
+                    title: "Work".to_string(),
+                    children: vec![
+                        BookmarkNode::Folder(BookmarkFolder {
+                            title: "AI Tools".to_string(),
+                            children: vec![
+                                BookmarkNode::Bookmark(BookmarkEntry {
+                                    title: "Claude".to_string(),
+                                    url: "https://claude.ai".to_string(),
+                                }),
+                                BookmarkNode::Bookmark(BookmarkEntry {
+                                    title: "Grok".to_string(),
+                                    url: "https://grok.com".to_string(),
+                                }),
+                            ],
+                        }),
+                        BookmarkNode::Folder(BookmarkFolder {
+                            title: "Docs".to_string(),
+                            children: vec![BookmarkNode::Bookmark(BookmarkEntry {
+                                title: "Rust Book".to_string(),
+                                url: "https://doc.rust-lang.org/book/".to_string(),
+                            })],
+                        }),
+                    ],
+                }),
+                BookmarkNode::Folder(BookmarkFolder {
+                    title: "Personal".to_string(),
+                    children: vec![BookmarkNode::Bookmark(BookmarkEntry {
+                        title: "Blog".to_string(),
+                        url: "https://example.com/blog".to_string(),
+                    })],
+                }),
+            ],
+        }
+    }
+
+    #[test]
+    fn bookmarks_lists_direct_children_for_folder_path() {
+        let tree = sample_bookmarks_tree();
+        let items = list_items_in_folder(&tree, Some("Work/AI Tools")).expect("list folder");
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].title.as_deref(), Some("Claude"));
+        assert_eq!(items[1].title.as_deref(), Some("Grok"));
+    }
+
+    #[test]
+    fn bookmarks_searches_recursively_from_folder_path() {
+        let tree = sample_bookmarks_tree();
+        let items = search_items(&tree, "claude", Some("Work")).expect("search");
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].folder_path, "Work/AI Tools");
+        assert_eq!(items[0].url.as_deref(), Some("https://claude.ai"));
+    }
+
+    #[test]
+    fn bookmarks_reject_invalid_folder_path_segments() {
+        let err = parse_folder_path("Work//AI").expect_err("empty segment should fail");
+
+        assert!(err.to_string().contains("invalid folder path"));
+    }
+
+    #[test]
+    fn bookmarks_parses_folder_path_segments() {
+        let parts = parse_folder_path("Work/AI Tools").expect("path");
+
+        assert_eq!(parts, vec!["Work".to_string(), "AI Tools".to_string()]);
+    }
+
+    #[test]
+    fn bookmarks_lists_root_direct_children_only() {
+        let tree = sample_bookmarks_tree();
+        let items = list_items_in_folder(&tree, None).expect("list root");
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].title.as_deref(), Some("Work"));
+        assert_eq!(items[1].title.as_deref(), Some("Personal"));
+    }
+
+    #[test]
+    fn bookmarks_add_rejects_duplicate_title_and_url_in_same_folder() {
+        let mut tree = sample_bookmarks_tree();
+
+        let err = add_bookmark(
+            &mut tree,
+            Some("Work/AI Tools"),
+            "Claude",
+            "https://claude.ai",
+        )
+        .expect_err("duplicate should fail");
+
+        assert!(err.to_string().contains("duplicate bookmark"));
+    }
+
+    #[test]
+    fn bookmarks_add_allows_same_title_with_different_url() {
+        let mut tree = sample_bookmarks_tree();
+
+        add_bookmark(
+            &mut tree,
+            Some("Work/AI Tools"),
+            "Claude",
+            "https://example.com/claude-alt",
+        )
+        .expect("same title, different url is allowed");
+
+        let items = list_items_in_folder(&tree, Some("Work/AI Tools")).expect("list folder");
+        assert_eq!(items.len(), 3);
+    }
+
+    #[test]
+    fn bookmarks_delete_matches_title_and_url() {
+        let mut tree = sample_bookmarks_tree();
+
+        let deleted = delete_bookmark(
+            &mut tree,
+            Some("Work/AI Tools"),
+            "Claude",
+            "https://claude.ai",
+        )
+        .expect("delete");
+
+        assert_eq!(deleted.title.as_deref(), Some("Claude"));
+        assert_eq!(deleted.url.as_deref(), Some("https://claude.ai"));
+    }
+
+    #[test]
+    fn bookmarks_delete_returns_not_found_for_missing_item() {
+        let mut tree = sample_bookmarks_tree();
+
+        let err = delete_bookmark(
+            &mut tree,
+            Some("Work/AI Tools"),
+            "Claude",
+            "https://example.com/missing",
+        )
+        .expect_err("missing bookmark should fail");
+
+        assert!(err.to_string().contains("bookmark not found"));
+    }
+
+    #[test]
+    fn bookmarks_delete_reports_conflict_for_duplicate_fingerprint() {
+        let mut tree = sample_bookmarks_tree();
+        add_bookmark(
+            &mut tree,
+            Some("Work/AI Tools"),
+            "Claude",
+            "https://mirror.example/claude",
+        )
+        .expect("same title different url allowed");
+        add_bookmark(
+            &mut tree,
+            Some("Work/AI Tools"),
+            "Claude",
+            "https://mirror.example/claude",
+        )
+        .expect_err("exact duplicate add stays blocked");
+
+        tree.children = vec![BookmarkNode::Folder(BookmarkFolder {
+            title: "Work".to_string(),
+            children: vec![BookmarkNode::Folder(BookmarkFolder {
+                title: "AI Tools".to_string(),
+                children: vec![
+                    BookmarkNode::Bookmark(BookmarkEntry {
+                        title: "Claude".to_string(),
+                        url: "https://claude.ai".to_string(),
+                    }),
+                    BookmarkNode::Bookmark(BookmarkEntry {
+                        title: "Claude".to_string(),
+                        url: "https://claude.ai".to_string(),
+                    }),
+                ],
+            })],
+        })];
+
+        let err = delete_bookmark(
+            &mut tree,
+            Some("Work/AI Tools"),
+            "Claude",
+            "https://claude.ai",
+        )
+        .expect_err("duplicate fingerprint should conflict");
+
+        assert!(err.to_string().contains("bookmark data conflict"));
+    }
+
+    #[test]
+    fn bookmarks_round_trip_through_plist_file() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("Bookmarks.plist");
+        let tree = sample_bookmarks_tree();
+
+        save_tree_to_path(&tree, &path).expect("write plist");
+        let loaded = load_tree_from_path(&path).expect("read plist");
+        let items = list_items_in_folder(&loaded, Some("Work/AI Tools")).expect("list folder");
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].title.as_deref(), Some("Claude"));
+        assert_eq!(items[1].title.as_deref(), Some("Grok"));
+    }
+}

--- a/crates/adapter-macos/src/bookmarks/plist_io.rs
+++ b/crates/adapter-macos/src/bookmarks/plist_io.rs
@@ -1,0 +1,387 @@
+use super::tree_ops::{
+    BookmarkEntry, BookmarkFolder, BookmarkNode, BookmarkTree, parse_folder_path,
+};
+use super::{SafariBookmarkItem, SafariBookmarkItemKind};
+use crate::MacosError;
+use plist::{Dictionary, Value};
+use std::path::Path;
+use uuid::Uuid;
+
+pub(super) fn load_tree_from_path(path: &Path) -> Result<BookmarkTree, MacosError> {
+    let value = Value::from_file(path)
+        .map_err(|err| MacosError::Other(format!("plist decode failed: {err}")))?;
+    tree_from_value(&value)
+}
+
+#[cfg(test)]
+pub(super) fn save_tree_to_path(tree: &BookmarkTree, path: &Path) -> Result<(), MacosError> {
+    tree_to_value(tree)
+        .to_file_xml(path)
+        .map_err(|err| MacosError::Other(format!("plist write failed: {err}")))
+}
+
+pub(super) fn add_bookmark_to_path(
+    path: &Path,
+    folder: Option<&str>,
+    title: &str,
+    url: &str,
+) -> Result<SafariBookmarkItem, MacosError> {
+    let mut root = load_root_value(path)?;
+    let children = resolve_children_mut_value(&mut root, folder)?;
+    let duplicate = children
+        .iter()
+        .any(|value| bookmark_matches(value, title, url));
+    if duplicate {
+        return Err(MacosError::Other("duplicate bookmark".to_string()));
+    }
+
+    children.push(make_leaf_value(title, url));
+    save_root_value(path, &root)?;
+
+    Ok(SafariBookmarkItem {
+        kind: SafariBookmarkItemKind::Bookmark,
+        title: Some(title.to_string()),
+        url: Some(url.to_string()),
+        folder_path: folder.unwrap_or_default().to_string(),
+    })
+}
+
+pub(super) fn delete_bookmark_from_path(
+    path: &Path,
+    folder: Option<&str>,
+    title: &str,
+    url: &str,
+) -> Result<SafariBookmarkItem, MacosError> {
+    let mut root = load_root_value(path)?;
+    let children = resolve_children_mut_value(&mut root, folder)?;
+    let matches: Vec<usize> = children
+        .iter()
+        .enumerate()
+        .filter_map(|(index, value)| bookmark_matches(value, title, url).then_some(index))
+        .collect();
+
+    let result = match matches.len() {
+        0 => Err(MacosError::Other("bookmark not found".to_string())),
+        1 => {
+            let value = children.remove(matches[0]);
+            bookmark_item_from_value(&value, folder.unwrap_or_default())
+        }
+        _ => Err(MacosError::Other("bookmark data conflict".to_string())),
+    }?;
+
+    save_root_value(path, &root)?;
+    Ok(result)
+}
+
+fn tree_from_value(value: &Value) -> Result<BookmarkTree, MacosError> {
+    let dict = value.as_dictionary().ok_or_else(|| {
+        MacosError::Other("plist decode failed: root is not a dictionary".to_string())
+    })?;
+    let children = dict
+        .get("Children")
+        .and_then(Value::as_array)
+        .ok_or_else(|| MacosError::Other("plist decode failed: missing Children".to_string()))?;
+
+    let mut parsed_children = Vec::new();
+    for child in children {
+        if let Some(node) = node_from_value(child)? {
+            parsed_children.push(node);
+        }
+    }
+
+    Ok(BookmarkTree {
+        children: parsed_children,
+    })
+}
+
+fn node_from_value(value: &Value) -> Result<Option<BookmarkNode>, MacosError> {
+    let dict = value.as_dictionary().ok_or_else(|| {
+        MacosError::Other("plist decode failed: bookmark node is not a dictionary".to_string())
+    })?;
+    let Some(bookmark_type) = dict.get("WebBookmarkType").and_then(Value::as_string) else {
+        return Ok(None);
+    };
+
+    match bookmark_type {
+        "WebBookmarkTypeList" => {
+            let title = dict
+                .get("Title")
+                .and_then(Value::as_string)
+                .unwrap_or_default()
+                .to_string();
+            let mut children = Vec::new();
+            if let Some(values) = dict.get("Children").and_then(Value::as_array) {
+                for child in values {
+                    if let Some(node) = node_from_value(child)? {
+                        children.push(node);
+                    }
+                }
+            }
+            Ok(Some(BookmarkNode::Folder(BookmarkFolder {
+                title,
+                children,
+            })))
+        }
+        "WebBookmarkTypeLeaf" => {
+            let title = dict
+                .get("URIDictionary")
+                .and_then(Value::as_dictionary)
+                .and_then(|uri| uri.get("title"))
+                .and_then(Value::as_string)
+                .unwrap_or_default()
+                .to_string();
+            let Some(url) = dict.get("URLString").and_then(Value::as_string) else {
+                return Ok(None);
+            };
+            Ok(Some(BookmarkNode::Bookmark(BookmarkEntry {
+                title,
+                url: url.to_string(),
+            })))
+        }
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+fn tree_to_value(tree: &BookmarkTree) -> Value {
+    let mut dict = Dictionary::new();
+    dict.insert("Title".to_string(), Value::String(String::new()));
+    dict.insert(
+        "WebBookmarkType".to_string(),
+        Value::String("WebBookmarkTypeList".to_string()),
+    );
+    dict.insert(
+        "WebBookmarkFileVersion".to_string(),
+        Value::Integer(1_i64.into()),
+    );
+    dict.insert(
+        "Children".to_string(),
+        Value::Array(tree.children.iter().map(node_to_value).collect()),
+    );
+    Value::Dictionary(dict)
+}
+
+#[cfg(test)]
+fn node_to_value(node: &BookmarkNode) -> Value {
+    match node {
+        BookmarkNode::Folder(folder) => {
+            let mut dict = Dictionary::new();
+            dict.insert("Title".to_string(), Value::String(folder.title.clone()));
+            dict.insert(
+                "WebBookmarkType".to_string(),
+                Value::String("WebBookmarkTypeList".to_string()),
+            );
+            dict.insert(
+                "Children".to_string(),
+                Value::Array(folder.children.iter().map(node_to_value).collect()),
+            );
+            Value::Dictionary(dict)
+        }
+        BookmarkNode::Bookmark(entry) => {
+            let mut uri = Dictionary::new();
+            uri.insert("title".to_string(), Value::String(entry.title.clone()));
+
+            let mut dict = Dictionary::new();
+            dict.insert(
+                "WebBookmarkType".to_string(),
+                Value::String("WebBookmarkTypeLeaf".to_string()),
+            );
+            dict.insert("URIDictionary".to_string(), Value::Dictionary(uri));
+            dict.insert("URLString".to_string(), Value::String(entry.url.clone()));
+            Value::Dictionary(dict)
+        }
+    }
+}
+
+fn load_root_value(path: &Path) -> Result<Value, MacosError> {
+    Value::from_file(path).map_err(|err| MacosError::Other(format!("plist decode failed: {err}")))
+}
+
+fn save_root_value(path: &Path, root: &Value) -> Result<(), MacosError> {
+    root.to_file_binary(path)
+        .map_err(|err| MacosError::Other(format!("plist write failed: {err}")))
+}
+
+fn resolve_children_mut_value<'a>(
+    root: &'a mut Value,
+    folder: Option<&str>,
+) -> Result<&'a mut Vec<Value>, MacosError> {
+    let dict = root.as_dictionary_mut().ok_or_else(|| {
+        MacosError::Other("plist decode failed: root is not a dictionary".to_string())
+    })?;
+    let mut children = ensure_children_array(dict)?;
+
+    let Some(folder) = folder else {
+        return Ok(children);
+    };
+
+    let parts = parse_folder_path(folder)?;
+    for part in parts {
+        let Some(index) = children
+            .iter()
+            .position(|value| folder_matches(value, &part))
+        else {
+            return Err(MacosError::Other("invalid folder path".to_string()));
+        };
+        let next = children
+            .get_mut(index)
+            .and_then(Value::as_dictionary_mut)
+            .map(ensure_children_array)
+            .transpose()?
+            .ok_or_else(|| MacosError::Other("invalid folder path".to_string()))?;
+        children = next;
+    }
+
+    Ok(children)
+}
+
+fn ensure_children_array(dict: &mut Dictionary) -> Result<&mut Vec<Value>, MacosError> {
+    if !dict.contains_key("Children") {
+        dict.insert("Children".to_string(), Value::Array(Vec::new()));
+    }
+
+    dict.get_mut("Children")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| MacosError::Other("invalid folder path".to_string()))
+}
+
+fn folder_matches(value: &Value, title: &str) -> bool {
+    value
+        .as_dictionary()
+        .map(|dict| {
+            dict.get("WebBookmarkType").and_then(Value::as_string) == Some("WebBookmarkTypeList")
+                && dict.get("Title").and_then(Value::as_string) == Some(title)
+        })
+        .unwrap_or(false)
+}
+
+fn bookmark_matches(value: &Value, title: &str, url: &str) -> bool {
+    value
+        .as_dictionary()
+        .map(|dict| {
+            dict.get("WebBookmarkType").and_then(Value::as_string) == Some("WebBookmarkTypeLeaf")
+                && dict
+                    .get("URIDictionary")
+                    .and_then(Value::as_dictionary)
+                    .and_then(|uri| uri.get("title"))
+                    .and_then(Value::as_string)
+                    == Some(title)
+                && dict.get("URLString").and_then(Value::as_string) == Some(url)
+        })
+        .unwrap_or(false)
+}
+
+fn make_leaf_value(title: &str, url: &str) -> Value {
+    let mut uri = Dictionary::new();
+    uri.insert("title".to_string(), Value::String(title.to_string()));
+
+    let mut dict = Dictionary::new();
+    dict.insert(
+        "WebBookmarkType".to_string(),
+        Value::String("WebBookmarkTypeLeaf".to_string()),
+    );
+    dict.insert("URIDictionary".to_string(), Value::Dictionary(uri));
+    dict.insert("URLString".to_string(), Value::String(url.to_string()));
+    dict.insert(
+        "WebBookmarkUUID".to_string(),
+        Value::String(Uuid::new_v4().to_string().to_uppercase()),
+    );
+    Value::Dictionary(dict)
+}
+
+fn bookmark_item_from_value(
+    value: &Value,
+    folder_path: &str,
+) -> Result<SafariBookmarkItem, MacosError> {
+    let dict = value
+        .as_dictionary()
+        .ok_or_else(|| MacosError::Other("bookmark not found".to_string()))?;
+    let title = dict
+        .get("URIDictionary")
+        .and_then(Value::as_dictionary)
+        .and_then(|uri| uri.get("title"))
+        .and_then(Value::as_string)
+        .map(ToOwned::to_owned);
+    let url = dict
+        .get("URLString")
+        .and_then(Value::as_string)
+        .map(ToOwned::to_owned);
+
+    Ok(SafariBookmarkItem {
+        kind: SafariBookmarkItemKind::Bookmark,
+        title,
+        url,
+        folder_path: folder_path.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{add_bookmark_to_path, delete_bookmark_from_path};
+    use plist::{Dictionary, Value};
+    use tempfile::tempdir;
+
+    fn empty_folder_root() -> Value {
+        let mut folder = Dictionary::new();
+        folder.insert("Title".to_string(), Value::String("Ryugu".to_string()));
+        folder.insert(
+            "WebBookmarkType".to_string(),
+            Value::String("WebBookmarkTypeList".to_string()),
+        );
+        folder.insert(
+            "WebBookmarkUUID".to_string(),
+            Value::String("F0776FB0-47B8-4DE0-BF4A-9D8ADFA9332A".to_string()),
+        );
+
+        let mut root = Dictionary::new();
+        root.insert("Title".to_string(), Value::String(String::new()));
+        root.insert(
+            "WebBookmarkType".to_string(),
+            Value::String("WebBookmarkTypeList".to_string()),
+        );
+        root.insert(
+            "WebBookmarkFileVersion".to_string(),
+            Value::Integer(1_i64.into()),
+        );
+        root.insert(
+            "Children".to_string(),
+            Value::Array(vec![Value::Dictionary(folder)]),
+        );
+        Value::Dictionary(root)
+    }
+
+    #[test]
+    fn add_bookmark_to_empty_folder_without_children_key_succeeds() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("Bookmarks.plist");
+        empty_folder_root()
+            .to_file_binary(&path)
+            .expect("write plist root");
+
+        let result = add_bookmark_to_path(
+            &path,
+            Some("Ryugu"),
+            "Smoke Test",
+            "https://example.com/smoke",
+        )
+        .expect("add bookmark");
+
+        assert_eq!(result.title.as_deref(), Some("Smoke Test"));
+        assert_eq!(result.url.as_deref(), Some("https://example.com/smoke"));
+        assert_eq!(result.folder_path, "Ryugu");
+    }
+
+    #[test]
+    fn delete_from_empty_folder_without_children_key_returns_not_found() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("Bookmarks.plist");
+        empty_folder_root()
+            .to_file_binary(&path)
+            .expect("write plist root");
+
+        let err = delete_bookmark_from_path(&path, Some("Ryugu"), "Missing", "https://example.com")
+            .expect_err("delete should fail");
+
+        assert!(err.to_string().contains("bookmark not found"));
+    }
+}

--- a/crates/adapter-macos/src/bookmarks/plist_io.rs
+++ b/crates/adapter-macos/src/bookmarks/plist_io.rs
@@ -198,8 +198,16 @@ fn load_root_value(path: &Path) -> Result<Value, MacosError> {
 }
 
 fn save_root_value(path: &Path, root: &Value) -> Result<(), MacosError> {
-    root.to_file_binary(path)
-        .map_err(|err| MacosError::Other(format!("plist write failed: {err}")))
+    let parent = path
+        .parent()
+        .ok_or_else(|| MacosError::Other("invalid path".to_string()))?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|err| MacosError::Other(format!("failed to create temp file: {err}")))?;
+    root.to_writer_binary(&mut temp)
+        .map_err(|err| MacosError::Other(format!("plist write failed: {err}")))?;
+    temp.persist(path)
+        .map_err(|err| MacosError::Other(format!("failed to persist plist: {err}")))?;
+    Ok(())
 }
 
 fn resolve_children_mut_value<'a>(

--- a/crates/adapter-macos/src/bookmarks/tree_ops.rs
+++ b/crates/adapter-macos/src/bookmarks/tree_ops.rs
@@ -1,0 +1,252 @@
+use super::{SafariBookmarkItem, SafariBookmarkItemKind};
+use crate::MacosError;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct BookmarkTree {
+    pub(super) children: Vec<BookmarkNode>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum BookmarkNode {
+    Folder(BookmarkFolder),
+    Bookmark(BookmarkEntry),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct BookmarkFolder {
+    pub(super) title: String,
+    pub(super) children: Vec<BookmarkNode>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct BookmarkEntry {
+    pub(super) title: String,
+    pub(super) url: String,
+}
+
+fn invalid_folder_path() -> MacosError {
+    MacosError::Other("invalid folder path".to_string())
+}
+
+pub(super) fn parse_folder_path(path: &str) -> Result<Vec<String>, MacosError> {
+    if path.trim().is_empty() {
+        return Err(invalid_folder_path());
+    }
+
+    let parts: Vec<String> = path
+        .split('/')
+        .map(str::trim)
+        .map(ToOwned::to_owned)
+        .collect();
+
+    if parts.iter().any(|part| part.is_empty()) {
+        return Err(invalid_folder_path());
+    }
+
+    Ok(parts)
+}
+
+fn join_folder_path(parent: &str, title: &str) -> String {
+    if parent.is_empty() {
+        title.to_string()
+    } else {
+        format!("{parent}/{title}")
+    }
+}
+
+fn resolve_children<'a>(
+    tree: &'a BookmarkTree,
+    folder: Option<&str>,
+) -> Result<(&'a [BookmarkNode], String), MacosError> {
+    let Some(folder) = folder else {
+        return Ok((&tree.children, String::new()));
+    };
+
+    let parts = parse_folder_path(folder)?;
+    let mut children = tree.children.as_slice();
+    let mut current_path = String::new();
+
+    for part in parts {
+        let next = children.iter().find_map(|node| match node {
+            BookmarkNode::Folder(folder) if folder.title == part => Some(folder),
+            _ => None,
+        });
+        let Some(folder) = next else {
+            return Err(invalid_folder_path());
+        };
+        current_path = join_folder_path(&current_path, &folder.title);
+        children = folder.children.as_slice();
+    }
+
+    Ok((children, current_path))
+}
+
+fn map_child_to_item(node: &BookmarkNode, current_folder_path: &str) -> SafariBookmarkItem {
+    match node {
+        BookmarkNode::Folder(folder) => SafariBookmarkItem {
+            kind: SafariBookmarkItemKind::Folder,
+            title: Some(folder.title.clone()),
+            url: None,
+            folder_path: join_folder_path(current_folder_path, &folder.title),
+        },
+        BookmarkNode::Bookmark(entry) => SafariBookmarkItem {
+            kind: SafariBookmarkItemKind::Bookmark,
+            title: Some(entry.title.clone()),
+            url: Some(entry.url.clone()),
+            folder_path: current_folder_path.to_string(),
+        },
+    }
+}
+
+pub(super) fn list_items_in_folder(
+    tree: &BookmarkTree,
+    folder: Option<&str>,
+) -> Result<Vec<SafariBookmarkItem>, MacosError> {
+    let (children, current_path) = resolve_children(tree, folder)?;
+    Ok(children
+        .iter()
+        .map(|node| map_child_to_item(node, &current_path))
+        .collect())
+}
+
+pub(super) fn search_items(
+    tree: &BookmarkTree,
+    query: &str,
+    folder: Option<&str>,
+) -> Result<Vec<SafariBookmarkItem>, MacosError> {
+    let (children, current_path) = resolve_children(tree, folder)?;
+    let normalized_query = query.trim().to_ascii_lowercase();
+    let mut results = Vec::new();
+    collect_search_matches(children, &current_path, &normalized_query, &mut results);
+    Ok(results)
+}
+
+fn collect_search_matches(
+    children: &[BookmarkNode],
+    current_folder_path: &str,
+    normalized_query: &str,
+    results: &mut Vec<SafariBookmarkItem>,
+) {
+    for node in children {
+        match node {
+            BookmarkNode::Folder(folder) => {
+                let next_path = join_folder_path(current_folder_path, &folder.title);
+                collect_search_matches(
+                    folder.children.as_slice(),
+                    &next_path,
+                    normalized_query,
+                    results,
+                );
+            }
+            BookmarkNode::Bookmark(entry) => {
+                let title = entry.title.to_ascii_lowercase();
+                let url = entry.url.to_ascii_lowercase();
+                if title.contains(normalized_query) || url.contains(normalized_query) {
+                    results.push(SafariBookmarkItem {
+                        kind: SafariBookmarkItemKind::Bookmark,
+                        title: Some(entry.title.clone()),
+                        url: Some(entry.url.clone()),
+                        folder_path: current_folder_path.to_string(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+fn resolve_children_mut_tree<'a>(
+    tree: &'a mut BookmarkTree,
+    folder: Option<&str>,
+) -> Result<&'a mut Vec<BookmarkNode>, MacosError> {
+    let Some(folder) = folder else {
+        return Ok(&mut tree.children);
+    };
+    let parts = parse_folder_path(folder)?;
+    resolve_children_mut_nodes(&mut tree.children, &parts)
+}
+
+#[cfg(test)]
+fn resolve_children_mut_nodes<'a>(
+    children: &'a mut Vec<BookmarkNode>,
+    parts: &[String],
+) -> Result<&'a mut Vec<BookmarkNode>, MacosError> {
+    let Some((segment, rest)) = parts.split_first() else {
+        return Ok(children);
+    };
+
+    let Some(index) = children.iter().position(|node| match node {
+        BookmarkNode::Folder(folder) => folder.title == *segment,
+        BookmarkNode::Bookmark(_) => false,
+    }) else {
+        return Err(invalid_folder_path());
+    };
+
+    match children.get_mut(index) {
+        Some(BookmarkNode::Folder(folder)) => {
+            resolve_children_mut_nodes(&mut folder.children, rest)
+        }
+        _ => Err(invalid_folder_path()),
+    }
+}
+
+#[cfg(test)]
+pub(super) fn add_bookmark(
+    tree: &mut BookmarkTree,
+    folder: Option<&str>,
+    title: &str,
+    url: &str,
+) -> Result<(), MacosError> {
+    let children = resolve_children_mut_tree(tree, folder)?;
+    let duplicate = children.iter().any(|node| match node {
+        BookmarkNode::Bookmark(entry) => entry.title == title && entry.url == url,
+        BookmarkNode::Folder(_) => false,
+    });
+    if duplicate {
+        return Err(MacosError::Other("duplicate bookmark".to_string()));
+    }
+
+    children.push(BookmarkNode::Bookmark(BookmarkEntry {
+        title: title.to_string(),
+        url: url.to_string(),
+    }));
+    Ok(())
+}
+
+#[cfg(test)]
+pub(super) fn delete_bookmark(
+    tree: &mut BookmarkTree,
+    folder: Option<&str>,
+    title: &str,
+    url: &str,
+) -> Result<SafariBookmarkItem, MacosError> {
+    let current_folder_path = folder.unwrap_or_default().to_string();
+    let children = resolve_children_mut_tree(tree, folder)?;
+    let matches: Vec<usize> = children
+        .iter()
+        .enumerate()
+        .filter_map(|(index, node)| match node {
+            BookmarkNode::Bookmark(entry) if entry.title == title && entry.url == url => {
+                Some(index)
+            }
+            _ => None,
+        })
+        .collect();
+
+    match matches.len() {
+        0 => Err(MacosError::Other("bookmark not found".to_string())),
+        1 => {
+            let index = matches[0];
+            let BookmarkNode::Bookmark(entry) = children.remove(index) else {
+                return Err(MacosError::Other("bookmark not found".to_string()));
+            };
+            Ok(SafariBookmarkItem {
+                kind: SafariBookmarkItemKind::Bookmark,
+                title: Some(entry.title),
+                url: Some(entry.url),
+                folder_path: current_folder_path,
+            })
+        }
+        _ => Err(MacosError::Other("bookmark data conflict".to_string())),
+    }
+}

--- a/crates/adapter-macos/src/bookmarks/tree_ops.rs
+++ b/crates/adapter-macos/src/bookmarks/tree_ops.rs
@@ -54,6 +54,10 @@ fn join_folder_path(parent: &str, title: &str) -> String {
     }
 }
 
+fn same_folder_title(left: &str, right: &str) -> bool {
+    left.to_lowercase() == right.to_lowercase()
+}
+
 fn resolve_children<'a>(
     tree: &'a BookmarkTree,
     folder: Option<&str>,
@@ -68,7 +72,7 @@ fn resolve_children<'a>(
 
     for part in parts {
         let next = children.iter().find_map(|node| match node {
-            BookmarkNode::Folder(folder) if folder.title == part => Some(folder),
+            BookmarkNode::Folder(folder) if same_folder_title(&folder.title, &part) => Some(folder),
             _ => None,
         });
         let Some(folder) = next else {
@@ -176,7 +180,7 @@ fn resolve_children_mut_nodes<'a>(
     };
 
     let Some(index) = children.iter().position(|node| match node {
-        BookmarkNode::Folder(folder) => folder.title == *segment,
+        BookmarkNode::Folder(folder) => same_folder_title(&folder.title, segment),
         BookmarkNode::Bookmark(_) => false,
     }) else {
         return Err(invalid_folder_path());

--- a/crates/adapter-macos/src/bookmarks/tree_ops.rs
+++ b/crates/adapter-macos/src/bookmarks/tree_ops.rs
@@ -119,7 +119,7 @@ pub(super) fn search_items(
     folder: Option<&str>,
 ) -> Result<Vec<SafariBookmarkItem>, MacosError> {
     let (children, current_path) = resolve_children(tree, folder)?;
-    let normalized_query = query.trim().to_ascii_lowercase();
+    let normalized_query = query.trim().to_lowercase();
     let mut results = Vec::new();
     collect_search_matches(children, &current_path, &normalized_query, &mut results);
     Ok(results)
@@ -143,8 +143,8 @@ fn collect_search_matches(
                 );
             }
             BookmarkNode::Bookmark(entry) => {
-                let title = entry.title.to_ascii_lowercase();
-                let url = entry.url.to_ascii_lowercase();
+                let title = entry.title.to_lowercase();
+                let url = entry.url.to_lowercase();
                 if title.contains(normalized_query) || url.contains(normalized_query) {
                     results.push(SafariBookmarkItem {
                         kind: SafariBookmarkItemKind::Bookmark,

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod applescript;
+pub mod bookmarks;
 pub mod calendar;
 pub mod clipboard;
 mod error;
@@ -9,6 +10,7 @@ pub mod plan;
 pub mod quick_notes;
 pub mod reminders;
 pub mod safari;
+mod safari_guard;
 pub mod screenshot;
 pub mod send;
 

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -1,207 +1,30 @@
 use std::collections::HashMap;
-use std::fs::{self, OpenOptions};
-use std::io::{ErrorKind, Write};
-use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::path::PathBuf;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::Connection;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::Value;
 
 use cueward_core::{Cue, CueSource};
 
 use crate::MacosError;
 use crate::applescript::{escape, escape_body, run_capture as run_applescript_capture};
+use crate::safari_guard::{safari_automation_state, with_safari_session};
+#[cfg(test)]
+pub(crate) use crate::safari_guard::{
+    SAFARI_LOCK_TTL_SECS, SafariAutomationSession, SafariLockFile, acquire_safari_lock,
+    read_safari_lock, release_safari_lock,
+};
 
 /// Core Data epoch: 2001-01-01 00:00:00 UTC
 const CORE_DATA_EPOCH: i64 = 978_307_200;
 const SAFARI_OPERATION_DELAY: Duration = Duration::from_secs(1);
-const SAFARI_LOCK_TTL_SECS: i64 = 1800;
 const SAFARI_429_MAX_RETRIES: usize = 3;
 const TAB_SEPARATOR: &str = "---TAB_SEP---";
 const FIELD_SEPARATOR: &str = "<<<FIELD_SEP>>>";
-
-static SAFARI_AUTOMATION_STATE: OnceLock<Mutex<SafariAutomationState>> = OnceLock::new();
-
-#[derive(Debug, Default)]
-struct SafariAutomationState {
-    depth: usize,
-    last_operation_at: Option<Instant>,
-    lock_path: Option<PathBuf>,
-    lock_owner_pid: Option<u32>,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-struct SafariLockFile {
-    pid: u32,
-    acquired_at: i64,
-    expires_at: i64,
-}
-
-struct SafariAutomationSession {
-    outermost: bool,
-}
-
-impl SafariAutomationSession {
-    fn enter() -> Result<Self, MacosError> {
-        let state = safari_automation_state();
-        let mut guard = state
-            .lock()
-            .map_err(|_| MacosError::Other("safari automation state poisoned".to_string()))?;
-
-        if guard.depth > 0 {
-            guard.depth += 1;
-            return Ok(Self { outermost: false });
-        }
-
-        let lock_path = safari_lock_path()?;
-        acquire_safari_lock(&lock_path, Utc::now().timestamp(), std::process::id())?;
-        guard.depth = 1;
-        guard.lock_owner_pid = Some(std::process::id());
-        guard.lock_path = Some(lock_path);
-
-        Ok(Self { outermost: true })
-    }
-}
-
-impl Drop for SafariAutomationSession {
-    fn drop(&mut self) {
-        let state = safari_automation_state();
-        let Ok(mut guard) = state.lock() else {
-            return;
-        };
-
-        if guard.depth == 0 {
-            return;
-        }
-
-        guard.depth -= 1;
-        if !self.outermost || guard.depth > 0 {
-            return;
-        }
-
-        if let (Some(path), Some(pid)) = (guard.lock_path.as_ref(), guard.lock_owner_pid) {
-            let _ = release_safari_lock(path, pid);
-        }
-        guard.lock_path = None;
-        guard.lock_owner_pid = None;
-    }
-}
-
-fn safari_automation_state() -> &'static Mutex<SafariAutomationState> {
-    SAFARI_AUTOMATION_STATE.get_or_init(|| Mutex::new(SafariAutomationState::default()))
-}
-
-fn with_safari_session<T>(action: impl FnOnce() -> Result<T, MacosError>) -> Result<T, MacosError> {
-    let _session = SafariAutomationSession::enter()?;
-    action()
-}
-
-fn safari_lock_path() -> Result<PathBuf, MacosError> {
-    let home = std::env::var("HOME")
-        .map_err(|_| MacosError::Other("HOME environment variable must be set".into()))?;
-    Ok(PathBuf::from(home).join(".cueward").join("lock.json"))
-}
-
-fn acquire_safari_lock(path: &Path, now_ts: i64, pid: u32) -> Result<(), MacosError> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| MacosError::Other("invalid Safari lock path".to_string()))?;
-    fs::create_dir_all(parent)
-        .map_err(|e| MacosError::Other(format!("failed to create {}: {e}", parent.display())))?;
-
-    for _ in 0..2 {
-        match OpenOptions::new().write(true).create_new(true).open(path) {
-            Ok(mut file) => {
-                let payload = SafariLockFile {
-                    pid,
-                    acquired_at: now_ts,
-                    expires_at: now_ts + SAFARI_LOCK_TTL_SECS,
-                };
-                let bytes = serde_json::to_vec_pretty(&payload)
-                    .map_err(|e| MacosError::Other(format!("failed to encode lock file: {e}")))?;
-                file.write_all(&bytes).map_err(|e| {
-                    let _ = fs::remove_file(path);
-                    MacosError::Other(format!("failed to write {}: {e}", path.display()))
-                })?;
-                return Ok(());
-            }
-            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
-                let existing_raw = match fs::read_to_string(path) {
-                    Ok(raw) => raw,
-                    Err(read_error) if read_error.kind() == ErrorKind::NotFound => continue,
-                    Err(read_error) => {
-                        return Err(MacosError::Other(format!(
-                            "failed to read Safari lock {}: {read_error}",
-                            path.display()
-                        )));
-                    }
-                };
-                let existing: SafariLockFile =
-                    serde_json::from_str(&existing_raw).map_err(|_| {
-                        MacosError::Other(format!(
-                            "Safari automation lock {} exists but is corrupted or unreadable",
-                            path.display()
-                        ))
-                    })?;
-                let expired = existing.expires_at <= now_ts;
-                if expired {
-                    match fs::remove_file(path) {
-                        Ok(()) => continue,
-                        Err(remove_error) if remove_error.kind() == ErrorKind::NotFound => continue,
-                        Err(remove_error) => {
-                            return Err(MacosError::Other(format!(
-                                "failed to clear stale Safari lock {}: {remove_error}",
-                                path.display()
-                            )));
-                        }
-                    }
-                }
-
-                return Err(MacosError::Other(format!(
-                    "Safari automation is locked by pid {} until {}",
-                    existing.pid, existing.expires_at
-                )));
-            }
-            Err(error) => {
-                return Err(MacosError::Other(format!(
-                    "failed to create Safari lock {}: {error}",
-                    path.display()
-                )));
-            }
-        }
-    }
-
-    Err(MacosError::Other(format!(
-        "failed to acquire Safari lock {}",
-        path.display()
-    )))
-}
-
-fn release_safari_lock(path: &Path, pid: u32) -> Result<(), MacosError> {
-    let owner_matches = read_safari_lock(path)
-        .map(|lock| lock.pid == pid)
-        .unwrap_or(false);
-    if !owner_matches {
-        return Ok(());
-    }
-    match fs::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(MacosError::Other(format!(
-            "failed to remove Safari lock {}: {err}",
-            path.display()
-        ))),
-    }
-}
-
-fn read_safari_lock(path: &Path) -> Option<SafariLockFile> {
-    let raw = fs::read_to_string(path).ok()?;
-    serde_json::from_str(&raw).ok()
-}
 
 fn compute_next_safari_operation(
     now: Instant,

--- a/crates/adapter-macos/src/safari.rs
+++ b/crates/adapter-macos/src/safari.rs
@@ -12,12 +12,12 @@ use cueward_core::{Cue, CueSource};
 
 use crate::MacosError;
 use crate::applescript::{escape, escape_body, run_capture as run_applescript_capture};
-use crate::safari_guard::{safari_automation_state, with_safari_session};
 #[cfg(test)]
 pub(crate) use crate::safari_guard::{
     SAFARI_LOCK_TTL_SECS, SafariAutomationSession, SafariLockFile, acquire_safari_lock,
     read_safari_lock, release_safari_lock,
 };
+use crate::safari_guard::{safari_automation_state, with_safari_session};
 
 /// Core Data epoch: 2001-01-01 00:00:00 UTC
 const CORE_DATA_EPOCH: i64 = 978_307_200;

--- a/crates/adapter-macos/src/safari_guard.rs
+++ b/crates/adapter-macos/src/safari_guard.rs
@@ -1,0 +1,192 @@
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::MacosError;
+
+pub(crate) const SAFARI_LOCK_TTL_SECS: i64 = 1800;
+
+static SAFARI_AUTOMATION_STATE: OnceLock<Mutex<SafariAutomationState>> = OnceLock::new();
+
+#[derive(Debug, Default)]
+pub(crate) struct SafariAutomationState {
+    pub(crate) depth: usize,
+    pub(crate) last_operation_at: Option<std::time::Instant>,
+    pub(crate) lock_path: Option<PathBuf>,
+    pub(crate) lock_owner_pid: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SafariLockFile {
+    pub(crate) pid: u32,
+    pub(crate) acquired_at: i64,
+    pub(crate) expires_at: i64,
+}
+
+pub(crate) struct SafariAutomationSession {
+    pub(crate) outermost: bool,
+}
+
+impl SafariAutomationSession {
+    pub(crate) fn enter() -> Result<Self, MacosError> {
+        let state = safari_automation_state();
+        let mut guard = state
+            .lock()
+            .map_err(|_| MacosError::Other("safari automation state poisoned".to_string()))?;
+
+        if guard.depth > 0 {
+            guard.depth += 1;
+            return Ok(Self { outermost: false });
+        }
+
+        let lock_path = safari_lock_path()?;
+        acquire_safari_lock(&lock_path, Utc::now().timestamp(), std::process::id())?;
+        guard.depth = 1;
+        guard.lock_owner_pid = Some(std::process::id());
+        guard.lock_path = Some(lock_path);
+
+        Ok(Self { outermost: true })
+    }
+}
+
+impl Drop for SafariAutomationSession {
+    fn drop(&mut self) {
+        let state = safari_automation_state();
+        let Ok(mut guard) = state.lock() else {
+            return;
+        };
+
+        if guard.depth == 0 {
+            return;
+        }
+
+        guard.depth -= 1;
+        if !self.outermost || guard.depth > 0 {
+            return;
+        }
+
+        if let (Some(path), Some(pid)) = (guard.lock_path.as_ref(), guard.lock_owner_pid) {
+            let _ = release_safari_lock(path, pid);
+        }
+        guard.lock_path = None;
+        guard.lock_owner_pid = None;
+    }
+}
+
+pub(crate) fn safari_automation_state() -> &'static Mutex<SafariAutomationState> {
+    SAFARI_AUTOMATION_STATE.get_or_init(|| Mutex::new(SafariAutomationState::default()))
+}
+
+pub(crate) fn with_safari_session<T>(
+    action: impl FnOnce() -> Result<T, MacosError>,
+) -> Result<T, MacosError> {
+    let _session = SafariAutomationSession::enter()?;
+    action()
+}
+
+fn safari_lock_path() -> Result<PathBuf, MacosError> {
+    let home = std::env::var("HOME")
+        .map_err(|_| MacosError::Other("HOME environment variable must be set".into()))?;
+    Ok(PathBuf::from(home).join(".cueward").join("lock.json"))
+}
+
+pub(crate) fn acquire_safari_lock(path: &Path, now_ts: i64, pid: u32) -> Result<(), MacosError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| MacosError::Other("invalid Safari lock path".to_string()))?;
+    fs::create_dir_all(parent)
+        .map_err(|e| MacosError::Other(format!("failed to create {}: {e}", parent.display())))?;
+
+    for _ in 0..2 {
+        match OpenOptions::new().write(true).create_new(true).open(path) {
+            Ok(mut file) => {
+                let payload = SafariLockFile {
+                    pid,
+                    acquired_at: now_ts,
+                    expires_at: now_ts + SAFARI_LOCK_TTL_SECS,
+                };
+                let bytes = serde_json::to_vec_pretty(&payload)
+                    .map_err(|e| MacosError::Other(format!("failed to encode lock file: {e}")))?;
+                file.write_all(&bytes).map_err(|e| {
+                    let _ = fs::remove_file(path);
+                    MacosError::Other(format!("failed to write {}: {e}", path.display()))
+                })?;
+                return Ok(());
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                let existing_raw = match fs::read_to_string(path) {
+                    Ok(raw) => raw,
+                    Err(read_error) if read_error.kind() == ErrorKind::NotFound => continue,
+                    Err(read_error) => {
+                        return Err(MacosError::Other(format!(
+                            "failed to read Safari lock {}: {read_error}",
+                            path.display()
+                        )));
+                    }
+                };
+                let existing: SafariLockFile =
+                    serde_json::from_str(&existing_raw).map_err(|_| {
+                        MacosError::Other(format!(
+                            "Safari automation lock {} exists but is corrupted or unreadable",
+                            path.display()
+                        ))
+                    })?;
+                let expired = existing.expires_at <= now_ts;
+                if expired {
+                    match fs::remove_file(path) {
+                        Ok(()) => continue,
+                        Err(remove_error) if remove_error.kind() == ErrorKind::NotFound => continue,
+                        Err(remove_error) => {
+                            return Err(MacosError::Other(format!(
+                                "failed to clear stale Safari lock {}: {remove_error}",
+                                path.display()
+                            )));
+                        }
+                    }
+                }
+
+                return Err(MacosError::Other(format!(
+                    "Safari automation is locked by pid {} until {}",
+                    existing.pid, existing.expires_at
+                )));
+            }
+            Err(error) => {
+                return Err(MacosError::Other(format!(
+                    "failed to create Safari lock {}: {error}",
+                    path.display()
+                )));
+            }
+        }
+    }
+
+    Err(MacosError::Other(format!(
+        "failed to acquire Safari lock {}",
+        path.display()
+    )))
+}
+
+pub(crate) fn release_safari_lock(path: &Path, pid: u32) -> Result<(), MacosError> {
+    let owner_matches = read_safari_lock(path)
+        .map(|lock| lock.pid == pid)
+        .unwrap_or(false);
+    if !owner_matches {
+        return Ok(());
+    }
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(MacosError::Other(format!(
+            "failed to remove Safari lock {}: {err}",
+            path.display()
+        ))),
+    }
+}
+
+pub(crate) fn read_safari_lock(path: &Path) -> Option<SafariLockFile> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -259,6 +259,63 @@ enum SafariAiAction {
 }
 
 #[derive(Subcommand)]
+enum SafariBookmarksAction {
+    /// List bookmark/folder items under the bookmark root or a specific folder path
+    List {
+        /// Restrict bookmarks operations to a Safari profile folder at the root
+        #[arg(long)]
+        profile: Option<String>,
+        /// Optional folder path such as Work/AI Tools
+        #[arg(long)]
+        folder: Option<String>,
+    },
+
+    /// Search bookmarks recursively from the root or a specific folder path
+    Search {
+        /// Query string to match against bookmark title or URL
+        query: String,
+        /// Restrict bookmarks operations to a Safari profile folder at the root
+        #[arg(long)]
+        profile: Option<String>,
+        /// Optional folder path such as Work/AI Tools
+        #[arg(long)]
+        folder: Option<String>,
+    },
+
+    /// Add a bookmark under the root or a specific folder path
+    Add {
+        /// Bookmark title
+        #[arg(long)]
+        title: String,
+        /// Bookmark URL
+        #[arg(long)]
+        url: String,
+        /// Restrict bookmarks operations to a Safari profile folder at the root
+        #[arg(long)]
+        profile: Option<String>,
+        /// Optional folder path such as Work/AI Tools
+        #[arg(long)]
+        folder: Option<String>,
+    },
+
+    /// Delete a bookmark by exact title + URL under the root or a specific folder path
+    Delete {
+        /// Bookmark title
+        #[arg(long)]
+        title: String,
+        /// Bookmark URL
+        #[arg(long)]
+        url: String,
+        /// Restrict bookmarks operations to a Safari profile folder at the root
+        #[arg(long)]
+        profile: Option<String>,
+        /// Optional folder path such as Work/AI Tools
+        #[arg(long)]
+        folder: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 enum SafariAction {
     /// List all current Safari tabs
     Tabs {
@@ -390,6 +447,12 @@ enum SafariAction {
         /// Timeout in seconds
         #[arg(long, default_value = "30")]
         timeout: u64,
+    },
+
+    /// Safari bookmarks workflows
+    Bookmarks {
+        #[command(subcommand)]
+        action: SafariBookmarksAction,
     },
 
     /// Safari AI provider workflows
@@ -681,6 +744,21 @@ fn print_external(source: &str, json: &str) {
     println!("<external source=\"cueward/{source}\">");
     println!("{safe}");
     println!("</external>");
+}
+
+fn bookmarks_target_folder(
+    profile: Option<&str>,
+    folder: Option<&str>,
+) -> Result<Option<String>, String> {
+    let profile = profile.map(str::trim).filter(|value| !value.is_empty());
+    let folder = folder.map(str::trim).filter(|value| !value.is_empty());
+
+    Ok(match (profile, folder) {
+        (Some(profile), Some(folder)) => Some(format!("{profile}/{folder}")),
+        (Some(profile), None) => Some(profile.to_string()),
+        (None, Some(folder)) => Some(folder.to_string()),
+        (None, None) => None,
+    })
 }
 
 fn main() {
@@ -1153,6 +1231,126 @@ fn main() {
                     }
                 }
             }
+            SafariAction::Bookmarks { action } => match action {
+                SafariBookmarksAction::List { profile, folder } => {
+                    let target_folder =
+                        match bookmarks_target_folder(profile.as_deref(), folder.as_deref()) {
+                            Ok(folder) => folder,
+                            Err(err) => {
+                                eprintln!("error: {err}");
+                                process::exit(1);
+                            }
+                        };
+                    match cueward_adapter_macos::bookmarks::list_bookmarks(target_folder.as_deref())
+                    {
+                        Ok(result) => {
+                            print_external(
+                                "safari/bookmarks/list",
+                                &serde_json::to_string_pretty(&result).unwrap(),
+                            );
+                            eprintln!("listed bookmarks");
+                        }
+                        Err(e) => {
+                            eprintln!("error: {e}");
+                            process::exit(1);
+                        }
+                    }
+                }
+                SafariBookmarksAction::Search {
+                    query,
+                    profile,
+                    folder,
+                } => {
+                    let target_folder =
+                        match bookmarks_target_folder(profile.as_deref(), folder.as_deref()) {
+                            Ok(folder) => folder,
+                            Err(err) => {
+                                eprintln!("error: {err}");
+                                process::exit(1);
+                            }
+                        };
+                    match cueward_adapter_macos::bookmarks::search_bookmarks(
+                        &query,
+                        target_folder.as_deref(),
+                    ) {
+                        Ok(result) => {
+                            print_external(
+                                "safari/bookmarks/search",
+                                &serde_json::to_string_pretty(&result).unwrap(),
+                            );
+                            eprintln!("searched bookmarks");
+                        }
+                        Err(e) => {
+                            eprintln!("error: {e}");
+                            process::exit(1);
+                        }
+                    }
+                }
+                SafariBookmarksAction::Add {
+                    title,
+                    url,
+                    profile,
+                    folder,
+                } => {
+                    let target_folder =
+                        match bookmarks_target_folder(profile.as_deref(), folder.as_deref()) {
+                            Ok(folder) => folder,
+                            Err(err) => {
+                                eprintln!("error: {err}");
+                                process::exit(1);
+                            }
+                        };
+                    match cueward_adapter_macos::bookmarks::add_bookmark_cli(
+                        &title,
+                        &url,
+                        target_folder.as_deref(),
+                    ) {
+                        Ok(result) => {
+                            print_external(
+                                "safari/bookmarks/add",
+                                &serde_json::to_string_pretty(&result).unwrap(),
+                            );
+                            eprintln!("bookmark added");
+                        }
+                        Err(e) => {
+                            eprintln!("error: {e}");
+                            process::exit(1);
+                        }
+                    }
+                }
+                SafariBookmarksAction::Delete {
+                    title,
+                    url,
+                    profile,
+                    folder,
+                } => {
+                    let target_folder =
+                        match bookmarks_target_folder(profile.as_deref(), folder.as_deref()) {
+                            Ok(folder) => folder,
+                            Err(err) => {
+                                eprintln!("error: {err}");
+                                process::exit(1);
+                            }
+                        };
+                    match cueward_adapter_macos::bookmarks::delete_bookmark_cli(
+                        &title,
+                        &url,
+                        target_folder.as_deref(),
+                    ) {
+                        Ok(result) => {
+                            print_external(
+                                "safari/bookmarks/delete",
+                                &serde_json::to_string_pretty(&result).unwrap(),
+                            );
+                            eprintln!("bookmark deleted");
+                        }
+                        Err(e) => {
+                            eprintln!("error: {e}");
+                            process::exit(1);
+                        }
+                    }
+                }
+            },
             SafariAction::Ai {
                 provider,
                 profile,
@@ -1831,7 +2029,8 @@ mod tests {
 
     use super::{
         Cli, Command, GeminiAiAction, GeminiMode, SafariAction, SafariAiAction, SafariAiProvider,
-        build_gemini_ai_action, local_day_bounds, validate_optional_output_path,
+        SafariBookmarksAction, bookmarks_target_folder, build_gemini_ai_action, local_day_bounds,
+        validate_optional_output_path,
     };
 
     #[test]
@@ -1931,6 +2130,222 @@ mod tests {
                 assert_eq!(times, 3);
                 assert_eq!(amount, None);
                 assert_eq!(selector, None);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_safari_bookmarks_list_with_folder() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "bookmarks",
+            "list",
+            "--folder",
+            "Work/AI Tools",
+        ])
+        .expect("parse safari bookmarks list");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Bookmarks {
+                        action: SafariBookmarksAction::List { profile, folder },
+                    },
+            } => {
+                assert_eq!(profile, None);
+                assert_eq!(folder.as_deref(), Some("Work/AI Tools"));
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_safari_bookmarks_list_with_profile() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "bookmarks",
+            "list",
+            "--profile",
+            "Ryugu",
+        ])
+        .expect("parse safari bookmarks list with profile");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Bookmarks {
+                        action: SafariBookmarksAction::List { profile, folder },
+                    },
+            } => {
+                assert_eq!(profile.as_deref(), Some("Ryugu"));
+                assert_eq!(folder, None);
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_safari_bookmarks_search_with_folder() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "bookmarks",
+            "search",
+            "claude",
+            "--folder",
+            "Work/AI Tools",
+        ])
+        .expect("parse safari bookmarks search");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Bookmarks {
+                        action:
+                            SafariBookmarksAction::Search {
+                                query,
+                                profile,
+                                folder,
+                            },
+                    },
+            } => {
+                assert_eq!(query, "claude");
+                assert_eq!(profile, None);
+                assert_eq!(folder.as_deref(), Some("Work/AI Tools"));
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_safari_bookmarks_add_with_title_url_and_folder() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "bookmarks",
+            "add",
+            "--title",
+            "Claude",
+            "--url",
+            "https://claude.ai",
+            "--folder",
+            "Work/AI Tools",
+        ])
+        .expect("parse safari bookmarks add");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Bookmarks {
+                        action:
+                            SafariBookmarksAction::Add {
+                                title,
+                                url,
+                                profile,
+                                folder,
+                            },
+                    },
+            } => {
+                assert_eq!(title, "Claude");
+                assert_eq!(url, "https://claude.ai");
+                assert_eq!(profile, None);
+                assert_eq!(folder.as_deref(), Some("Work/AI Tools"));
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_safari_bookmarks_add_with_profile_and_folder() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "bookmarks",
+            "add",
+            "--title",
+            "Claude",
+            "--url",
+            "https://claude.ai",
+            "--profile",
+            "Ryugu",
+            "--folder",
+            "Work/AI Tools",
+        ])
+        .expect("parse safari bookmarks add with profile");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Bookmarks {
+                        action:
+                            SafariBookmarksAction::Add {
+                                title,
+                                url,
+                                profile,
+                                folder,
+                            },
+                    },
+            } => {
+                assert_eq!(title, "Claude");
+                assert_eq!(url, "https://claude.ai");
+                assert_eq!(profile.as_deref(), Some("Ryugu"));
+                assert_eq!(folder.as_deref(), Some("Work/AI Tools"));
+            }
+            _ => panic!("unexpected command"),
+        }
+    }
+
+    #[test]
+    fn bookmarks_target_folder_prepends_profile_to_folder() {
+        let folder =
+            bookmarks_target_folder(Some("Ryugu"), Some("Work/AI Tools")).expect("target folder");
+
+        assert_eq!(folder, Some("Ryugu/Work/AI Tools".to_string()));
+    }
+
+    #[test]
+    fn bookmarks_target_folder_uses_profile_as_root_when_folder_missing() {
+        let folder = bookmarks_target_folder(Some("Ryugu"), None).expect("target folder");
+
+        assert_eq!(folder, Some("Ryugu".to_string()));
+    }
+
+    #[test]
+    fn cli_parses_safari_bookmarks_delete_with_title_url_and_folder() {
+        let cli = Cli::try_parse_from([
+            "cueward",
+            "safari",
+            "bookmarks",
+            "delete",
+            "--title",
+            "Claude",
+            "--url",
+            "https://claude.ai",
+            "--folder",
+            "Work/AI Tools",
+        ])
+        .expect("parse safari bookmarks delete");
+
+        match cli.command {
+            Command::Safari {
+                action:
+                    SafariAction::Bookmarks {
+                        action:
+                            SafariBookmarksAction::Delete {
+                                title,
+                                url,
+                                profile,
+                                folder,
+                            },
+                    },
+            } => {
+                assert_eq!(title, "Claude");
+                assert_eq!(url, "https://claude.ai");
+                assert_eq!(profile, None);
+                assert_eq!(folder.as_deref(), Some("Work/AI Tools"));
             }
             _ => panic!("unexpected command"),
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -746,19 +746,16 @@ fn print_external(source: &str, json: &str) {
     println!("</external>");
 }
 
-fn bookmarks_target_folder(
-    profile: Option<&str>,
-    folder: Option<&str>,
-) -> Result<Option<String>, String> {
+fn bookmarks_target_folder(profile: Option<&str>, folder: Option<&str>) -> Option<String> {
     let profile = profile.map(str::trim).filter(|value| !value.is_empty());
     let folder = folder.map(str::trim).filter(|value| !value.is_empty());
 
-    Ok(match (profile, folder) {
+    match (profile, folder) {
         (Some(profile), Some(folder)) => Some(format!("{profile}/{folder}")),
         (Some(profile), None) => Some(profile.to_string()),
         (None, Some(folder)) => Some(folder.to_string()),
         (None, None) => None,
-    })
+    }
 }
 
 fn main() {
@@ -1234,13 +1231,7 @@ fn main() {
             SafariAction::Bookmarks { action } => match action {
                 SafariBookmarksAction::List { profile, folder } => {
                     let target_folder =
-                        match bookmarks_target_folder(profile.as_deref(), folder.as_deref()) {
-                            Ok(folder) => folder,
-                            Err(err) => {
-                                eprintln!("error: {err}");
-                                process::exit(1);
-                            }
-                        };
+                        bookmarks_target_folder(profile.as_deref(), folder.as_deref());
                     match cueward_adapter_macos::bookmarks::list_bookmarks(target_folder.as_deref())
                     {
                         Ok(result) => {
@@ -1262,13 +1253,7 @@ fn main() {
                     folder,
                 } => {
                     let target_folder =
-                        match bookmarks_target_folder(profile.as_deref(), folder.as_deref()) {
-                            Ok(folder) => folder,
-                            Err(err) => {
-                                eprintln!("error: {err}");
-                                process::exit(1);
-                            }
-                        };
+                        bookmarks_target_folder(profile.as_deref(), folder.as_deref());
                     match cueward_adapter_macos::bookmarks::search_bookmarks(
                         &query,
                         target_folder.as_deref(),
@@ -1293,13 +1278,7 @@ fn main() {
                     folder,
                 } => {
                     let target_folder =
-                        match bookmarks_target_folder(profile.as_deref(), folder.as_deref()) {
-                            Ok(folder) => folder,
-                            Err(err) => {
-                                eprintln!("error: {err}");
-                                process::exit(1);
-                            }
-                        };
+                        bookmarks_target_folder(profile.as_deref(), folder.as_deref());
                     match cueward_adapter_macos::bookmarks::add_bookmark_cli(
                         &title,
                         &url,
@@ -1325,13 +1304,7 @@ fn main() {
                     folder,
                 } => {
                     let target_folder =
-                        match bookmarks_target_folder(profile.as_deref(), folder.as_deref()) {
-                            Ok(folder) => folder,
-                            Err(err) => {
-                                eprintln!("error: {err}");
-                                process::exit(1);
-                            }
-                        };
+                        bookmarks_target_folder(profile.as_deref(), folder.as_deref());
                     match cueward_adapter_macos::bookmarks::delete_bookmark_cli(
                         &title,
                         &url,
@@ -2300,15 +2273,14 @@ mod tests {
 
     #[test]
     fn bookmarks_target_folder_prepends_profile_to_folder() {
-        let folder =
-            bookmarks_target_folder(Some("Ryugu"), Some("Work/AI Tools")).expect("target folder");
+        let folder = bookmarks_target_folder(Some("Ryugu"), Some("Work/AI Tools"));
 
         assert_eq!(folder, Some("Ryugu/Work/AI Tools".to_string()));
     }
 
     #[test]
     fn bookmarks_target_folder_uses_profile_as_root_when_folder_missing() {
-        let folder = bookmarks_target_folder(Some("Ryugu"), None).expect("target folder");
+        let folder = bookmarks_target_folder(Some("Ryugu"), None);
 
         assert_eq!(folder, Some("Ryugu".to_string()));
     }

--- a/docs/plans/2026-04-13-safari-bookmarks-crud.md
+++ b/docs/plans/2026-04-13-safari-bookmarks-crud.md
@@ -1,0 +1,401 @@
+# Safari Bookmarks CRUD Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `cueward safari bookmarks` list/search/add/delete commands on macOS, backed by Safari `Bookmarks.plist`, with full folder-path support and `title + url` fingerprint semantics inside a folder.
+
+**Architecture:** Keep the product surface under the existing `safari` command tree, but follow the repo rule that new Safari-adjacent features must not grow `safari.rs` with feature logic. Implement bookmark plist parsing and CRUD in a new sibling module `crates/adapter-macos/src/bookmarks.rs`, expose it from `lib.rs`, and let the CLI dispatch to that module directly. Preserve existing bookmark plist fields by using a lossless raw plist mutation path for add/delete, and keep bookmarks behind the shared Safari session guard so they serialize with other Safari commands.
+
+**Tech Stack:** Rust 2024, `clap`, `serde`/`serde_json`, new `plist` crate, `tempfile`, `cargo test`
+
+---
+
+## Chunk 1: CLI Contract And Bookmark Read Path
+
+### Task 1: Add Safari bookmarks CLI parse coverage
+
+**Files:**
+- Modify: `crates/cli/src/main.rs`
+
+- [ ] **Step 1: Write the failing parse tests**
+
+Add tests near the existing Safari CLI parse tests for:
+
+```rust
+#[test]
+fn cli_parses_safari_bookmarks_list_with_folder() {
+    let cli = Cli::try_parse_from([
+        "cueward",
+        "safari",
+        "bookmarks",
+        "list",
+        "--folder",
+        "Work/AI Tools",
+    ])
+    .expect("parse safari bookmarks list");
+
+    match cli.command {
+        Command::Safari {
+            action: SafariAction::Bookmarks {
+                action: SafariBookmarksAction::List { folder },
+            },
+        } => assert_eq!(folder.as_deref(), Some("Work/AI Tools")),
+        _ => panic!("unexpected command"),
+    }
+}
+
+#[test]
+fn cli_parses_safari_bookmarks_delete_with_title_url_and_folder() {
+    let cli = Cli::try_parse_from([
+        "cueward",
+        "safari",
+        "bookmarks",
+        "delete",
+        "--title",
+        "Claude",
+        "--url",
+        "https://claude.ai",
+        "--folder",
+        "Work/AI Tools",
+    ])
+    .expect("parse safari bookmarks delete");
+
+    match cli.command {
+        Command::Safari {
+            action: SafariAction::Bookmarks {
+                action: SafariBookmarksAction::Delete { title, url, folder },
+            },
+        } => {
+            assert_eq!(title, "Claude");
+            assert_eq!(url, "https://claude.ai");
+            assert_eq!(folder.as_deref(), Some("Work/AI Tools"));
+        }
+        _ => panic!("unexpected command"),
+    }
+}
+```
+
+Also cover:
+
+- `bookmarks search <query> --folder ...`
+- `bookmarks add --title ... --url ... --folder ...`
+
+- [ ] **Step 2: Run the parse tests to verify they fail**
+
+Run: `cargo test -p cueward-cli cli_parses_safari_bookmarks -- --nocapture`
+
+Expected: FAIL because `SafariAction::Bookmarks` and `SafariBookmarksAction` do not exist yet.
+
+- [ ] **Step 3: Add the minimal CLI enums to make parsing compile**
+
+In `crates/cli/src/main.rs`:
+
+- add `SafariBookmarksAction` as a nested `#[derive(Subcommand)]` enum
+- add `SafariAction::Bookmarks { action: SafariBookmarksAction }`
+- keep the new enum limited to:
+  - `List { folder: Option<String> }`
+  - `Search { query: String, folder: Option<String> }`
+  - `Add { title: String, url: String, folder: Option<String> }`
+  - `Delete { title: String, url: String, folder: Option<String> }`
+
+Do not add dispatch logic yet. This task is only about making the CLI contract concrete and testable.
+
+- [ ] **Step 4: Run the parse tests to verify they pass**
+
+Run: `cargo test -p cueward-cli cli_parses_safari_bookmarks -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cli/src/main.rs
+git commit -m "test: define safari bookmarks cli contract"
+```
+
+### Task 2: Add bookmark read/search tests and module scaffolding
+
+**Files:**
+- Modify: `crates/adapter-macos/Cargo.toml`
+- Modify: `crates/adapter-macos/src/lib.rs`
+- Create: `crates/adapter-macos/src/bookmarks.rs`
+
+- [ ] **Step 1: Write the failing adapter tests for read-only behavior**
+
+Create `crates/adapter-macos/src/bookmarks.rs` with tests that use inline sample plist content plus `tempfile::tempdir()` where file I/O is needed.
+
+Add tests for:
+
+```rust
+#[test]
+fn bookmarks_lists_direct_children_for_folder_path() {
+    let tree = sample_bookmarks_tree();
+    let items = list_items_in_folder(&tree, Some("Work/AI Tools")).expect("list folder");
+
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].title.as_deref(), Some("Claude"));
+    assert_eq!(items[1].title.as_deref(), Some("Grok"));
+}
+
+#[test]
+fn bookmarks_searches_recursively_from_folder_path() {
+    let tree = sample_bookmarks_tree();
+    let items = search_items(&tree, "claude", Some("Work")).expect("search");
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].folder_path, "Work/AI Tools");
+    assert_eq!(items[0].url.as_deref(), Some("https://claude.ai"));
+}
+```
+
+Also add:
+
+- invalid folder path test
+- folder path parser test for `Work/AI Tools`
+- root listing test for direct children only
+
+- [ ] **Step 2: Run the adapter tests to verify they fail**
+
+Run: `cargo test -p cueward-adapter-macos bookmarks_ -- --nocapture`
+
+Expected: FAIL because the new `bookmarks` module, helpers, and `plist` dependency are missing.
+
+- [ ] **Step 3: Add minimal module wiring and read/search implementation**
+
+In `crates/adapter-macos/Cargo.toml`:
+
+- add `plist = "1"`
+
+In `crates/adapter-macos/src/lib.rs`:
+
+- add `pub mod bookmarks;`
+
+In `crates/adapter-macos/src/bookmarks.rs`:
+
+- define typed plist/domain structs needed for read/search only
+- parse folder paths into non-empty segments
+- recursively walk `Children`
+- implement folder lookup from root and `list` / `search` helpers
+- keep URL values opaque strings; do not add canonicalization logic
+- support `--profile` as a root-folder prefix, so `--profile Ryugu --folder "Work/AI Tools"` resolves to `Ryugu/Work/AI Tools`
+
+Prefer a small read model:
+
+- `BookmarkTree`
+- `BookmarkFolder`
+- `BookmarkEntry`
+- `SafariBookmarkItem`
+- `SafariBookmarksListResult`
+- `SafariBookmarksSearchResult`
+
+Keep the module small. If `bookmarks.rs` starts approaching the repo's 500-line cap, split pure helpers into a second sibling file in the same PR rather than stuffing everything into one file.
+
+- [ ] **Step 4: Run the adapter tests to verify they pass**
+
+Run: `cargo test -p cueward-adapter-macos bookmarks_ -- --nocapture`
+
+Expected: PASS for the new read/search/path tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-macos/Cargo.toml crates/adapter-macos/src/lib.rs crates/adapter-macos/src/bookmarks.rs
+git commit -m "feat: add safari bookmark read model"
+```
+
+## Chunk 2: Bookmark Mutation And CLI Wiring
+
+### Task 3: Add add/delete mutation tests and implement fingerprint rules
+
+**Files:**
+- Modify: `crates/adapter-macos/src/bookmarks.rs`
+
+- [ ] **Step 1: Write the failing mutation tests**
+
+Add tests for the approved fingerprint semantics:
+
+```rust
+#[test]
+fn bookmarks_add_rejects_duplicate_title_and_url_in_same_folder() {
+    let mut tree = sample_bookmarks_tree();
+
+    let err = add_bookmark(
+        &mut tree,
+        Some("Work/AI Tools"),
+        "Claude",
+        "https://claude.ai",
+    )
+    .expect_err("duplicate should fail");
+
+    assert!(err.to_string().contains("duplicate bookmark"));
+}
+
+#[test]
+fn bookmarks_add_allows_same_title_with_different_url() {
+    let mut tree = sample_bookmarks_tree();
+
+    add_bookmark(
+        &mut tree,
+        Some("Work/AI Tools"),
+        "Claude",
+        "https://example.com/claude-alt",
+    )
+    .expect("same title, different url is allowed");
+}
+
+#[test]
+fn bookmarks_delete_matches_title_and_url() {
+    let mut tree = sample_bookmarks_tree();
+
+    let deleted = delete_bookmark(
+        &mut tree,
+        Some("Work/AI Tools"),
+        "Claude",
+        "https://claude.ai",
+    )
+    .expect("delete");
+
+    assert_eq!(deleted.title, "Claude");
+    assert_eq!(deleted.url.as_deref(), Some("https://claude.ai"));
+}
+```
+
+Also add:
+
+- delete not found test
+- delete conflict test when the fixture intentionally contains duplicate `title + url`
+- round-trip file test that reads a temp plist, mutates it, writes it back, and reloads it
+
+- [ ] **Step 2: Run the mutation tests to verify they fail**
+
+Run: `cargo test -p cueward-adapter-macos bookmarks_add_ -- --nocapture`
+
+Run: `cargo test -p cueward-adapter-macos bookmarks_delete_ -- --nocapture`
+
+Expected: FAIL because mutation helpers and write-back logic do not exist yet.
+
+- [ ] **Step 3: Implement minimal add/delete and plist persistence**
+
+In `crates/adapter-macos/src/bookmarks.rs`:
+
+- add public functions:
+  - `list_bookmarks(folder: Option<&str>) -> Result<SafariBookmarksListResult, MacosError>`
+  - `search_bookmarks(query: &str, folder: Option<&str>) -> Result<SafariBookmarksSearchResult, MacosError>`
+  - `add_bookmark_cli(title: &str, url: &str, folder: Option<&str>) -> Result<SafariBookmarkMutationResult, MacosError>`
+  - `delete_bookmark_cli(title: &str, url: &str, folder: Option<&str>) -> Result<SafariBookmarkMutationResult, MacosError>`
+- read `~/Library/Safari/Bookmarks.plist`
+- for `add/delete`, mutate the raw plist tree in place and preserve untouched fields
+- tolerate empty folder nodes that omit the `Children` key by treating them as empty lists
+- write the updated plist back once on success
+- treat duplicate `title + url` entries in one folder as data conflict for delete
+- return precise `MacosError::Other(...)` messages matching the spec:
+  - `bookmarks plist not found`
+  - `invalid folder path`
+  - `duplicate bookmark`
+  - `bookmark not found`
+  - `bookmark data conflict`
+  - `plist decode failed`
+  - `plist write failed`
+
+Do not add folder creation or recursive list output in this task.
+
+- [ ] **Step 4: Run the mutation tests to verify they pass**
+
+Run: `cargo test -p cueward-adapter-macos bookmarks_add_ -- --nocapture`
+
+Run: `cargo test -p cueward-adapter-macos bookmarks_delete_ -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-macos/src/bookmarks.rs
+git commit -m "feat: implement safari bookmark mutations"
+```
+
+### Task 4: Wire CLI dispatch, JSON output, and docs
+
+**Files:**
+- Modify: `crates/cli/src/main.rs`
+- Modify: `crates/adapter-macos/src/lib.rs`
+- Modify: `README.md`
+
+- [ ] **Step 1: Add the failing glue assertions where the codebase already has seams**
+
+The current CLI architecture inlines dispatch inside `main.rs`, so there is no clean test seam for command execution without a larger refactor. Keep scope tight:
+
+- rely on the existing parse tests from Task 1
+- rely on the adapter behavior tests from Tasks 2-3
+- use compile + targeted package tests as the glue verification step
+
+Before changing dispatch, add or update any small enum/result tests that help the compiler catch mismatch early, but do not introduce a new abstraction layer just to test dispatch.
+
+- [ ] **Step 2: Wire the new command variants through the CLI**
+
+In `crates/cli/src/main.rs`:
+
+- handle `SafariAction::Bookmarks`
+- dispatch directly to `cueward_adapter_macos::bookmarks::*`
+- build the effective target path from `--profile` + `--folder`
+- for `list`, `search`, `add`, and `delete`, print the pretty JSON payload with `print_external(...)` because bookmark title/url are untrusted external content
+- keep stderr status text short and consistent with existing Safari commands
+
+In `crates/adapter-macos/src/lib.rs`:
+
+- keep `pub mod bookmarks;` exported for CLI use
+
+In the shared Safari guard module:
+
+- extract the existing session lock types/helpers from `safari.rs` into a shared internal module
+- keep `safari.rs` and `bookmarks.rs` both behind the same `with_safari_session()`
+
+In `README.md`:
+
+- add a `Safari bookmarks` subsection near the existing Safari command examples
+- document the exact four commands plus the `Work/AI Tools` folder path example
+- show delete with both `--title` and `--url`
+
+- [ ] **Step 3: Run targeted verification**
+
+Run: `cargo test -p cueward-cli cli_parses_safari_bookmarks -- --nocapture`
+
+Run: `cargo test -p cueward-adapter-macos bookmarks_ -- --nocapture`
+
+Run: `cargo test -p cueward-cli`
+
+Run: `cargo test -p cueward-adapter-macos`
+
+Expected:
+
+- new bookmarks parse tests PASS
+- adapter bookmark tests PASS
+- full package test suites stay green
+
+- [ ] **Step 4: Run formatter**
+
+Run: `cargo fmt`
+
+Expected: no diff after formatting, or only mechanical formatting changes
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cli/src/main.rs crates/adapter-macos/src/lib.rs README.md
+git commit -m "feat: add safari bookmarks cli"
+```
+
+## Final Verification
+
+- [ ] Run: `cargo test -p cueward-cli`
+- [ ] Run: `cargo test -p cueward-adapter-macos`
+- [ ] Skim `README.md` examples against the implemented CLI flags
+- [ ] Manually inspect that `docs/specs/2026-04-13-safari-bookmarks-crud.md` and the implementation still match
+
+## Notes For Execution
+
+- Use `@test-driven-development` discipline while executing: tests first, then minimal implementation.
+- Do not expand scope into folder creation, rename, move, or recursive list output.
+- Keep bookmark logic in `crates/adapter-macos/src/bookmarks.rs`; do not add new feature code to `safari.rs`.
+- It is acceptable to move the shared Safari guard into a dedicated internal module if that is required to keep `bookmarks` serialized with other Safari commands.
+- Prefer inline plist fixtures in Rust tests over adding a new fixtures directory unless the inline sample becomes unreadable.

--- a/docs/specs/2026-04-13-safari-bookmarks-crud.md
+++ b/docs/specs/2026-04-13-safari-bookmarks-crud.md
@@ -45,6 +45,7 @@ cueward safari bookmarks delete --title "Claude" --url "https://claude.ai" [--pr
 - 若只有 `--profile Ryugu`，等同操作 `Ryugu` root folder
 - `--folder "Work/AI Tools"` 代表沿著 `Work -> AI Tools` 往下走
 - 路徑分隔符固定為 `/`
+- 第一期不支援 folder title 本身包含 `/`
 - 空 segment 不允許，例如 `Work//AI`
 - 任一路徑不存在，或對應節點不是資料夾，都回傳 `invalid folder path`
 - 第一期不自動建立缺失資料夾

--- a/docs/specs/2026-04-13-safari-bookmarks-crud.md
+++ b/docs/specs/2026-04-13-safari-bookmarks-crud.md
@@ -1,0 +1,282 @@
+# Safari Bookmarks CRUD
+
+## Goal
+
+處理 issue #51，為 `cueward` 新增 Safari 書籤的讀取、新增、刪除、搜尋能力。
+
+需求重點：
+
+- 產品入口仍在 `cueward safari ...` 之下
+- 支援任意深度的資料夾路徑，例如 `Work/AI Tools`
+- 以資料夾內的 `title + url` 作為書籤唯一指紋
+- 第一期只處理既有資料夾內的書籤，不自動建立新資料夾
+
+## CLI
+
+新增 `safari bookmarks` 子命令：
+
+```bash
+cueward safari bookmarks list [--profile "Ryugu"] [--folder "Work/AI Tools"]
+cueward safari bookmarks search "claude" [--profile "Ryugu"] [--folder "Work/AI Tools"]
+cueward safari bookmarks add --title "Claude" --url "https://claude.ai" [--profile "Ryugu"] [--folder "Work/AI Tools"]
+cueward safari bookmarks delete --title "Claude" --url "https://claude.ai" [--profile "Ryugu"] [--folder "Work/AI Tools"]
+```
+
+語意：
+
+- `list`
+  - 未指定 `--folder` 時，列出 bookmarks root 的直接 children
+  - 若指定 `--profile`，則 scope 到該 profile root folder
+  - 指定 `--folder` 時，列出目標資料夾的直接 children
+- `search`
+  - 從 root 或指定 folder 起點遞迴搜尋
+  - 先做大小寫不敏感的 `title/url contains query`
+- `add`
+  - 需要 `--title` 與 `--url`
+  - 若同資料夾內已存在完全相同的 `title + url`，回傳 duplicate error
+  - 同名不同網址允許存在
+- `delete`
+  - 需要 `--title`、`--url`
+  - 以 `folder + title + url` 精確刪除
+
+## Folder Path 規則
+
+- `--profile Ryugu --folder "Work/AI Tools"` 代表沿著 `Ryugu -> Work -> AI Tools` 往下走
+- 若只有 `--profile Ryugu`，等同操作 `Ryugu` root folder
+- `--folder "Work/AI Tools"` 代表沿著 `Work -> AI Tools` 往下走
+- 路徑分隔符固定為 `/`
+- 空 segment 不允許，例如 `Work//AI`
+- 任一路徑不存在，或對應節點不是資料夾，都回傳 `invalid folder path`
+- 第一期不自動建立缺失資料夾
+
+Safari 書籤樹的解析邏輯採遞迴走訪 `Children`，可支援任意深度。
+
+## 架構決策
+
+產品面維持在 `cueward safari ...` 底下，但 adapter 實作依照 repo 規則放在 `bookmarks.rs`，避免繼續惡化正在重構中的 `safari.rs`。
+
+調整為：
+
+- `crates/adapter-macos/src/bookmarks.rs`
+- `crates/adapter-macos/src/lib.rs`
+
+外部呼叫面維持：
+
+- CLI 仍然是 `cueward safari bookmarks ...`
+- `cueward-adapter-macos` 額外暴露 `pub mod bookmarks;`
+
+`bookmarks.rs` 負責：
+
+- `Bookmarks.plist` 讀取與寫回
+- plist tree 到 Rust 結構的映射
+- folder path 走訪
+- `list/search/add/delete` 商業規則
+
+不把這次功能塞回既有 `safari.rs` 的原因：
+
+- `AGENTS.md` / `CLAUDE.md` 明確規定 `safari.rs` 正在重構，禁止新增功能
+- repo 預期的檔案位置就是 `crates/adapter-macos/src/bookmarks.rs`
+- 書籤 CRUD 是本機資料檔操作，不應和 DOM automation 混在同一檔
+
+這一版只做到「不惡化」：
+
+- 不在 #51 順手處理 #66 的 Safari 模組重構
+- 書籤 CRUD 仍保持獨立模組，但會接到共享的 Safari session guard
+
+## 資料模型
+
+內部至少區分兩層：
+
+1. plist node 結構
+2. 書籤操作用的 domain model
+
+domain model 應能表達：
+
+- folder title
+- bookmark title
+- bookmark url
+- folder path
+- children
+
+第一期不追求完整暴露 Safari plist 的所有欄位給 CLI，但寫回時必須保留未修改節點的原始 plist 欄位。
+
+## 讀寫策略
+
+`Bookmarks.plist` 路徑：
+
+- `~/Library/Safari/Bookmarks.plist`
+
+策略：
+
+- `list/search` 時可解析成較小的 domain model
+- `add/delete` 時必須直接在 raw plist tree 上做 lossless mutation
+- 成功後一次性寫回原 plist，保留未修改節點的原始欄位
+
+不採 shell 為中心的 `plutil` 字串拼接流程，原因：
+
+- typed parse/write 比較穩
+- 較容易做 deterministic unit tests
+- 可以把 plist 結構與商業規則分層
+- raw plist write path 可避免特殊節點 metadata 被意外洗掉
+
+## Safari Session Guard
+
+所有 `safari bookmarks` 子命令都必須包在共享的 `with_safari_session()` 後面。
+
+原因：
+
+- 和其他 `cueward safari ...` 指令共用同一把 lock file
+- 避免 `bookmarks add/delete` 與其他 Safari 指令競態寫入
+- 符合 repo 的「所有 Safari 操作包 `with_safari_session()`」硬規則
+
+## 唯一性與衝突
+
+書籤唯一指紋定義為同資料夾內的 `title + url`。
+
+規則：
+
+- `add` 遇到相同 `title + url`：拒絕新增
+- `same title + different url`：允許
+- `delete`：必須同時匹配 `title + url`
+- 若底層資料異常，出現多筆完全相同的 `title + url`，回傳 `bookmark data conflict`，不默默刪多筆
+
+## 輸出格式
+
+維持 cueward 現有風格，輸出結構化 JSON；CLI 層對外部書籤資料使用 `print_external()` 包裝。
+
+`list`：
+
+```json
+{
+  "folder_path": "Work/AI Tools",
+  "items": [
+    {
+      "kind": "bookmark",
+      "title": "Claude",
+      "url": "https://claude.ai",
+      "folder_path": "Work/AI Tools"
+    },
+    {
+      "kind": "folder",
+      "title": "Docs",
+      "folder_path": "Work/AI Tools/Docs"
+    }
+  ]
+}
+```
+
+`search`：
+
+```json
+{
+  "query": "claude",
+  "items": [
+    {
+      "title": "Claude",
+      "url": "https://claude.ai",
+      "folder_path": "Work/AI Tools"
+    }
+  ]
+}
+```
+
+`add`：
+
+```json
+{
+  "created": true,
+  "bookmark": {
+    "title": "Claude",
+    "url": "https://claude.ai",
+    "folder_path": "Work/AI Tools"
+  }
+}
+```
+
+`delete`：
+
+```json
+{
+  "deleted": true,
+  "bookmark": {
+    "title": "Claude",
+    "url": "https://claude.ai",
+    "folder_path": "Work/AI Tools"
+  }
+}
+```
+
+## 錯誤處理
+
+明確區分以下錯誤：
+
+- `bookmarks plist not found`
+- `invalid folder path`
+- `duplicate bookmark`
+- `bookmark not found`
+- `bookmark data conflict`
+- `plist decode failed`
+- `plist write failed`
+
+CLI 行為維持既有模式：
+
+- 成功：exit 0，JSON 到 stdout；若內容來自 bookmark title/url，使用 `print_external()`
+- 失敗：exit 1，錯誤到 stderr
+
+## 測試策略
+
+### 1. CLI parse tests
+
+放在 `crates/cli/src/main.rs` 現有測試區塊，覆蓋：
+
+- `cueward safari bookmarks list`
+- `cueward safari bookmarks list --folder "Work/AI Tools"`
+- `cueward safari bookmarks search "claude" --folder "Work/AI Tools"`
+- `cueward safari bookmarks add --title ... --url ... --folder ...`
+- `cueward safari bookmarks delete --title ... --url ... --folder ...`
+
+### 2. 純函式測試
+
+放在 `crates/adapter-macos/src/bookmarks.rs`，覆蓋：
+
+- folder path 解析
+- 遞迴走訪 children
+- `title + url` 指紋比對
+- duplicate/conflict 判斷
+- search contains query 邏輯
+
+### 3. plist round-trip tests
+
+用 fixture plist 驗證：
+
+- `list` 讀出正確 folder children
+- `search` 可跨層命中
+- `add` 成功插入新 bookmark
+- `add` 對完全相同 `title + url` 報 duplicate
+- `delete` 精確刪除指定 bookmark
+- 異常重複資料時 `delete` 報 conflict
+
+## 不做的事
+
+第一期不包含：
+
+- 建立、重新命名、刪除 bookmark folder
+- `list --recursive`
+- 跨資料夾搬移 bookmark
+- 自動將重名書籤改成 `(1)`、`(2)` 等後綴
+- 嘗試修復既有損壞的 plist 資料
+
+## 實作影響範圍
+
+- `crates/cli/src/main.rs`
+  - 新增 `SafariBookmarksAction`
+  - 新增 `SafariAction::Bookmarks`
+  - 補 dispatch 與 CLI parse tests
+- `crates/adapter-macos/src/bookmarks.rs`
+  - 新增書籤 CRUD 實作與測試
+- `crates/adapter-macos/src/lib.rs`
+  - 暴露 `pub mod bookmarks;`
+- `README.md`
+  - 補 Safari bookmarks 用法範例
+- `Cargo.toml` / `crates/adapter-macos/Cargo.toml`
+  - 新增 plist 解析依賴


### PR DESCRIPTION
## Summary
- add `cueward safari bookmarks` list/search/add/delete with explicit `--profile` support
- implement macOS Safari bookmark CRUD in a dedicated `bookmarks` module with lossless raw plist mutation for add/delete
- move the shared Safari session lock into a reusable internal guard so bookmarks serialize with other Safari operations

## Why
Cueward already exposes Safari tab and automation commands, but it had no bookmark management flow. This adds bookmark CRUD without growing `safari.rs`, preserves existing Safari bookmark metadata during writes, and keeps bookmark operations behind the same Safari lock used by other `cueward safari ...` commands.

## Impact
- users can manage Safari bookmarks from cueward, including profile-scoped folders like `--profile Ryugu --folder "Work/AI Tools"`
- bookmark outputs are wrapped with `print_external()` like other external Safari content
- the implementation tolerates empty Safari folder nodes that omit `Children`

## Validation
- `cargo fmt`
- `cargo test -p cueward-cli`
- `cargo test -p cueward-adapter-macos`
- `cargo test`
- `cargo build --release`
- real smoke test with `--profile Ryugu`: add -> list -> delete -> search confirms cleanup
