### PR TITLE
[codex] merge dev into main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +327,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "ureq",
  "urlencoding",
  "uuid",
 ]
@@ -373,6 +380,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -434,6 +452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +472,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs4"
@@ -570,10 +607,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -688,6 +827,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +883,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "murmurhash32"
@@ -809,6 +964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +986,15 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -981,6 +1151,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1218,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1118,6 +1337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1384,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1361,6 +1603,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1672,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1716,12 @@ name = "utf8-ranges"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1572,6 +1864,24 @@ checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1850,6 +2160,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,6 +2202,66 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "cueward-adapter-macos"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "chrono",
@@ -327,14 +327,14 @@ dependencies = [
 
 [[package]]
 name = "cueward-adapter-windows"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cueward-core",
 ]
 
 [[package]]
 name = "cueward-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "clap",
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "cueward-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aho-corasick",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/HCYT/cueward"
@@ -17,6 +17,6 @@ readme = "README.md"
 rust-version = "1.85"
 
 [workspace.dependencies]
-cueward-core = { version = "0.2.0", path = "crates/core" }
-cueward-adapter-macos = { version = "0.2.0", path = "crates/adapter-macos" }
-cueward-adapter-windows = { version = "0.2.0", path = "crates/adapter-windows" }
+cueward-core = { version = "0.2.1", path = "crates/core" }
+cueward-adapter-macos = { version = "0.2.1", path = "crates/adapter-macos" }
+cueward-adapter-windows = { version = "0.2.1", path = "crates/adapter-windows" }

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ cueward reddit search "async rust"
 cueward reddit search "async rust" --subreddit r/rust --limit 25
 ```
 
+Repeated scans may return status metadata such as `fresh`, `unchanged`, `skipped`, `warning`, or `deleted`, with `data` omitted when the target is skipped or confirmed deleted.
+
 Outputs JSON to stdout:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -153,6 +153,23 @@ cueward safari ai --provider gemini --profile Work list
 
 Supported Gemini modes: `deep-research`, `image`, `video`, `music`.
 
+### Reddit
+
+Read Reddit via public `old.reddit.com/*.json` endpoints. These commands do not use Safari automation.
+
+```bash
+# Read a subreddit feed
+cueward reddit feed rust
+cueward reddit feed r/rust --limit 50
+
+# Read a post plus top-level comments
+cueward reddit post https://www.reddit.com/r/rust/comments/abc123/example_title/
+
+# Search posts globally or inside one subreddit
+cueward reddit search "async rust"
+cueward reddit search "async rust" --subreddit r/rust --limit 25
+```
+
 Outputs JSON to stdout:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Read current Safari tabs, not just browsing history:
 cueward safari tabs
 
 # Filter by Safari profile name parsed from window title
-cueward safari tabs --profile Ryugu
+cueward safari tabs --profile Work
 
 # Current active tab in the front window
 cueward safari active
@@ -78,7 +78,7 @@ cueward safari fill "textarea" "hello from cueward"
 cueward safari wait ".result" --timeout 30
 
 # Target a specific tab by index or URL/title match
-cueward safari read --tab "gemini.google.com" --profile Ryugu
+cueward safari read --tab "gemini.google.com" --profile Work
 cueward safari exec "document.title" --tab 2
 cueward safari source --tab "ChatGPT"
 
@@ -86,33 +86,33 @@ cueward safari source --tab "ChatGPT"
 cueward safari scroll down
 cueward safari scroll up --amount 1000
 cueward safari scroll top
-cueward safari scroll bottom --profile Ryugu
+cueward safari scroll bottom --profile Work
 
 # Close multiple tabs by profile or URL pattern
-cueward safari close-tabs --profile Ryugu --url "gemini.google.com"
-cueward safari close-tabs --profile Ryugu  # close all tabs in profile
+cueward safari close-tabs --profile Work --url "gemini.google.com"
+cueward safari close-tabs --profile Work  # close all tabs in profile
 
 # List bookmark/folder items from the Safari bookmarks root
 cueward safari bookmarks list
 
 # Scope bookmarks to a specific Safari profile folder
-cueward safari bookmarks list --profile Ryugu
+cueward safari bookmarks list --profile Work
 
 # Traverse nested bookmark folders inside a profile
-cueward safari bookmarks list --profile Ryugu --folder "Work/AI Tools"
+cueward safari bookmarks list --profile Work --folder "Projects/AI Tools"
 
 # Folder paths use "/" as the separator; folder titles containing "/" are not supported
 # in this first version
 
 # Search bookmarks recursively from the root or a profile folder
 cueward safari bookmarks search "claude"
-cueward safari bookmarks search "claude" --profile Ryugu --folder "Work"
+cueward safari bookmarks search "claude" --profile Work --folder "Projects"
 
 # Add a bookmark into a nested folder inside a profile
-cueward safari bookmarks add --title "Claude" --url "https://claude.ai" --profile Ryugu --folder "Work/AI Tools"
+cueward safari bookmarks add --title "Claude" --url "https://claude.ai" --profile Work --folder "Projects/AI Tools"
 
 # Delete by exact title + URL within a profile folder
-cueward safari bookmarks delete --title "Claude" --url "https://claude.ai" --profile Ryugu --folder "Work/AI Tools"
+cueward safari bookmarks delete --title "Claude" --url "https://claude.ai" --profile Work --folder "Projects/AI Tools"
 ```
 
 ### Safari AI
@@ -148,7 +148,7 @@ cueward safari ai --provider gemini save-images https://gemini.google.com/app/ab
 cueward safari ai --provider gemini save-media https://gemini.google.com/app/abc123
 
 # Use a specific Safari profile
-cueward safari ai --provider gemini --profile Ryugu list
+cueward safari ai --provider gemini --profile Work list
 ```
 
 Supported Gemini modes: `deep-research`, `image`, `video`, `music`.

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 description = "macOS adapter for Cueward with Safari, Notes, Messages, Reminders, Calendar, Screenshot, Clipboard, and OCR integrations."
 
 [dependencies]
-cueward-core = { version = "0.2.0", path = "../core" }
+cueward-core = { version = "0.2.1", path = "../core" }
 rusqlite = { version = "0.35", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -21,3 +21,4 @@ sha2 = "0.10"
 base64 = "0.22"
 urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
+ureq = "2"

--- a/crates/adapter-macos/src/bookmarks/plist_io.rs
+++ b/crates/adapter-macos/src/bookmarks/plist_io.rs
@@ -331,7 +331,7 @@ mod tests {
 
     fn empty_folder_root() -> Value {
         let mut folder = Dictionary::new();
-        folder.insert("Title".to_string(), Value::String("Ryugu".to_string()));
+        folder.insert("Title".to_string(), Value::String("Work".to_string()));
         folder.insert(
             "WebBookmarkType".to_string(),
             Value::String("WebBookmarkTypeList".to_string()),
@@ -368,7 +368,7 @@ mod tests {
 
         let result = add_bookmark_to_path(
             &path,
-            Some("Ryugu"),
+            Some("Work"),
             "Smoke Test",
             "https://example.com/smoke",
         )
@@ -376,7 +376,7 @@ mod tests {
 
         assert_eq!(result.title.as_deref(), Some("Smoke Test"));
         assert_eq!(result.url.as_deref(), Some("https://example.com/smoke"));
-        assert_eq!(result.folder_path, "Ryugu");
+        assert_eq!(result.folder_path, "Work");
     }
 
     #[test]
@@ -387,7 +387,7 @@ mod tests {
             .to_file_binary(&path)
             .expect("write plist root");
 
-        let err = delete_bookmark_from_path(&path, Some("Ryugu"), "Missing", "https://example.com")
+        let err = delete_bookmark_from_path(&path, Some("Work"), "Missing", "https://example.com")
             .expect_err("delete should fail");
 
         assert!(err.to_string().contains("bookmark not found"));

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -8,6 +8,7 @@ mod notes;
 pub mod ocr;
 pub mod plan;
 pub mod quick_notes;
+pub mod reddit;
 pub mod reminders;
 pub mod safari;
 mod safari_guard;

--- a/crates/adapter-macos/src/lib.rs
+++ b/crates/adapter-macos/src/lib.rs
@@ -8,6 +8,7 @@ mod notes;
 pub mod ocr;
 pub mod plan;
 pub mod quick_notes;
+pub mod scan_state;
 pub mod reddit;
 pub mod reminders;
 pub mod safari;
@@ -16,6 +17,7 @@ pub mod screenshot;
 pub mod send;
 
 pub use error::MacosError;
+pub use scan_state::{ScanEnvelope, ScanStatus};
 
 use chrono::{DateTime, Utc};
 use cueward_core::{Cue, PlatformAdapter};

--- a/crates/adapter-macos/src/reddit.rs
+++ b/crates/adapter-macos/src/reddit.rs
@@ -1,0 +1,436 @@
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::MacosError;
+
+const REDDIT_BASE: &str = "https://old.reddit.com";
+const REDDIT_OPERATION_DELAY: Duration = Duration::from_secs(1);
+const REDDIT_MAX_RETRIES: usize = 3;
+const REDDIT_UA: &str = concat!(
+    "cueward/",
+    env!("CARGO_PKG_VERSION"),
+    " (+https://github.com/HCYT/cueward)"
+);
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct RedditSubredditInfo {
+    pub name: String,
+    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscribers: Option<u64>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct RedditPostSummary {
+    pub id: String,
+    pub title: String,
+    pub author: String,
+    pub subreddit: String,
+    pub url: String,
+    pub permalink: String,
+    pub score: i64,
+    pub num_comments: u64,
+    pub created_utc: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selftext: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct RedditComment {
+    pub id: String,
+    pub author: String,
+    pub body: String,
+    pub score: i64,
+    pub created_utc: i64,
+    pub permalink: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct RedditFeedResult {
+    pub subreddit: RedditSubredditInfo,
+    pub posts: Vec<RedditPostSummary>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct RedditPostResult {
+    pub post: RedditPostSummary,
+    pub comments: Vec<RedditComment>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct RedditSearchResult {
+    pub query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subreddit: Option<String>,
+    pub limit: usize,
+    pub posts: Vec<RedditPostSummary>,
+}
+
+/// Read a subreddit feed via old.reddit.com JSON endpoints.
+pub fn feed(subreddit: &str, limit: usize) -> Result<RedditFeedResult, MacosError> {
+    validate_limit(limit)?;
+    let subreddit = normalize_subreddit(subreddit)?;
+    let about = fetch_json(&build_about_url(&subreddit))?;
+    let listing = fetch_json(&build_feed_url(&subreddit, limit))?;
+    Ok(RedditFeedResult {
+        subreddit: parse_subreddit_info(&about)?,
+        posts: parse_listing_posts(&listing)?,
+    })
+}
+
+/// Read a Reddit post plus its top-level comments.
+pub fn post(url: &str) -> Result<RedditPostResult, MacosError> {
+    let url = normalize_post_url(url)?;
+    let payload = fetch_json(&url)?;
+    parse_post_result(&payload)
+}
+
+/// Search Reddit posts via the public JSON API.
+pub fn search(
+    query: &str,
+    subreddit: Option<&str>,
+    limit: usize,
+) -> Result<RedditSearchResult, MacosError> {
+    validate_limit(limit)?;
+    let query = query.trim();
+    if query.is_empty() {
+        return Err(MacosError::Other("reddit query must not be empty".to_string()));
+    }
+    let subreddit = match subreddit {
+        Some(value) => Some(normalize_subreddit(value)?),
+        None => None,
+    };
+    let posts = parse_listing_posts(&fetch_json(&build_search_url(query, subreddit.as_deref(), limit))?)?;
+    Ok(RedditSearchResult {
+        query: query.to_string(),
+        subreddit,
+        limit,
+        posts,
+    })
+}
+
+fn validate_limit(limit: usize) -> Result<(), MacosError> {
+    if limit == 0 {
+        return Err(MacosError::Other("reddit limit must be greater than 0".to_string()));
+    }
+    Ok(())
+}
+
+fn normalize_subreddit(input: &str) -> Result<String, MacosError> {
+    let trimmed = input.trim();
+    let trimmed = trimmed.strip_prefix("r/").unwrap_or(trimmed);
+    let trimmed = trimmed.strip_prefix("R/").unwrap_or(trimmed);
+    let trimmed = trimmed.trim_matches('/');
+    if trimmed.is_empty() || trimmed.contains('/') {
+        return Err(MacosError::Other(format!("invalid subreddit: {input}")));
+    }
+    Ok(trimmed.to_ascii_lowercase())
+}
+
+fn normalize_post_url(input: &str) -> Result<String, MacosError> {
+    let trimmed = input.trim();
+    let without_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+    let (host, rest) = without_scheme
+        .split_once('/')
+        .ok_or_else(|| MacosError::Other(format!("invalid reddit post url: {input}")))?;
+    let host = host.to_ascii_lowercase();
+    if !matches!(host.as_str(), "reddit.com" | "www.reddit.com" | "old.reddit.com") {
+        return Err(MacosError::Other(format!("invalid reddit post url: {input}")));
+    }
+    let path_only = rest
+        .split('?')
+        .next()
+        .unwrap_or(rest)
+        .split('#')
+        .next()
+        .unwrap_or(rest);
+    let path = path_only.trim_matches('/');
+    let segments: Vec<&str> = path.split('/').collect();
+    if segments.len() < 4 || segments[0] != "r" || segments[2] != "comments" {
+        return Err(MacosError::Other(format!("invalid reddit post url: {input}")));
+    }
+    let subreddit = normalize_subreddit(segments[1])?;
+    let post_id = segments[3];
+    if post_id.is_empty() {
+        return Err(MacosError::Other(format!("invalid reddit post url: {input}")));
+    }
+    let slug = segments.get(4).copied().unwrap_or("");
+    let suffix = if slug.is_empty() {
+        String::new()
+    } else {
+        format!("/{slug}")
+    };
+    Ok(format!(
+        "{REDDIT_BASE}/r/{subreddit}/comments/{post_id}{suffix}.json?limit=500"
+    ))
+}
+
+fn build_about_url(subreddit: &str) -> String {
+    format!("{REDDIT_BASE}/r/{subreddit}/about.json")
+}
+
+fn build_feed_url(subreddit: &str, limit: usize) -> String {
+    format!("{REDDIT_BASE}/r/{subreddit}.json?limit={limit}")
+}
+
+fn build_search_url(query: &str, subreddit: Option<&str>, limit: usize) -> String {
+    let query = urlencoding::encode(query);
+    match subreddit {
+        Some(subreddit) => format!(
+            "{REDDIT_BASE}/r/{subreddit}/search.json?q={query}&restrict_sr=on&limit={limit}&sort=relevance"
+        ),
+        None => format!("{REDDIT_BASE}/search.json?q={query}&limit={limit}&sort=relevance"),
+    }
+}
+
+fn fetch_json(url: &str) -> Result<Value, MacosError> {
+    let mut last_error = None;
+
+    for attempt in 0..=REDDIT_MAX_RETRIES {
+        throttle_reddit_request()?;
+        let response = ureq::get(url)
+            .set("User-Agent", REDDIT_UA)
+            .set("Accept", "application/json")
+            .call();
+        match response {
+            Ok(response) => {
+                let body = response.into_string().map_err(|error| {
+                    MacosError::Other(format!("failed to read reddit response: {error}"))
+                })?;
+                return serde_json::from_str(&body).map_err(|error| {
+                    MacosError::Other(format!("invalid reddit json payload: {error}"))
+                });
+            }
+            Err(ureq::Error::Status(status, response)) => {
+                let retry_after = retry_after_delay(&response);
+                let body = response.into_string().unwrap_or_default();
+                if should_retry_status(status) && attempt < REDDIT_MAX_RETRIES {
+                    last_error = Some(format!(
+                        "reddit returned retryable status {status}: {}",
+                        body.trim()
+                    ));
+                    thread::sleep(retry_after.unwrap_or_else(|| reddit_backoff(attempt)));
+                    continue;
+                }
+                return Err(MacosError::Other(format!(
+                    "reddit returned unexpected status {status}: {}",
+                    body.trim()
+                )));
+            }
+            Err(ureq::Error::Transport(error)) => {
+                if attempt < REDDIT_MAX_RETRIES {
+                    last_error = Some(format!("reddit request failed: {error}"));
+                    thread::sleep(reddit_backoff(attempt));
+                    continue;
+                }
+                return Err(MacosError::Other(format!("reddit request failed: {error}")));
+            }
+        }
+    }
+
+    Err(MacosError::Other(
+        last_error.unwrap_or_else(|| "reddit request failed after retries".to_string()),
+    ))
+}
+
+fn reddit_request_state() -> &'static Mutex<Option<Instant>> {
+    static STATE: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(None))
+}
+
+fn compute_next_reddit_request(
+    now: Instant,
+    last_request_at: Option<Instant>,
+) -> (Option<Duration>, Instant) {
+    match last_request_at {
+        Some(last) if now < last + REDDIT_OPERATION_DELAY => {
+            let next_allowed = last + REDDIT_OPERATION_DELAY;
+            (Some(next_allowed - now), next_allowed)
+        }
+        _ => (None, now),
+    }
+}
+
+fn throttle_reddit_request() -> Result<(), MacosError> {
+    let sleep_for = {
+        let mut guard = reddit_request_state()
+            .lock()
+            .map_err(|_| MacosError::Other("reddit request state poisoned".to_string()))?;
+        let now = Instant::now();
+        let (delay, next_allowed) = compute_next_reddit_request(now, *guard);
+        *guard = Some(next_allowed);
+        delay
+    };
+
+    if let Some(delay) = sleep_for {
+        thread::sleep(delay);
+    }
+    Ok(())
+}
+
+fn should_retry_status(status: u16) -> bool {
+    status == 429 || (500..600).contains(&status)
+}
+
+fn retry_after_delay(response: &ureq::Response) -> Option<Duration> {
+    response
+        .header("Retry-After")
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .map(Duration::from_secs)
+}
+
+fn reddit_backoff(attempt: usize) -> Duration {
+    Duration::from_secs(2 * (attempt as u64 + 1))
+}
+
+fn parse_subreddit_info(root: &Value) -> Result<RedditSubredditInfo, MacosError> {
+    let data = object(root, "reddit about payload")?
+        .get("data")
+        .ok_or_else(|| MacosError::Other("invalid reddit json payload: missing about data".to_string()))
+        .and_then(|value| object(value, "reddit about data"))?;
+    Ok(RedditSubredditInfo {
+        name: string(data, "display_name").unwrap_or_default().to_ascii_lowercase(),
+        display_name: string(data, "display_name_prefixed").unwrap_or_default(),
+        title: optional_string(data, "title"),
+        description: optional_string(data, "public_description"),
+        subscribers: optional_u64(data, "subscribers"),
+    })
+}
+
+fn parse_listing_posts(root: &Value) -> Result<Vec<RedditPostSummary>, MacosError> {
+    let children = listing_children(root)?;
+    Ok(children
+        .iter()
+        .filter_map(|child| thing_data(child).ok())
+        .filter_map(parse_post_summary)
+        .collect())
+}
+
+fn parse_post_result(root: &Value) -> Result<RedditPostResult, MacosError> {
+    let items = array(root, "reddit post payload")?;
+    let post_listing = items
+        .first()
+        .ok_or_else(|| MacosError::Other("invalid reddit post payload: missing post listing".to_string()))?;
+    let comments_listing = items
+        .get(1)
+        .ok_or_else(|| MacosError::Other("invalid reddit post payload: missing comments listing".to_string()))?;
+    let post = listing_children(post_listing)?
+        .iter()
+        .filter_map(|child| thing_data(child).ok())
+        .find_map(parse_post_summary)
+        .ok_or_else(|| MacosError::Other("post payload missing article data".to_string()))?;
+    let comments = listing_children(comments_listing)?
+        .iter()
+        .filter(|child| child.get("kind").and_then(Value::as_str) == Some("t1"))
+        .filter_map(|child| thing_data(child).ok())
+        .filter_map(parse_comment)
+        .collect();
+    Ok(RedditPostResult { post, comments })
+}
+
+fn listing_children(root: &Value) -> Result<&Vec<Value>, MacosError> {
+    let data = object(root, "reddit listing payload")?
+        .get("data")
+        .ok_or_else(|| MacosError::Other("invalid reddit json payload: missing listing data".to_string()))
+        .and_then(|value| object(value, "reddit listing data"))?;
+    data.get("children")
+        .ok_or_else(|| MacosError::Other("invalid reddit json payload: missing listing children".to_string()))
+        .and_then(|value| array(value, "reddit listing children"))
+}
+
+fn thing_data(root: &Value) -> Result<&Map<String, Value>, MacosError> {
+    object(root, "reddit thing")?
+        .get("data")
+        .ok_or_else(|| MacosError::Other("invalid reddit thing: missing data".to_string()))
+        .and_then(|value| object(value, "reddit thing data"))
+}
+
+fn parse_post_summary(data: &Map<String, Value>) -> Option<RedditPostSummary> {
+    Some(RedditPostSummary {
+        id: string(data, "id")?,
+        title: string(data, "title")?,
+        author: string(data, "author")?,
+        subreddit: string(data, "subreddit")?,
+        url: string(data, "url")?,
+        permalink: prefixed_permalink(optional_string(data, "permalink")?)?,
+        score: optional_i64(data, "score").unwrap_or(0),
+        num_comments: optional_u64(data, "num_comments").unwrap_or(0),
+        created_utc: optional_i64(data, "created_utc").unwrap_or(0),
+        selftext: optional_string(data, "selftext").filter(|value| !value.is_empty()),
+    })
+}
+
+fn parse_comment(data: &Map<String, Value>) -> Option<RedditComment> {
+    Some(RedditComment {
+        id: string(data, "id")?,
+        author: string(data, "author")?,
+        body: string(data, "body")?,
+        score: optional_i64(data, "score").unwrap_or(0),
+        created_utc: optional_i64(data, "created_utc").unwrap_or(0),
+        permalink: prefixed_permalink(optional_string(data, "permalink")?)?,
+    })
+}
+
+fn prefixed_permalink(path: String) -> Option<String> {
+    if path.is_empty() {
+        return None;
+    }
+    Some(if path.starts_with("http://") || path.starts_with("https://") {
+        path
+    } else {
+        format!("https://reddit.com{path}")
+    })
+}
+
+fn object<'a>(value: &'a Value, label: &str) -> Result<&'a Map<String, Value>, MacosError> {
+    value
+        .as_object()
+        .ok_or_else(|| MacosError::Other(format!("invalid {label}: expected object")))
+}
+
+fn array<'a>(value: &'a Value, label: &str) -> Result<&'a Vec<Value>, MacosError> {
+    value
+        .as_array()
+        .ok_or_else(|| MacosError::Other(format!("invalid {label}: expected array")))
+}
+
+fn string(data: &Map<String, Value>, key: &str) -> Option<String> {
+    data.get(key).and_then(Value::as_str).map(ToOwned::to_owned)
+}
+
+fn optional_string(data: &Map<String, Value>, key: &str) -> Option<String> {
+    string(data, key)
+}
+
+fn optional_u64(data: &Map<String, Value>, key: &str) -> Option<u64> {
+    data.get(key).and_then(|value| {
+        value.as_u64().or_else(|| {
+            value
+                .as_i64()
+                .and_then(|n| if n >= 0 { Some(n as u64) } else { None })
+        })
+    })
+}
+
+fn optional_i64(data: &Map<String, Value>, key: &str) -> Option<i64> {
+    data.get(key).and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_u64().map(|n| n as i64))
+            .or_else(|| value.as_f64().map(|n| n as i64))
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/adapter-macos/src/reddit/mod.rs
+++ b/crates/adapter-macos/src/reddit/mod.rs
@@ -16,6 +16,12 @@ const REDDIT_UA: &str = concat!(
     " (+https://github.com/HCYT/cueward)"
 );
 
+mod scan;
+#[cfg(test)]
+mod tests;
+
+pub use scan::{feed, post, search};
+
 #[derive(Debug, Serialize, PartialEq, Eq)]
 pub struct RedditSubredditInfo {
     pub name: String,
@@ -74,57 +80,14 @@ pub struct RedditSearchResult {
     pub posts: Vec<RedditPostSummary>,
 }
 
-/// Read a subreddit feed via old.reddit.com JSON endpoints.
-pub fn feed(subreddit: &str, limit: usize) -> Result<RedditFeedResult, MacosError> {
-    validate_limit(limit)?;
-    let subreddit = normalize_subreddit(subreddit)?;
-    let about = fetch_json(&build_about_url(&subreddit))?;
-    let listing = fetch_json(&build_feed_url(&subreddit, limit))?;
-    Ok(RedditFeedResult {
-        subreddit: parse_subreddit_info(&about)?,
-        posts: parse_listing_posts(&listing)?,
-    })
-}
-
-/// Read a Reddit post plus its top-level comments.
-pub fn post(url: &str) -> Result<RedditPostResult, MacosError> {
-    let url = normalize_post_url(url)?;
-    let payload = fetch_json(&url)?;
-    parse_post_result(&payload)
-}
-
-/// Search Reddit posts via the public JSON API.
-pub fn search(
-    query: &str,
-    subreddit: Option<&str>,
-    limit: usize,
-) -> Result<RedditSearchResult, MacosError> {
-    validate_limit(limit)?;
-    let query = query.trim();
-    if query.is_empty() {
-        return Err(MacosError::Other("reddit query must not be empty".to_string()));
-    }
-    let subreddit = match subreddit {
-        Some(value) => Some(normalize_subreddit(value)?),
-        None => None,
-    };
-    let posts = parse_listing_posts(&fetch_json(&build_search_url(query, subreddit.as_deref(), limit))?)?;
-    Ok(RedditSearchResult {
-        query: query.to_string(),
-        subreddit,
-        limit,
-        posts,
-    })
-}
-
-fn validate_limit(limit: usize) -> Result<(), MacosError> {
+pub(super) fn validate_limit(limit: usize) -> Result<(), MacosError> {
     if limit == 0 {
         return Err(MacosError::Other("reddit limit must be greater than 0".to_string()));
     }
     Ok(())
 }
 
-fn normalize_subreddit(input: &str) -> Result<String, MacosError> {
+pub(super) fn normalize_subreddit(input: &str) -> Result<String, MacosError> {
     let trimmed = input.trim();
     let trimmed = trimmed.strip_prefix("r/").unwrap_or(trimmed);
     let trimmed = trimmed.strip_prefix("R/").unwrap_or(trimmed);
@@ -135,7 +98,7 @@ fn normalize_subreddit(input: &str) -> Result<String, MacosError> {
     Ok(trimmed.to_ascii_lowercase())
 }
 
-fn normalize_post_url(input: &str) -> Result<String, MacosError> {
+pub(super) fn normalize_post_url(input: &str) -> Result<String, MacosError> {
     let trimmed = input.trim();
     let without_scheme = trimmed
         .strip_prefix("https://")
@@ -176,15 +139,15 @@ fn normalize_post_url(input: &str) -> Result<String, MacosError> {
     ))
 }
 
-fn build_about_url(subreddit: &str) -> String {
+pub(super) fn build_about_url(subreddit: &str) -> String {
     format!("{REDDIT_BASE}/r/{subreddit}/about.json")
 }
 
-fn build_feed_url(subreddit: &str, limit: usize) -> String {
+pub(super) fn build_feed_url(subreddit: &str, limit: usize) -> String {
     format!("{REDDIT_BASE}/r/{subreddit}.json?limit={limit}")
 }
 
-fn build_search_url(query: &str, subreddit: Option<&str>, limit: usize) -> String {
+pub(super) fn build_search_url(query: &str, subreddit: Option<&str>, limit: usize) -> String {
     let query = urlencoding::encode(query);
     match subreddit {
         Some(subreddit) => format!(
@@ -194,11 +157,27 @@ fn build_search_url(query: &str, subreddit: Option<&str>, limit: usize) -> Strin
     }
 }
 
-fn fetch_json(url: &str) -> Result<Value, MacosError> {
+pub(super) enum FetchJsonError {
+    NotFound,
+    Other(MacosError),
+}
+
+impl From<FetchJsonError> for MacosError {
+    fn from(value: FetchJsonError) -> Self {
+        match value {
+            FetchJsonError::NotFound => {
+                MacosError::Other("reddit target not found".to_string())
+            }
+            FetchJsonError::Other(error) => error,
+        }
+    }
+}
+
+pub(super) fn fetch_json(url: &str) -> Result<Value, FetchJsonError> {
     let mut last_error = None;
 
     for attempt in 0..=REDDIT_MAX_RETRIES {
-        throttle_reddit_request()?;
+        throttle_reddit_request().map_err(FetchJsonError::Other)?;
         let response = ureq::get(url)
             .set("User-Agent", REDDIT_UA)
             .set("Accept", "application/json")
@@ -206,15 +185,22 @@ fn fetch_json(url: &str) -> Result<Value, MacosError> {
         match response {
             Ok(response) => {
                 let body = response.into_string().map_err(|error| {
-                    MacosError::Other(format!("failed to read reddit response: {error}"))
+                    FetchJsonError::Other(MacosError::Other(format!(
+                        "failed to read reddit response: {error}"
+                    )))
                 })?;
                 return serde_json::from_str(&body).map_err(|error| {
-                    MacosError::Other(format!("invalid reddit json payload: {error}"))
+                    FetchJsonError::Other(MacosError::Other(format!(
+                        "invalid reddit json payload: {error}"
+                    )))
                 });
             }
             Err(ureq::Error::Status(status, response)) => {
                 let retry_after = retry_after_delay(&response);
                 let body = response.into_string().unwrap_or_default();
+                if status == 404 {
+                    return Err(FetchJsonError::NotFound);
+                }
                 if should_retry_status(status) && attempt < REDDIT_MAX_RETRIES {
                     last_error = Some(format!(
                         "reddit returned retryable status {status}: {}",
@@ -223,10 +209,10 @@ fn fetch_json(url: &str) -> Result<Value, MacosError> {
                     thread::sleep(retry_after.unwrap_or_else(|| reddit_backoff(attempt)));
                     continue;
                 }
-                return Err(MacosError::Other(format!(
+                return Err(FetchJsonError::Other(MacosError::Other(format!(
                     "reddit returned unexpected status {status}: {}",
                     body.trim()
-                )));
+                ))));
             }
             Err(ureq::Error::Transport(error)) => {
                 if attempt < REDDIT_MAX_RETRIES {
@@ -234,14 +220,16 @@ fn fetch_json(url: &str) -> Result<Value, MacosError> {
                     thread::sleep(reddit_backoff(attempt));
                     continue;
                 }
-                return Err(MacosError::Other(format!("reddit request failed: {error}")));
+                return Err(FetchJsonError::Other(MacosError::Other(format!(
+                    "reddit request failed: {error}"
+                ))));
             }
         }
     }
 
-    Err(MacosError::Other(
+    Err(FetchJsonError::Other(MacosError::Other(
         last_error.unwrap_or_else(|| "reddit request failed after retries".to_string()),
-    ))
+    )))
 }
 
 fn reddit_request_state() -> &'static Mutex<Option<Instant>> {
@@ -294,7 +282,7 @@ fn reddit_backoff(attempt: usize) -> Duration {
     Duration::from_secs(2 * (attempt as u64 + 1))
 }
 
-fn parse_subreddit_info(root: &Value) -> Result<RedditSubredditInfo, MacosError> {
+pub(super) fn parse_subreddit_info(root: &Value) -> Result<RedditSubredditInfo, MacosError> {
     let data = object(root, "reddit about payload")?
         .get("data")
         .ok_or_else(|| MacosError::Other("invalid reddit json payload: missing about data".to_string()))
@@ -308,7 +296,7 @@ fn parse_subreddit_info(root: &Value) -> Result<RedditSubredditInfo, MacosError>
     })
 }
 
-fn parse_listing_posts(root: &Value) -> Result<Vec<RedditPostSummary>, MacosError> {
+pub(super) fn parse_listing_posts(root: &Value) -> Result<Vec<RedditPostSummary>, MacosError> {
     let children = listing_children(root)?;
     Ok(children
         .iter()
@@ -317,7 +305,7 @@ fn parse_listing_posts(root: &Value) -> Result<Vec<RedditPostSummary>, MacosErro
         .collect())
 }
 
-fn parse_post_result(root: &Value) -> Result<RedditPostResult, MacosError> {
+pub(super) fn parse_post_result(root: &Value) -> Result<RedditPostResult, MacosError> {
     let items = array(root, "reddit post payload")?;
     let post_listing = items
         .first()
@@ -431,6 +419,3 @@ fn optional_i64(data: &Map<String, Value>, key: &str) -> Option<i64> {
             .or_else(|| value.as_f64().map(|n| n as i64))
     })
 }
-
-#[cfg(test)]
-mod tests;

--- a/crates/adapter-macos/src/reddit/scan.rs
+++ b/crates/adapter-macos/src/reddit/scan.rs
@@ -1,0 +1,232 @@
+use chrono::{TimeZone, Utc};
+use serde::Serialize;
+
+use crate::scan_state::{
+    ScanEnvelope, ScanStatus, build_scan_key, entry_for, fingerprint_json, is_bot_like_author,
+    is_too_old, is_too_short, load_state, make_envelope, record_not_found, record_success,
+    save_state_warning, skip_reason, stored_entry,
+};
+use crate::MacosError;
+
+use super::{
+    FetchJsonError, RedditComment, RedditFeedResult, RedditPostResult, RedditPostSummary,
+    RedditSearchResult, build_about_url, build_feed_url, build_search_url, fetch_json,
+    normalize_post_url, normalize_subreddit, parse_listing_posts, parse_post_result,
+    parse_subreddit_info, validate_limit,
+};
+
+#[derive(Serialize)]
+struct RedditPostFingerprint<'a> {
+    id: &'a str,
+    title: &'a str,
+    author: &'a str,
+    subreddit: &'a str,
+    url: &'a str,
+    permalink: &'a str,
+    created_utc: i64,
+    selftext: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct RedditCommentFingerprint<'a> {
+    id: &'a str,
+    author: &'a str,
+    body: &'a str,
+    permalink: &'a str,
+    created_utc: i64,
+}
+
+fn fingerprint_posts(posts: &[RedditPostSummary]) -> Result<String, MacosError> {
+    let payload: Vec<_> = posts
+        .iter()
+        .map(|post| RedditPostFingerprint {
+            id: &post.id,
+            title: &post.title,
+            author: &post.author,
+            subreddit: &post.subreddit,
+            url: &post.url,
+            permalink: &post.permalink,
+            created_utc: post.created_utc,
+            selftext: post.selftext.as_deref(),
+        })
+        .collect();
+    fingerprint_json(&payload)
+}
+
+fn fingerprint_comments(comments: &[RedditComment]) -> Result<String, MacosError> {
+    let payload: Vec<_> = comments
+        .iter()
+        .map(|comment| RedditCommentFingerprint {
+            id: &comment.id,
+            author: &comment.author,
+            body: &comment.body,
+            permalink: &comment.permalink,
+            created_utc: comment.created_utc,
+        })
+        .collect();
+    fingerprint_json(&payload)
+}
+
+pub(super) fn filter_comments(
+    comments: Vec<RedditComment>,
+    now: chrono::DateTime<Utc>,
+) -> Vec<RedditComment> {
+    comments
+        .into_iter()
+        .filter(|comment| !is_bot_like_author(&comment.author))
+        .filter(|comment| !is_too_short(&comment.body))
+        .filter(|comment| {
+            Utc.timestamp_opt(comment.created_utc, 0)
+                .single()
+                .map(|created_at| !is_too_old(created_at, now))
+                .unwrap_or(true)
+        })
+        .collect()
+}
+
+/// Read a subreddit feed via old.reddit.com JSON endpoints with scan-state tracking.
+pub fn feed(subreddit: &str, limit: usize) -> Result<ScanEnvelope<RedditFeedResult>, MacosError> {
+    validate_limit(limit)?;
+    let subreddit = normalize_subreddit(subreddit)?;
+    let target_url = build_feed_url(&subreddit, limit);
+    let key = build_scan_key("reddit", &target_url);
+    let now = Utc::now();
+    let mut state = load_state();
+
+    {
+        let entry = entry_for(&mut state, &key, "reddit", &target_url);
+        if entry.deleted {
+            return Ok(make_envelope(
+                entry,
+                ScanStatus::Deleted,
+                Some("deleted_target".to_string()),
+                None,
+                None,
+            ));
+        }
+        if let Some(reason) = skip_reason(entry, now) {
+            return Ok(make_envelope(entry, ScanStatus::Skipped, Some(reason), None, None));
+        }
+    }
+
+    let about = fetch_json(&build_about_url(&subreddit)).map_err(MacosError::from)?;
+    let listing = fetch_json(&target_url).map_err(MacosError::from)?;
+    let result = RedditFeedResult {
+        subreddit: parse_subreddit_info(&about)?,
+        posts: parse_listing_posts(&listing)?,
+    };
+    let fingerprint = fingerprint_posts(&result.posts)?;
+    let status = {
+        let entry = entry_for(&mut state, &key, "reddit", &target_url);
+        record_success(entry, fingerprint, now)
+    };
+    let warning = save_state_warning(&state);
+    let entry = stored_entry(&state, &key)?;
+    Ok(make_envelope(entry, status, None, warning, Some(result)))
+}
+
+/// Read a Reddit post plus its top-level comments with scan-state tracking.
+pub fn post(url: &str) -> Result<ScanEnvelope<RedditPostResult>, MacosError> {
+    let url = normalize_post_url(url)?;
+    let key = build_scan_key("reddit", &url);
+    let now = Utc::now();
+    let mut state = load_state();
+
+    {
+        let entry = entry_for(&mut state, &key, "reddit", &url);
+        if entry.deleted {
+            return Ok(make_envelope(
+                entry,
+                ScanStatus::Deleted,
+                Some("deleted_target".to_string()),
+                None,
+                None,
+            ));
+        }
+        if let Some(reason) = skip_reason(entry, now) {
+            return Ok(make_envelope(entry, ScanStatus::Skipped, Some(reason), None, None));
+        }
+    }
+
+    let payload = match fetch_json(&url) {
+        Ok(payload) => payload,
+        Err(FetchJsonError::NotFound) => {
+            let status = {
+                let entry = entry_for(&mut state, &key, "reddit", &url);
+                record_not_found(entry, now)
+            };
+            let warning = save_state_warning(&state);
+            let entry = stored_entry(&state, &key)?;
+            let reason = match status {
+                ScanStatus::Deleted => Some("target_confirmed_deleted".to_string()),
+                ScanStatus::Warning => Some("target_missing_first_strike".to_string()),
+                _ => None,
+            };
+            return Ok(make_envelope(entry, status, reason, warning, None));
+        }
+        Err(error) => return Err(MacosError::from(error)),
+    };
+    let mut result = parse_post_result(&payload)?;
+    result.comments = filter_comments(result.comments, now);
+    let fingerprint = fingerprint_comments(&result.comments)?;
+    let status = {
+        let entry = entry_for(&mut state, &key, "reddit", &url);
+        record_success(entry, fingerprint, now)
+    };
+    let warning = save_state_warning(&state);
+    let entry = stored_entry(&state, &key)?;
+    Ok(make_envelope(entry, status, None, warning, Some(result)))
+}
+
+/// Search Reddit posts via the public JSON API with scan-state tracking.
+pub fn search(
+    query: &str,
+    subreddit: Option<&str>,
+    limit: usize,
+) -> Result<ScanEnvelope<RedditSearchResult>, MacosError> {
+    validate_limit(limit)?;
+    let query = query.trim();
+    if query.is_empty() {
+        return Err(MacosError::Other("reddit query must not be empty".to_string()));
+    }
+    let subreddit = match subreddit {
+        Some(value) => Some(normalize_subreddit(value)?),
+        None => None,
+    };
+    let target_url = build_search_url(query, subreddit.as_deref(), limit);
+    let key = build_scan_key("reddit", &target_url);
+    let now = Utc::now();
+    let mut state = load_state();
+
+    {
+        let entry = entry_for(&mut state, &key, "reddit", &target_url);
+        if entry.deleted {
+            return Ok(make_envelope(
+                entry,
+                ScanStatus::Deleted,
+                Some("deleted_target".to_string()),
+                None,
+                None,
+            ));
+        }
+        if let Some(reason) = skip_reason(entry, now) {
+            return Ok(make_envelope(entry, ScanStatus::Skipped, Some(reason), None, None));
+        }
+    }
+
+    let posts = parse_listing_posts(&fetch_json(&target_url).map_err(MacosError::from)?)?;
+    let result = RedditSearchResult {
+        query: query.to_string(),
+        subreddit,
+        limit,
+        posts,
+    };
+    let fingerprint = fingerprint_posts(&result.posts)?;
+    let status = {
+        let entry = entry_for(&mut state, &key, "reddit", &target_url);
+        record_success(entry, fingerprint, now)
+    };
+    let warning = save_state_warning(&state);
+    let entry = stored_entry(&state, &key)?;
+    Ok(make_envelope(entry, status, None, warning, Some(result)))
+}

--- a/crates/adapter-macos/src/reddit/tests.rs
+++ b/crates/adapter-macos/src/reddit/tests.rs
@@ -1,0 +1,212 @@
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+
+use super::{
+    build_feed_url, build_search_url, compute_next_reddit_request, normalize_post_url,
+    normalize_subreddit, parse_listing_posts, parse_post_result, parse_subreddit_info,
+    reddit_backoff, should_retry_status,
+};
+
+#[test]
+fn normalize_subreddit_accepts_prefixed_or_plain_names() {
+    assert_eq!(normalize_subreddit("rust").unwrap(), "rust");
+    assert_eq!(normalize_subreddit("r/rust").unwrap(), "rust");
+    assert_eq!(normalize_subreddit(" R/Rust ").unwrap(), "rust");
+}
+
+#[test]
+fn normalize_subreddit_rejects_invalid_names() {
+    assert!(normalize_subreddit("").is_err());
+    assert!(normalize_subreddit("r/").is_err());
+    assert!(normalize_subreddit("r/rust/top").is_err());
+}
+
+#[test]
+fn normalize_post_url_rewrites_supported_hosts_to_old_reddit_json() {
+    let url = normalize_post_url(
+        "https://www.reddit.com/r/rust/comments/abc123/example_title/?utm_source=test",
+    )
+    .unwrap();
+
+    assert_eq!(
+        url,
+        "https://old.reddit.com/r/rust/comments/abc123/example_title.json?limit=500"
+    );
+}
+
+#[test]
+fn normalize_post_url_ignores_query_and_fragment_without_trailing_slash() {
+    let url = normalize_post_url(
+        "https://www.reddit.com/r/rust/comments/abc123/example_title?context=3#top",
+    )
+    .unwrap();
+
+    assert_eq!(
+        url,
+        "https://old.reddit.com/r/rust/comments/abc123/example_title.json?limit=500"
+    );
+}
+
+#[test]
+fn build_search_url_handles_global_and_subreddit_search() {
+    assert_eq!(
+        build_search_url("async rust", None, 10),
+        "https://old.reddit.com/search.json?q=async%20rust&limit=10&sort=relevance"
+    );
+    assert_eq!(
+        build_search_url("async rust", Some("rust"), 25),
+        "https://old.reddit.com/r/rust/search.json?q=async%20rust&restrict_sr=on&limit=25&sort=relevance"
+    );
+    assert_eq!(build_feed_url("rust", 20), "https://old.reddit.com/r/rust.json?limit=20");
+}
+
+#[test]
+fn reddit_backoff_is_small_and_linear() {
+    assert_eq!(reddit_backoff(0), Duration::from_secs(2));
+    assert_eq!(reddit_backoff(1), Duration::from_secs(4));
+    assert_eq!(reddit_backoff(2), Duration::from_secs(6));
+}
+
+#[test]
+fn compute_next_reddit_request_reserves_minimum_delay() {
+    let now = Instant::now();
+    let (delay, next_allowed) =
+        compute_next_reddit_request(now, Some(now + Duration::from_millis(250)));
+
+    assert!(delay.is_some());
+    assert!(next_allowed > now);
+}
+
+#[test]
+fn retryable_statuses_cover_429_and_server_errors() {
+    assert!(should_retry_status(429));
+    assert!(should_retry_status(500));
+    assert!(should_retry_status(503));
+    assert!(!should_retry_status(404));
+}
+
+#[test]
+fn parse_subreddit_info_reads_about_payload() {
+    let payload = json!({
+        "kind": "t5",
+        "data": {
+            "display_name": "rust",
+            "display_name_prefixed": "r/rust",
+            "title": "The Rust Programming Language",
+            "public_description": "Fearless concurrency",
+            "subscribers": 123
+        }
+    });
+
+    let info = parse_subreddit_info(&payload).unwrap();
+
+    assert_eq!(info.name, "rust");
+    assert_eq!(info.display_name, "r/rust");
+    assert_eq!(info.title.as_deref(), Some("The Rust Programming Language"));
+    assert_eq!(info.description.as_deref(), Some("Fearless concurrency"));
+    assert_eq!(info.subscribers, Some(123));
+}
+
+#[test]
+fn parse_subreddit_info_ignores_negative_subscriber_count() {
+    let payload = json!({
+        "kind": "t5",
+        "data": {
+            "display_name": "rust",
+            "display_name_prefixed": "r/rust",
+            "subscribers": -1
+        }
+    });
+
+    let info = parse_subreddit_info(&payload).unwrap();
+
+    assert_eq!(info.subscribers, None);
+}
+
+#[test]
+fn parse_listing_posts_reads_posts_from_listing_payload() {
+    let payload = json!({
+        "kind": "Listing",
+        "data": {
+            "children": [{
+                "kind": "t3",
+                "data": {
+                    "id": "abc123",
+                    "title": "Rust 1.90 released",
+                    "author": "example_user",
+                    "subreddit": "rust",
+                    "url": "https://www.rust-lang.org/",
+                    "permalink": "/r/rust/comments/abc123/rust_190_released/",
+                    "score": 420,
+                    "num_comments": 37,
+                    "created_utc": 1760000000,
+                    "selftext": ""
+                }
+            }]
+        }
+    });
+
+    let posts = parse_listing_posts(&payload).unwrap();
+
+    assert_eq!(posts.len(), 1);
+    assert_eq!(posts[0].id, "abc123");
+    assert_eq!(
+        posts[0].permalink,
+        "https://reddit.com/r/rust/comments/abc123/rust_190_released/"
+    );
+}
+
+#[test]
+fn parse_post_result_returns_post_and_top_level_comments_only() {
+    let payload = json!([
+        {
+            "kind": "Listing",
+            "data": {
+                "children": [{
+                    "kind": "t3",
+                    "data": {
+                        "id": "abc123",
+                        "title": "Rust 1.90 released",
+                        "author": "example_user",
+                        "subreddit": "rust",
+                        "url": "https://www.rust-lang.org/",
+                        "permalink": "/r/rust/comments/abc123/rust_190_released/",
+                        "score": 420,
+                        "num_comments": 37,
+                        "created_utc": 1760000000,
+                        "selftext": "release notes"
+                    }
+                }]
+            }
+        },
+        {
+            "kind": "Listing",
+            "data": {
+                "children": [
+                    {
+                        "kind": "t1",
+                        "data": {
+                            "id": "c1",
+                            "author": "commenter1",
+                            "body": "great release",
+                            "score": 12,
+                            "created_utc": 1760000100,
+                            "permalink": "/r/rust/comments/abc123/rust_190_released/c1/"
+                        }
+                    },
+                    {
+                        "kind": "more",
+                        "data": { "count": 3 }
+                    }
+                ]
+            }
+        }
+    ]);
+
+    let result = parse_post_result(&payload).unwrap();
+
+    assert_eq!(result.post.id, "abc123");
+    assert_eq!(result.comments.len(), 1);
+    assert_eq!(result.comments[0].id, "c1");
+}

--- a/crates/adapter-macos/src/reddit/tests.rs
+++ b/crates/adapter-macos/src/reddit/tests.rs
@@ -1,12 +1,13 @@
+use chrono::{Duration as ChronoDuration, Utc};
 use std::time::{Duration, Instant};
-
 use serde_json::json;
 
 use super::{
     build_feed_url, build_search_url, compute_next_reddit_request, normalize_post_url,
     normalize_subreddit, parse_listing_posts, parse_post_result, parse_subreddit_info,
-    reddit_backoff, should_retry_status,
+    reddit_backoff, should_retry_status, RedditComment,
 };
+use super::scan::filter_comments;
 
 #[test]
 fn normalize_subreddit_accepts_prefixed_or_plain_names() {
@@ -209,4 +210,48 @@ fn parse_post_result_returns_post_and_top_level_comments_only() {
     assert_eq!(result.post.id, "abc123");
     assert_eq!(result.comments.len(), 1);
     assert_eq!(result.comments[0].id, "c1");
+}
+
+#[test]
+fn filter_comments_drops_deleted_short_and_old_comments() {
+    let now = Utc::now();
+    let comments = vec![
+        RedditComment {
+            id: "c1".to_string(),
+            author: "[deleted]".to_string(),
+            body: "this comment is long enough but deleted".to_string(),
+            score: 1,
+            created_utc: now.timestamp(),
+            permalink: "https://reddit.com/c1".to_string(),
+        },
+        RedditComment {
+            id: "c2".to_string(),
+            author: "real_user".to_string(),
+            body: "too short".to_string(),
+            score: 1,
+            created_utc: now.timestamp(),
+            permalink: "https://reddit.com/c2".to_string(),
+        },
+        RedditComment {
+            id: "c3".to_string(),
+            author: "real_user".to_string(),
+            body: "this comment is long enough but too old to keep around".to_string(),
+            score: 1,
+            created_utc: (now - ChronoDuration::days(31)).timestamp(),
+            permalink: "https://reddit.com/c3".to_string(),
+        },
+        RedditComment {
+            id: "c4".to_string(),
+            author: "real_user".to_string(),
+            body: "this comment is long enough and recent so it should survive".to_string(),
+            score: 1,
+            created_utc: now.timestamp(),
+            permalink: "https://reddit.com/c4".to_string(),
+        },
+    ];
+
+    let filtered = filter_comments(comments, now);
+
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].id, "c4");
 }

--- a/crates/adapter-macos/src/safari/script_tests.rs
+++ b/crates/adapter-macos/src/safari/script_tests.rs
@@ -7,12 +7,12 @@ use super::script::{
 
 #[test]
 fn parse_tab_line_decodes_fields() {
-    let line = "61998<<<FIELD_SEP>>>Ryugu — Google\\tGemini<<<FIELD_SEP>>>0<<<FIELD_SEP>>>Google\\tGemini<<<FIELD_SEP>>>https://gemini.google.com/app<<<FIELD_SEP>>>true";
+    let line = "61998<<<FIELD_SEP>>>Work — Google\\tGemini<<<FIELD_SEP>>>0<<<FIELD_SEP>>>Google\\tGemini<<<FIELD_SEP>>>https://gemini.google.com/app<<<FIELD_SEP>>>true";
 
     let tab = parse_tab_line(line).expect("tab");
 
     assert_eq!(tab.window_id, 61998);
-    assert_eq!(tab.window_name, "Ryugu — Google\tGemini");
+    assert_eq!(tab.window_name, "Work — Google\tGemini");
     assert_eq!(tab.profile, None);
     assert_eq!(tab.index, 0);
     assert_eq!(tab.title, "Google\tGemini");

--- a/crates/adapter-macos/src/safari/social/x.rs
+++ b/crates/adapter-macos/src/safari/social/x.rs
@@ -1,12 +1,31 @@
 use std::thread;
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
 use crate::MacosError;
+use crate::scan_state::{
+    ScanEnvelope, ScanStatus, build_scan_key, entry_for, fingerprint_json, is_bot_like_author,
+    is_too_old, is_too_short, load_state, make_envelope, record_not_found, record_success,
+    save_state_warning, skip_reason, stored_entry,
+};
 use crate::safari_guard::with_safari_session;
 
 use super::super::core::{execute_js_for_profile, focus_tab, open};
 use super::super::script::escape_js_string;
 use super::SocialFeedPost;
+
+const X_HOME_URL: &str = "https://x.com/home";
+
+#[derive(Serialize)]
+struct XPostFingerprint<'a> {
+    author: &'a str,
+    handle: Option<&'a str>,
+    time: Option<&'a str>,
+    content: &'a str,
+    url: Option<&'a str>,
+}
 
 fn x_search_url(query: &str) -> String {
     let encoded = urlencoding::encode(query);
@@ -96,37 +115,201 @@ fn navigate_tab_or_open(
     Ok(())
 }
 
-pub fn x_extract_feed(profile_filter: Option<&str>) -> Result<Vec<SocialFeedPost>, MacosError> {
+fn normalize_x_post_url(input: &str) -> Result<String, MacosError> {
+    let trimmed = input.trim();
+    let without_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+    let (host, rest) = without_scheme
+        .split_once('/')
+        .ok_or_else(|| MacosError::Other(format!("invalid x post url: {input}")))?;
+    let host = host.to_ascii_lowercase();
+    if !matches!(
+        host.as_str(),
+        "x.com" | "www.x.com" | "twitter.com" | "www.twitter.com"
+    ) {
+        return Err(MacosError::Other(format!("invalid x post url: {input}")));
+    }
+    let path_only = rest
+        .split('?')
+        .next()
+        .unwrap_or(rest)
+        .split('#')
+        .next()
+        .unwrap_or(rest)
+        .trim_matches('/');
+    if !path_only.contains("/status/") {
+        return Err(MacosError::Other(format!("invalid x post url: {input}")));
+    }
+    Ok(format!("https://x.com/{path_only}"))
+}
+
+fn parse_x_time(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn filter_x_posts(posts: Vec<SocialFeedPost>, now: DateTime<Utc>) -> Vec<SocialFeedPost> {
+    posts.into_iter()
+        .filter(|post| !is_bot_like_author(&post.author))
+        .filter(|post| !is_too_short(&post.content))
+        .filter(|post| {
+            post.time
+                .as_deref()
+                .and_then(parse_x_time)
+                .map(|created_at| !is_too_old(created_at, now))
+                .unwrap_or(true)
+        })
+        .collect()
+}
+
+fn fingerprint_x_posts(posts: &[SocialFeedPost]) -> Result<String, MacosError> {
+    let payload: Vec<_> = posts
+        .iter()
+        .map(|post| XPostFingerprint {
+            author: &post.author,
+            handle: post.handle.as_deref(),
+            time: post.time.as_deref(),
+            content: &post.content,
+            url: post.url.as_deref(),
+        })
+        .collect();
+    fingerprint_json(&payload)
+}
+
+pub fn x_extract_feed(
+    profile_filter: Option<&str>,
+) -> Result<ScanEnvelope<Vec<SocialFeedPost>>, MacosError> {
     with_safari_session(|| {
+        let now = Utc::now();
+        let target_url = X_HOME_URL.to_string();
+        let key = build_scan_key("x", &target_url);
+        let mut state = load_state();
+        {
+            let entry = entry_for(&mut state, &key, "x", &target_url);
+            if entry.deleted {
+                return Ok(make_envelope(
+                    entry,
+                    ScanStatus::Deleted,
+                    Some("deleted_target".to_string()),
+                    None,
+                    None,
+                ));
+            }
+            if let Some(reason) = skip_reason(entry, now) {
+                return Ok(make_envelope(entry, ScanStatus::Skipped, Some(reason), None, None));
+            }
+        }
         let _ = focus_tab("x.com", profile_filter);
-        poll_x_posts(5, profile_filter)
+        let posts = filter_x_posts(poll_x_posts(5, profile_filter)?, now);
+        let fingerprint = fingerprint_x_posts(&posts)?;
+        let status = {
+            let entry = entry_for(&mut state, &key, "x", &target_url);
+            record_success(entry, fingerprint, now)
+        };
+        let warning = save_state_warning(&state);
+        let entry = stored_entry(&state, &key)?;
+        Ok(make_envelope(entry, status, None, warning, Some(posts)))
     })
 }
 
 pub fn x_search(
     query: &str,
     profile_filter: Option<&str>,
-) -> Result<Vec<SocialFeedPost>, MacosError> {
+) -> Result<ScanEnvelope<Vec<SocialFeedPost>>, MacosError> {
     with_safari_session(|| {
-        let url = x_search_url(query);
-        navigate_tab_or_open(&url, "x.com", profile_filter, "safari_x_search_navigate")?;
-        poll_x_posts(10, profile_filter)
+        let now = Utc::now();
+        let target_url = x_search_url(query);
+        let key = build_scan_key("x", &target_url);
+        let mut state = load_state();
+        {
+            let entry = entry_for(&mut state, &key, "x", &target_url);
+            if entry.deleted {
+                return Ok(make_envelope(
+                    entry,
+                    ScanStatus::Deleted,
+                    Some("deleted_target".to_string()),
+                    None,
+                    None,
+                ));
+            }
+            if let Some(reason) = skip_reason(entry, now) {
+                return Ok(make_envelope(entry, ScanStatus::Skipped, Some(reason), None, None));
+            }
+        }
+        navigate_tab_or_open(&target_url, "x.com", profile_filter, "safari_x_search_navigate")?;
+        let posts = filter_x_posts(poll_x_posts(10, profile_filter)?, now);
+        let fingerprint = fingerprint_x_posts(&posts)?;
+        let status = {
+            let entry = entry_for(&mut state, &key, "x", &target_url);
+            record_success(entry, fingerprint, now)
+        };
+        let warning = save_state_warning(&state);
+        let entry = stored_entry(&state, &key)?;
+        Ok(make_envelope(entry, status, None, warning, Some(posts)))
     })
 }
 
 pub fn x_read_post(
     url: &str,
     profile_filter: Option<&str>,
-) -> Result<Vec<SocialFeedPost>, MacosError> {
+) -> Result<ScanEnvelope<Vec<SocialFeedPost>>, MacosError> {
     with_safari_session(|| {
-        navigate_tab_or_open(url, "x.com", profile_filter, "safari_x_read_navigate")?;
-        poll_x_posts(10, profile_filter)
+        let now = Utc::now();
+        let target_url = normalize_x_post_url(url)?;
+        let key = build_scan_key("x", &target_url);
+        let mut state = load_state();
+        {
+            let entry = entry_for(&mut state, &key, "x", &target_url);
+            if entry.deleted {
+                return Ok(make_envelope(
+                    entry,
+                    ScanStatus::Deleted,
+                    Some("deleted_target".to_string()),
+                    None,
+                    None,
+                ));
+            }
+            if let Some(reason) = skip_reason(entry, now) {
+                return Ok(make_envelope(entry, ScanStatus::Skipped, Some(reason), None, None));
+            }
+        }
+        navigate_tab_or_open(&target_url, "x.com", profile_filter, "safari_x_read_navigate")?;
+        let raw_posts = poll_x_posts(10, profile_filter)?;
+        if raw_posts.is_empty() {
+            let status = {
+                let entry = entry_for(&mut state, &key, "x", &target_url);
+                record_not_found(entry, now)
+            };
+            let warning = save_state_warning(&state);
+            let entry = stored_entry(&state, &key)?;
+            let reason = match status {
+                ScanStatus::Deleted => Some("target_confirmed_deleted".to_string()),
+                ScanStatus::Warning => Some("target_missing_first_strike".to_string()),
+                _ => None,
+            };
+            return Ok(make_envelope(entry, status, reason, warning, None));
+        }
+        let posts = filter_x_posts(raw_posts, now);
+        let fingerprint = fingerprint_x_posts(&posts)?;
+        let status = {
+            let entry = entry_for(&mut state, &key, "x", &target_url);
+            record_success(entry, fingerprint, now)
+        };
+        let warning = save_state_warning(&state);
+        let entry = stored_entry(&state, &key)?;
+        Ok(make_envelope(entry, status, None, warning, Some(posts)))
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{x_extract_feed_js, x_search_url};
+    use chrono::{Duration, Utc};
+
+    use super::{filter_x_posts, normalize_x_post_url, x_extract_feed_js, x_search_url};
+    use super::SocialFeedPost;
 
     #[test]
     fn x_search_url_encodes_query() {
@@ -145,5 +328,57 @@ mod tests {
         assert!(script.contains("a[href*='/status/']"));
         assert!(script.contains("url: postUrl || null"));
         assert!(script.contains("https://x.com"));
+    }
+
+    #[test]
+    fn normalize_x_post_url_strips_query_and_legacy_host() {
+        let url = normalize_x_post_url("https://twitter.com/user/status/123?context=3#top")
+            .expect("normalized url");
+
+        assert_eq!(url, "https://x.com/user/status/123");
+    }
+
+    #[test]
+    fn filter_x_posts_drops_deleted_short_and_old_items() {
+        let now = Utc::now();
+        let posts = vec![
+            SocialFeedPost {
+                author: "AutoModerator".to_string(),
+                handle: None,
+                time: Some(now.to_rfc3339()),
+                content: "this post is long enough to pass length checks".to_string(),
+                url: Some("https://x.com/1".to_string()),
+                metrics: Vec::new(),
+            },
+            SocialFeedPost {
+                author: "real_user".to_string(),
+                handle: None,
+                time: Some((now - Duration::days(31)).to_rfc3339()),
+                content: "this post is also long enough to pass the filter".to_string(),
+                url: Some("https://x.com/2".to_string()),
+                metrics: Vec::new(),
+            },
+            SocialFeedPost {
+                author: "real_user".to_string(),
+                handle: None,
+                time: Some(now.to_rfc3339()),
+                content: "too short".to_string(),
+                url: Some("https://x.com/3".to_string()),
+                metrics: Vec::new(),
+            },
+            SocialFeedPost {
+                author: "real_user".to_string(),
+                handle: None,
+                time: Some(now.to_rfc3339()),
+                content: "this post is long enough and recent so it should survive".to_string(),
+                url: Some("https://x.com/4".to_string()),
+                metrics: Vec::new(),
+            },
+        ];
+
+        let filtered = filter_x_posts(posts, now);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].url.as_deref(), Some("https://x.com/4"));
     }
 }

--- a/crates/adapter-macos/src/scan_state.rs
+++ b/crates/adapter-macos/src/scan_state.rs
@@ -1,0 +1,337 @@
+use std::collections::hash_map::Entry;
+
+use chrono::{DateTime, Duration, Utc};
+use cueward_core::{ScanTargetState, State};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::MacosError;
+
+pub const NORMAL_MIN_SCAN_INTERVAL: Duration = Duration::minutes(30);
+pub const BACKOFF_SCAN_INTERVAL: Duration = Duration::hours(6);
+pub const STALE_SKIP_AFTER: Duration = Duration::days(3);
+pub const STALE_RECHECK_INTERVAL: Duration = Duration::hours(24);
+pub const CONTENT_MAX_AGE_DAYS: i64 = 30;
+pub const MIN_CONTENT_WORDS: usize = 5;
+pub const MIN_CONTENT_CHARS: usize = 20;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ScanStatus {
+    Fresh,
+    Unchanged,
+    Skipped,
+    Warning,
+    Deleted,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ScanEnvelope<T> {
+    pub provider: String,
+    pub target_url: String,
+    pub status: ScanStatus,
+    pub no_change_count: u32,
+    pub consecutive_not_found_count: u32,
+    pub deleted: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_checked_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_changed_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<T>,
+}
+
+pub fn build_scan_key(provider: &str, target_url: &str) -> String {
+    format!("{provider}:{target_url}")
+}
+
+pub fn load_state() -> State {
+    State::load()
+}
+
+pub fn stored_entry<'a>(
+    state: &'a State,
+    key: &str,
+) -> Result<&'a ScanTargetState, MacosError> {
+    state
+        .scan_target(key)
+        .ok_or_else(|| MacosError::Other("scan state entry not found".to_string()))
+}
+
+pub fn save_state_warning(state: &State) -> Option<String> {
+    state
+        .save()
+        .err()
+        .map(|error| format!("failed to save scan state: {error}"))
+}
+
+pub fn entry_for<'a>(
+    state: &'a mut State,
+    key: &str,
+    provider: &str,
+    target_url: &str,
+) -> &'a mut ScanTargetState {
+    match state.scan_targets.entry(key.to_string()) {
+        Entry::Occupied(entry) => entry.into_mut(),
+        Entry::Vacant(entry) => entry.insert(ScanTargetState {
+            provider: provider.to_string(),
+            target_url: target_url.to_string(),
+            ..ScanTargetState::default()
+        }),
+    }
+}
+
+pub fn skip_reason(entry: &ScanTargetState, now: DateTime<Utc>) -> Option<String> {
+    if entry.deleted {
+        return Some("deleted_target".to_string());
+    }
+    let last_checked_at = entry.last_checked_at?;
+    if let Some(last_changed_at) = entry.last_changed_at {
+        if now - last_changed_at >= STALE_SKIP_AFTER
+            && now - last_checked_at < STALE_RECHECK_INTERVAL
+        {
+            return Some("stale_target_backoff".to_string());
+        }
+    }
+    let min_interval = if entry.no_change_count >= 2 {
+        BACKOFF_SCAN_INTERVAL
+    } else {
+        NORMAL_MIN_SCAN_INTERVAL
+    };
+    if now - last_checked_at < min_interval {
+        return Some("backoff_interval_not_elapsed".to_string());
+    }
+    None
+}
+
+pub fn record_success(
+    entry: &mut ScanTargetState,
+    fingerprint: String,
+    now: DateTime<Utc>,
+) -> ScanStatus {
+    entry.last_checked_at = Some(now);
+    let status = if entry.last_fingerprint.as_deref() == Some(fingerprint.as_str()) {
+        entry.no_change_count += 1;
+        ScanStatus::Unchanged
+    } else {
+        entry.last_changed_at = Some(now);
+        entry.last_fingerprint = Some(fingerprint);
+        entry.no_change_count = 0;
+        ScanStatus::Fresh
+    };
+    entry.consecutive_not_found_count = 0;
+    entry.deleted = false;
+    status
+}
+
+pub fn record_not_found(entry: &mut ScanTargetState, now: DateTime<Utc>) -> ScanStatus {
+    entry.last_checked_at = Some(now);
+    entry.consecutive_not_found_count += 1;
+    if entry.consecutive_not_found_count >= 2 {
+        entry.deleted = true;
+        ScanStatus::Deleted
+    } else {
+        ScanStatus::Warning
+    }
+}
+
+pub fn make_envelope<T>(
+    entry: &ScanTargetState,
+    status: ScanStatus,
+    reason: Option<String>,
+    warning: Option<String>,
+    data: Option<T>,
+) -> ScanEnvelope<T> {
+    ScanEnvelope {
+        provider: entry.provider.clone(),
+        target_url: entry.target_url.clone(),
+        status,
+        no_change_count: entry.no_change_count,
+        consecutive_not_found_count: entry.consecutive_not_found_count,
+        deleted: entry.deleted,
+        last_checked_at: entry.last_checked_at,
+        last_changed_at: entry.last_changed_at,
+        reason,
+        warning,
+        data,
+    }
+}
+
+pub fn fingerprint_json<T: Serialize>(value: &T) -> Result<String, MacosError> {
+    let json = serde_json::to_vec(value)
+        .map_err(|error| MacosError::Other(format!("failed to serialize fingerprint payload: {error}")))?;
+    let mut hasher = Sha256::new();
+    hasher.update(json);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+pub fn is_bot_like_author(author: &str) -> bool {
+    let normalized = author.trim().to_ascii_lowercase();
+    matches!(
+        normalized.as_str(),
+        "automoderator" | "[deleted]" | "[removed]"
+    )
+}
+
+pub fn is_too_short(text: &str) -> bool {
+    let trimmed = text.trim();
+    trimmed.chars().count() < MIN_CONTENT_CHARS
+        && trimmed.split_whitespace().count() < MIN_CONTENT_WORDS
+}
+
+pub fn is_too_old(created_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
+    now - created_at > Duration::days(CONTENT_MAX_AGE_DAYS)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Duration, TimeZone, Utc};
+    use cueward_core::State;
+    use serde::Serialize;
+
+    use super::{
+        BACKOFF_SCAN_INTERVAL, NORMAL_MIN_SCAN_INTERVAL, STALE_RECHECK_INTERVAL, ScanStatus,
+        STALE_SKIP_AFTER,
+        build_scan_key, entry_for, fingerprint_json, is_bot_like_author, is_too_old, is_too_short,
+        make_envelope, record_not_found, record_success, skip_reason,
+    };
+
+    #[derive(Serialize)]
+    struct FingerprintPayload<'a> {
+        id: &'a str,
+        content: &'a str,
+    }
+
+    #[test]
+    fn build_scan_key_combines_provider_and_target() {
+        assert_eq!(
+            build_scan_key("reddit", "https://old.reddit.com/r/rust.json?limit=20"),
+            "reddit:https://old.reddit.com/r/rust.json?limit=20"
+        );
+    }
+
+    #[test]
+    fn skip_reason_honors_backoff_and_stale_targets() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 13, 12, 0, 0).unwrap();
+        let mut state = State::default();
+        let entry = entry_for(&mut state, "x:https://x.com/home", "x", "https://x.com/home");
+        entry.last_checked_at = Some(now - NORMAL_MIN_SCAN_INTERVAL + Duration::minutes(5));
+        entry.no_change_count = 0;
+        assert_eq!(
+            skip_reason(entry, now).as_deref(),
+            Some("backoff_interval_not_elapsed")
+        );
+
+        entry.last_checked_at = Some(now - BACKOFF_SCAN_INTERVAL + Duration::minutes(5));
+        entry.no_change_count = 2;
+        assert_eq!(
+            skip_reason(entry, now).as_deref(),
+            Some("backoff_interval_not_elapsed")
+        );
+
+        entry.last_checked_at = Some(now - Duration::hours(12));
+        entry.last_changed_at = Some(now - STALE_SKIP_AFTER - Duration::hours(1));
+        assert_eq!(
+            skip_reason(entry, now).as_deref(),
+            Some("stale_target_backoff")
+        );
+
+        entry.last_checked_at = Some(now - STALE_RECHECK_INTERVAL - Duration::hours(1));
+        assert_eq!(skip_reason(entry, now), None);
+    }
+
+    #[test]
+    fn record_not_found_requires_two_strikes() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 13, 12, 0, 0).unwrap();
+        let mut state = State::default();
+        let entry = entry_for(
+            &mut state,
+            "reddit:https://old.reddit.com/r/rust/comments/abc.json?limit=500",
+            "reddit",
+            "https://old.reddit.com/r/rust/comments/abc.json?limit=500",
+        );
+
+        assert_eq!(record_not_found(entry, now), ScanStatus::Warning);
+        assert_eq!(entry.consecutive_not_found_count, 1);
+        assert!(!entry.deleted);
+
+        assert_eq!(record_not_found(entry, now), ScanStatus::Deleted);
+        assert_eq!(entry.consecutive_not_found_count, 2);
+        assert!(entry.deleted);
+    }
+
+    #[test]
+    fn fingerprint_json_is_stable_for_same_payload() {
+        let left = fingerprint_json(&FingerprintPayload {
+            id: "1",
+            content: "same",
+        })
+        .unwrap();
+        let right = fingerprint_json(&FingerprintPayload {
+            id: "1",
+            content: "same",
+        })
+        .unwrap();
+        let changed = fingerprint_json(&FingerprintPayload {
+            id: "1",
+            content: "different",
+        })
+        .unwrap();
+
+        assert_eq!(left, right);
+        assert_ne!(left, changed);
+    }
+
+    #[test]
+    fn record_success_tracks_fresh_and_unchanged() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 13, 12, 0, 0).unwrap();
+        let mut state = State::default();
+        let entry = entry_for(&mut state, "x:https://x.com/home", "x", "https://x.com/home");
+
+        assert_eq!(record_success(entry, "abc".to_string(), now), ScanStatus::Fresh);
+        assert_eq!(entry.no_change_count, 0);
+        assert_eq!(record_success(entry, "abc".to_string(), now), ScanStatus::Unchanged);
+        assert_eq!(entry.no_change_count, 1);
+    }
+
+    #[test]
+    fn filters_detect_deleted_bot_short_and_old_content() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 13, 12, 0, 0).unwrap();
+        let old = now - Duration::days(31);
+
+        assert!(is_bot_like_author("AutoModerator"));
+        assert!(is_bot_like_author("[deleted]"));
+        assert!(is_too_short("too short"));
+        assert!(!is_too_short("這是一段足夠長但沒有空白的中文內容用來驗證長度判斷"));
+        assert!(is_too_old(old, now));
+        assert!(!is_too_old(now, now));
+    }
+
+    #[test]
+    fn make_envelope_copies_entry_metadata() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 13, 12, 0, 0).unwrap();
+        let mut state = State::default();
+        let entry = entry_for(&mut state, "x:https://x.com/home", "x", "https://x.com/home");
+        entry.last_checked_at = Some(now);
+        entry.last_changed_at = Some(now);
+        entry.no_change_count = 2;
+
+        let envelope = make_envelope(
+            entry,
+            ScanStatus::Skipped,
+            Some("backoff_interval_not_elapsed".to_string()),
+            None,
+            Some(vec!["placeholder"]),
+        );
+
+        assert_eq!(envelope.provider, "x");
+        assert_eq!(envelope.no_change_count, 2);
+        assert_eq!(envelope.status, ScanStatus::Skipped);
+        assert_eq!(envelope.reason.as_deref(), Some("backoff_interval_not_elapsed"));
+        assert_eq!(envelope.data, Some(vec!["placeholder"]));
+    }
+}

--- a/crates/cli/src/commands/helpers.rs
+++ b/crates/cli/src/commands/helpers.rs
@@ -177,15 +177,15 @@ mod tests {
 
     #[test]
     fn bookmarks_target_folder_prepends_profile_to_folder() {
-        let folder = bookmarks_target_folder(Some("Ryugu"), Some("Work/AI Tools"));
+        let folder = bookmarks_target_folder(Some("Work"), Some("Projects/AI Tools"));
 
-        assert_eq!(folder, Some("Ryugu/Work/AI Tools".to_string()));
+        assert_eq!(folder, Some("Work/Projects/AI Tools".to_string()));
     }
 
     #[test]
     fn bookmarks_target_folder_uses_profile_as_root_when_folder_missing() {
-        let folder = bookmarks_target_folder(Some("Ryugu"), None);
+        let folder = bookmarks_target_folder(Some("Work"), None);
 
-        assert_eq!(folder, Some("Ryugu".to_string()));
+        assert_eq!(folder, Some("Work".to_string()));
     }
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod helpers;
 pub(crate) mod notes;
 pub(crate) mod ocr;
 pub(crate) mod quick_notes;
+pub(crate) mod reddit;
 pub(crate) mod reminders;
 pub(crate) mod safari;
 pub(crate) mod safari_ai;
@@ -15,6 +16,8 @@ pub(crate) mod screenshot;
 pub(crate) mod search;
 pub(crate) mod send;
 pub(crate) mod triage;
+#[cfg(test)]
+mod reddit_tests;
 #[cfg(test)]
 mod safari_ai_tests;
 #[cfg(test)]
@@ -26,6 +29,7 @@ pub(crate) use calendar::CalendarAction;
 pub(crate) use clipboard::ClipboardAction;
 pub(crate) use notes::NotesAction;
 pub(crate) use quick_notes::QuickNotesAction;
+pub(crate) use reddit::RedditAction;
 pub(crate) use reminders::RemindersAction;
 pub(crate) use safari::SafariAction;
 
@@ -92,6 +96,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         action: RemindersAction,
     },
+    /// Read Reddit via public JSON endpoints
+    Reddit {
+        #[command(subcommand)]
+        action: RedditAction,
+    },
     /// Extract text from images or PDFs via Vision OCR
     Ocr {
         /// Path to image or PDF file
@@ -157,6 +166,7 @@ pub(crate) fn dispatch(command: Command) {
         } => send::dispatch(title, body, folder, notify),
         Command::Plan { title, notes, list } => reminders::dispatch_plan(title, notes, list),
         Command::Reminders { action } => reminders::dispatch(action),
+        Command::Reddit { action } => reddit::dispatch(action),
         Command::Ocr { path } => ocr::dispatch(path),
         Command::Safari { action } => safari::dispatch(action),
         Command::Notes { action } => notes::dispatch(action),

--- a/crates/cli/src/commands/reddit.rs
+++ b/crates/cli/src/commands/reddit.rs
@@ -48,7 +48,12 @@ pub(crate) fn dispatch(action: RedditAction) {
             match cueward_adapter_macos::reddit::feed(&subreddit, limit) {
                 Ok(result) => {
                     print_serialized_or_exit("reddit/feed", serde_json::to_string_pretty(&result));
-                    eprintln!("{} post(s)", result.posts.len());
+                    let count = result
+                        .data
+                        .as_ref()
+                        .map(|data| data.posts.len())
+                        .unwrap_or(0);
+                    eprintln!("{count} post(s)");
                 }
                 Err(error) => {
                     eprintln!("error: {error}");
@@ -59,7 +64,12 @@ pub(crate) fn dispatch(action: RedditAction) {
         RedditAction::Post { url } => match cueward_adapter_macos::reddit::post(&url) {
             Ok(result) => {
                 print_serialized_or_exit("reddit/post", serde_json::to_string_pretty(&result));
-                eprintln!("{} top-level comment(s)", result.comments.len());
+                let count = result
+                    .data
+                    .as_ref()
+                    .map(|data| data.comments.len())
+                    .unwrap_or(0);
+                eprintln!("{count} top-level comment(s)");
             }
             Err(error) => {
                 eprintln!("error: {error}");
@@ -73,7 +83,12 @@ pub(crate) fn dispatch(action: RedditAction) {
         } => match cueward_adapter_macos::reddit::search(&query, subreddit.as_deref(), limit) {
             Ok(result) => {
                 print_serialized_or_exit("reddit/search", serde_json::to_string_pretty(&result));
-                eprintln!("{} post(s)", result.posts.len());
+                let count = result
+                    .data
+                    .as_ref()
+                    .map(|data| data.posts.len())
+                    .unwrap_or(0);
+                eprintln!("{count} post(s)");
             }
             Err(error) => {
                 eprintln!("error: {error}");

--- a/crates/cli/src/commands/reddit.rs
+++ b/crates/cli/src/commands/reddit.rs
@@ -1,0 +1,84 @@
+use std::process;
+
+use clap::Subcommand;
+
+use super::helpers::print_external;
+
+#[derive(Subcommand)]
+pub(crate) enum RedditAction {
+    /// Read a subreddit feed
+    Feed {
+        /// Subreddit name, e.g. rust or r/rust
+        subreddit: String,
+        /// Max posts to return
+        #[arg(long, default_value = "20")]
+        limit: usize,
+    },
+    /// Read a Reddit post and its top-level comments
+    Post {
+        /// Reddit post URL
+        url: String,
+    },
+    /// Search Reddit posts
+    Search {
+        /// Search query
+        query: String,
+        /// Restrict search to a subreddit, e.g. rust or r/rust
+        #[arg(long)]
+        subreddit: Option<String>,
+        /// Max posts to return
+        #[arg(long, default_value = "10")]
+        limit: usize,
+    },
+}
+
+fn print_serialized_or_exit(source: &str, serialized: Result<String, serde_json::Error>) {
+    match serialized {
+        Ok(json) => print_external(source, &json),
+        Err(error) => {
+            eprintln!("error: failed to serialize result: {error}");
+            process::exit(1);
+        }
+    }
+}
+
+pub(crate) fn dispatch(action: RedditAction) {
+    match action {
+        RedditAction::Feed { subreddit, limit } => {
+            match cueward_adapter_macos::reddit::feed(&subreddit, limit) {
+                Ok(result) => {
+                    print_serialized_or_exit("reddit/feed", serde_json::to_string_pretty(&result));
+                    eprintln!("{} post(s)", result.posts.len());
+                }
+                Err(error) => {
+                    eprintln!("error: {error}");
+                    process::exit(1);
+                }
+            }
+        }
+        RedditAction::Post { url } => match cueward_adapter_macos::reddit::post(&url) {
+            Ok(result) => {
+                print_serialized_or_exit("reddit/post", serde_json::to_string_pretty(&result));
+                eprintln!("{} top-level comment(s)", result.comments.len());
+            }
+            Err(error) => {
+                eprintln!("error: {error}");
+                process::exit(1);
+            }
+        },
+        RedditAction::Search {
+            query,
+            subreddit,
+            limit,
+        } => match cueward_adapter_macos::reddit::search(&query, subreddit.as_deref(), limit) {
+            Ok(result) => {
+                print_serialized_or_exit("reddit/search", serde_json::to_string_pretty(&result));
+                eprintln!("{} post(s)", result.posts.len());
+            }
+            Err(error) => {
+                eprintln!("error: {error}");
+                process::exit(1);
+            }
+        },
+    }
+}

--- a/crates/cli/src/commands/reddit_tests.rs
+++ b/crates/cli/src/commands/reddit_tests.rs
@@ -1,0 +1,108 @@
+use clap::Parser;
+
+use super::reddit::RedditAction;
+use super::{Cli, Command};
+
+#[test]
+fn cli_parses_reddit_feed() {
+    let cli =
+        Cli::try_parse_from(["cueward", "reddit", "feed", "rust"]).expect("parse reddit feed");
+
+    match cli.command {
+        Command::Reddit {
+            action: RedditAction::Feed { subreddit, limit },
+        } => {
+            assert_eq!(subreddit, "rust");
+            assert_eq!(limit, 20);
+        }
+        _ => panic!("unexpected command"),
+    }
+}
+
+#[test]
+fn cli_parses_reddit_feed_with_prefixed_subreddit_and_limit() {
+    let cli = Cli::try_parse_from(["cueward", "reddit", "feed", "r/rust", "--limit", "50"])
+        .expect("parse reddit feed with limit");
+
+    match cli.command {
+        Command::Reddit {
+            action: RedditAction::Feed { subreddit, limit },
+        } => {
+            assert_eq!(subreddit, "r/rust");
+            assert_eq!(limit, 50);
+        }
+        _ => panic!("unexpected command"),
+    }
+}
+
+#[test]
+fn cli_parses_reddit_post() {
+    let cli = Cli::try_parse_from([
+        "cueward",
+        "reddit",
+        "post",
+        "https://www.reddit.com/r/rust/comments/abc123/example_title/",
+    ])
+    .expect("parse reddit post");
+
+    match cli.command {
+        Command::Reddit {
+            action: RedditAction::Post { url },
+        } => assert_eq!(
+            url,
+            "https://www.reddit.com/r/rust/comments/abc123/example_title/"
+        ),
+        _ => panic!("unexpected command"),
+    }
+}
+
+#[test]
+fn cli_parses_reddit_search() {
+    let cli = Cli::try_parse_from(["cueward", "reddit", "search", "async rust"])
+        .expect("parse reddit search");
+
+    match cli.command {
+        Command::Reddit {
+            action: RedditAction::Search {
+                query,
+                subreddit,
+                limit,
+            },
+        } => {
+            assert_eq!(query, "async rust");
+            assert_eq!(subreddit, None);
+            assert_eq!(limit, 10);
+        }
+        _ => panic!("unexpected command"),
+    }
+}
+
+#[test]
+fn cli_parses_reddit_search_with_subreddit_and_limit() {
+    let cli = Cli::try_parse_from([
+        "cueward",
+        "reddit",
+        "search",
+        "async rust",
+        "--subreddit",
+        "r/rust",
+        "--limit",
+        "25",
+    ])
+    .expect("parse reddit search with subreddit");
+
+    match cli.command {
+        Command::Reddit {
+            action: RedditAction::Search {
+                query,
+                subreddit,
+                limit,
+            },
+        } => {
+            assert_eq!(query, "async rust");
+            assert_eq!(subreddit.as_deref(), Some("r/rust"));
+            assert_eq!(limit, 25);
+        }
+        _ => panic!("unexpected command"),
+    }
+}

--- a/crates/cli/src/commands/safari_ai/x.rs
+++ b/crates/cli/src/commands/safari_ai/x.rs
@@ -22,7 +22,8 @@ pub(crate) fn dispatch(action: SafariAiAction, profile: Option<&str>) {
             match cueward_adapter_macos::safari::x_search(&prompt, profile) {
                 Ok(posts) => {
                     print_external("safari/x/search", &serde_json::to_string_pretty(&posts).unwrap());
-                    eprintln!("{} post(s)", posts.len());
+                    let count = posts.data.as_ref().map(|items| items.len()).unwrap_or(0);
+                    eprintln!("{count} post(s)");
                 }
                 Err(e) => {
                     eprintln!("error: {e}");
@@ -33,7 +34,8 @@ pub(crate) fn dispatch(action: SafariAiAction, profile: Option<&str>) {
         SafariAiAction::List => match cueward_adapter_macos::safari::x_extract_feed(profile) {
             Ok(posts) => {
                 print_external("safari/x/feed", &serde_json::to_string_pretty(&posts).unwrap());
-                eprintln!("{} post(s)", posts.len());
+                let count = posts.data.as_ref().map(|items| items.len()).unwrap_or(0);
+                eprintln!("{count} post(s)");
             }
             Err(e) => {
                 eprintln!("error: {e}");
@@ -43,7 +45,8 @@ pub(crate) fn dispatch(action: SafariAiAction, profile: Option<&str>) {
         SafariAiAction::Read { url } => match cueward_adapter_macos::safari::x_read_post(&url, profile) {
             Ok(posts) => {
                 print_external("safari/x/read", &serde_json::to_string_pretty(&posts).unwrap());
-                eprintln!("{} post(s)", posts.len());
+                let count = posts.data.as_ref().map(|items| items.len()).unwrap_or(0);
+                eprintln!("{count} post(s)");
             }
             Err(e) => {
                 eprintln!("error: {e}");

--- a/crates/cli/src/commands/safari_ai_tests.rs
+++ b/crates/cli/src/commands/safari_ai_tests.rs
@@ -230,7 +230,7 @@ fn cli_parses_gemini_with_profile() {
         "--provider",
         "gemini",
         "--profile",
-        "Ryugu",
+        "Work",
         "prompt",
         "--prompt",
         "hello",
@@ -246,7 +246,7 @@ fn cli_parses_gemini_with_profile() {
                     ..
                 },
         } => {
-            assert_eq!(profile.as_deref(), Some("Ryugu"));
+            assert_eq!(profile.as_deref(), Some("Work"));
             assert_eq!(prompt, "hello");
         }
         _ => panic!("unexpected command"),

--- a/crates/cli/src/commands/safari_bookmarks_tests.rs
+++ b/crates/cli/src/commands/safari_bookmarks_tests.rs
@@ -38,7 +38,7 @@ fn cli_parses_safari_bookmarks_list_with_profile() {
         "bookmarks",
         "list",
         "--profile",
-        "Ryugu",
+        "Work",
     ])
     .expect("parse safari bookmarks list with profile");
 
@@ -49,7 +49,7 @@ fn cli_parses_safari_bookmarks_list_with_profile() {
                     action: SafariBookmarksAction::List { profile, folder },
                 },
         } => {
-            assert_eq!(profile.as_deref(), Some("Ryugu"));
+            assert_eq!(profile.as_deref(), Some("Work"));
             assert_eq!(folder, None);
         }
         _ => panic!("unexpected command"),
@@ -139,7 +139,7 @@ fn cli_parses_safari_bookmarks_add_with_profile_and_folder() {
         "--url",
         "https://claude.ai",
         "--profile",
-        "Ryugu",
+        "Work",
         "--folder",
         "Work/AI Tools",
     ])
@@ -160,7 +160,7 @@ fn cli_parses_safari_bookmarks_add_with_profile_and_folder() {
         } => {
             assert_eq!(title, "Claude");
             assert_eq!(url, "https://claude.ai");
-            assert_eq!(profile.as_deref(), Some("Ryugu"));
+            assert_eq!(profile.as_deref(), Some("Work"));
             assert_eq!(folder.as_deref(), Some("Work/AI Tools"));
         }
         _ => panic!("unexpected command"),

--- a/crates/cli/src/commands/safari_tests.rs
+++ b/crates/cli/src/commands/safari_tests.rs
@@ -5,7 +5,7 @@ use super::safari::SafariAction;
 
 #[test]
 fn cli_parses_safari_exec_with_profile() {
-    let cli = Cli::try_parse_from(["cueward", "safari", "exec", "--profile", "Ryugu", "1+1"])
+    let cli = Cli::try_parse_from(["cueward", "safari", "exec", "--profile", "Work", "1+1"])
         .expect("parse safari exec with profile");
 
     match cli.command {
@@ -16,7 +16,7 @@ fn cli_parses_safari_exec_with_profile() {
                 },
         } => {
             assert_eq!(js_code, "1+1");
-            assert_eq!(profile.as_deref(), Some("Ryugu"));
+            assert_eq!(profile.as_deref(), Some("Work"));
         }
         _ => panic!("unexpected command"),
     }
@@ -24,13 +24,13 @@ fn cli_parses_safari_exec_with_profile() {
 
 #[test]
 fn cli_parses_safari_active_with_profile() {
-    let cli = Cli::try_parse_from(["cueward", "safari", "active", "--profile", "Ryugu"])
+    let cli = Cli::try_parse_from(["cueward", "safari", "active", "--profile", "Work"])
         .expect("parse safari active with profile");
 
     match cli.command {
         Command::Safari {
             action: SafariAction::Active { profile },
-        } => assert_eq!(profile.as_deref(), Some("Ryugu")),
+        } => assert_eq!(profile.as_deref(), Some("Work")),
         _ => panic!("unexpected command"),
     }
 }
@@ -44,7 +44,7 @@ fn cli_parses_scroll_and_read() {
         "--tab",
         "x.com",
         "--profile",
-        "Ryugu",
+        "Work",
         "--times",
         "3",
     ])
@@ -62,7 +62,7 @@ fn cli_parses_scroll_and_read() {
                 },
         } => {
             assert_eq!(tab.as_deref(), Some("x.com"));
-            assert_eq!(profile.as_deref(), Some("Ryugu"));
+            assert_eq!(profile.as_deref(), Some("Work"));
             assert_eq!(times, 3);
             assert_eq!(amount, None);
             assert_eq!(selector, None);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,5 +8,5 @@ pub mod tagger;
 pub use adapter::PlatformAdapter;
 pub use cue::{AttachmentSegment, Cue, CueSource};
 pub use index::CueIndex;
-pub use state::State;
+pub use state::{ScanTargetState, State};
 pub use tagger::Tagger;

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -5,10 +5,28 @@ use std::path::PathBuf;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScanTargetState {
+    pub provider: String,
+    pub target_url: String,
+    pub last_checked_at: Option<DateTime<Utc>>,
+    pub last_changed_at: Option<DateTime<Utc>>,
+    pub last_fingerprint: Option<String>,
+    #[serde(default)]
+    pub no_change_count: u32,
+    #[serde(default)]
+    pub consecutive_not_found_count: u32,
+    #[serde(default)]
+    pub deleted: bool,
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct State {
     /// Last successful capture timestamp per source
+    #[serde(default)]
     pub watermarks: HashMap<String, DateTime<Utc>>,
+    #[serde(default)]
+    pub scan_targets: HashMap<String, ScanTargetState>,
 }
 
 impl State {
@@ -42,5 +60,100 @@ impl State {
         if ts > *entry {
             *entry = ts;
         }
+    }
+
+    pub fn scan_target(&self, key: &str) -> Option<&ScanTargetState> {
+        self.scan_targets.get(key)
+    }
+
+    pub fn scan_target_mut(&mut self, key: &str) -> Option<&mut ScanTargetState> {
+        self.scan_targets.get_mut(key)
+    }
+
+    pub fn set_scan_target(&mut self, key: String, state: ScanTargetState) {
+        self.scan_targets.insert(key, state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::{ScanTargetState, State};
+
+    #[test]
+    fn load_legacy_state_without_scan_targets() {
+        let state: State = serde_json::from_str(r#"{"watermarks":{}}"#).expect("legacy state");
+
+        assert!(state.scan_targets.is_empty());
+    }
+
+    #[test]
+    fn state_round_trips_scan_targets() {
+        let mut state = State::default();
+        let now = Utc::now();
+        state.set_scan_target(
+            "reddit:https://old.reddit.com/r/rust.json?limit=20".to_string(),
+            ScanTargetState {
+                provider: "reddit".to_string(),
+                target_url: "https://old.reddit.com/r/rust.json?limit=20".to_string(),
+                last_checked_at: Some(now),
+                last_changed_at: Some(now),
+                last_fingerprint: Some("abc123".to_string()),
+                no_change_count: 2,
+                consecutive_not_found_count: 1,
+                deleted: false,
+            },
+        );
+
+        let json = serde_json::to_string(&state).expect("encode state");
+        let decoded: State = serde_json::from_str(&json).expect("decode state");
+
+        let entry = decoded
+            .scan_target("reddit:https://old.reddit.com/r/rust.json?limit=20")
+            .expect("scan target");
+        assert_eq!(entry.provider, "reddit");
+        assert_eq!(entry.last_fingerprint.as_deref(), Some("abc123"));
+        assert_eq!(entry.no_change_count, 2);
+        assert_eq!(entry.consecutive_not_found_count, 1);
+    }
+
+    #[test]
+    fn set_scan_target_replaces_existing_entry() {
+        let mut state = State::default();
+        let key = "x:https://x.com/home".to_string();
+
+        state.set_scan_target(
+            key.clone(),
+            ScanTargetState {
+                provider: "x".to_string(),
+                target_url: "https://x.com/home".to_string(),
+                last_checked_at: None,
+                last_changed_at: None,
+                last_fingerprint: Some("old".to_string()),
+                no_change_count: 1,
+                consecutive_not_found_count: 0,
+                deleted: false,
+            },
+        );
+
+        state.set_scan_target(
+            key.clone(),
+            ScanTargetState {
+                provider: "x".to_string(),
+                target_url: "https://x.com/home".to_string(),
+                last_checked_at: None,
+                last_changed_at: None,
+                last_fingerprint: Some("new".to_string()),
+                no_change_count: 0,
+                consecutive_not_found_count: 2,
+                deleted: true,
+            },
+        );
+
+        let entry = state.scan_target(&key).expect("updated scan target");
+        assert_eq!(entry.last_fingerprint.as_deref(), Some("new"));
+        assert_eq!(entry.consecutive_not_found_count, 2);
+        assert!(entry.deleted);
     }
 }

--- a/docs/plans/2026-04-11-calendar-screenshot-clipboard.md
+++ b/docs/plans/2026-04-11-calendar-screenshot-clipboard.md
@@ -1012,11 +1012,11 @@ git commit -m "build: release build with calendar, screenshot, clipboard"
 
 ---
 
-### Task 9: Update Ryugu daemon tools/cueward.ts
+### Task 9: Update host app tools/cueward.ts
 
 **Files:**
-- Modify: `/Users/cyh/Development/Ryugu/daemon/src/tools/cueward.ts`
-- Modify: `/Users/cyh/Development/Ryugu/daemon/src/tools/tools.test.ts`
+- Modify: `/path/to/host-app/daemon/src/tools/cueward.ts`
+- Modify: `/path/to/host-app/daemon/src/tools/tools.test.ts`
 
 - [ ] **Step 1: Add new actions to VALID_ACTIONS and subcommand whitelists**
 
@@ -1127,16 +1127,16 @@ Add to `tools.test.ts`:
 
 - [ ] **Step 4: Run daemon tests**
 
-Run: `cd /Users/cyh/Development/Ryugu/daemon && npx tsx --test src/tools/tools.test.ts 2>&1 | tail -10`
+Run: `cd /path/to/host-app/daemon && npx tsx --test src/tools/tools.test.ts 2>&1 | tail -10`
 Expected: all PASS
 
-Run: `cd /Users/cyh/Development/Ryugu/daemon && npm test 2>&1 | tail -5`
+Run: `cd /path/to/host-app/daemon && npm test 2>&1 | tail -5`
 Expected: all PASS
 
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /Users/cyh/Development/Ryugu
+cd /path/to/host-app
 git add daemon/src/tools/cueward.ts daemon/src/tools/tools.test.ts
 git commit -m "feat(tools): add calendar, screenshot, clipboard to cueward wrapper"
 ```

--- a/docs/plans/2026-04-12-scroll-read-pipeline.md
+++ b/docs/plans/2026-04-12-scroll-read-pipeline.md
@@ -19,7 +19,7 @@
 - [ ] **Step 1: Write the failing test**
 
 Add a CLI parse test for:
-`cueward safari scroll-and-read --tab x.com --profile Ryugu --times 3`
+`cueward safari scroll-and-read --tab x.com --profile Work --times 3`
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -132,4 +132,3 @@ Run:
 
 Run:
 `git diff -- crates/cli/src/main.rs crates/adapter-macos/src/safari.rs docs/plans/2026-04-12-scroll-read-pipeline.md`
-

--- a/docs/plans/2026-04-13-reddit-json-api.md
+++ b/docs/plans/2026-04-13-reddit-json-api.md
@@ -1,0 +1,180 @@
+# Reddit JSON API Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new top-level `cueward reddit` command that reads Reddit via `old.reddit.com/*.json` without Safari automation.
+
+**Architecture:** Keep Reddit as a standalone read-only provider. Put HTTP + JSON parsing in `crates/adapter-macos/src/reddit.rs`, expose it from `adapter-macos`, and add a dedicated CLI command module at `crates/cli/src/commands/reddit.rs`. Use `ureq` for synchronous requests, normalize subreddit / post URL inputs up front, and return structured JSON wrapped with `print_external()`.
+
+**Tech Stack:** Rust, clap, serde, serde_json, ureq, cargo test
+
+---
+
+### Task 1: Add CLI command surface for `cueward reddit`
+
+**Files:**
+- Modify: `crates/cli/src/commands/mod.rs`
+- Create: `crates/cli/src/commands/reddit.rs`
+- Create: `crates/cli/src/commands/reddit_tests.rs`
+
+- [ ] **Step 1: Write the failing CLI parse tests**
+
+Add tests for:
+- `cueward reddit feed rust`
+- `cueward reddit feed r/rust --limit 50`
+- `cueward reddit post https://www.reddit.com/r/rust/comments/abc123/example_title/`
+- `cueward reddit search "async rust"`
+- `cueward reddit search "async rust" --subreddit r/rust --limit 25`
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run:
+`cargo test reddit_tests -- --nocapture`
+
+Expected: FAIL because the `reddit` command does not exist yet.
+
+- [ ] **Step 3: Add the minimal clap surface**
+
+Implement:
+- `Command::Reddit { action: RedditAction }`
+- `RedditAction::{Feed, Post, Search}`
+- `dispatch()` stub in `commands/reddit.rs`
+
+- [ ] **Step 4: Run the CLI tests again**
+
+Run:
+`cargo test reddit_tests -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/cli/src/commands/mod.rs crates/cli/src/commands/reddit.rs crates/cli/src/commands/reddit_tests.rs
+git commit -m "feat: add reddit cli surface"
+```
+
+### Task 2: Implement Reddit adapter core with pure parser tests
+
+**Files:**
+- Modify: `crates/adapter-macos/src/lib.rs`
+- Modify: `crates/adapter-macos/Cargo.toml`
+- Create: `crates/adapter-macos/src/reddit.rs`
+
+- [ ] **Step 1: Write failing pure tests in `reddit.rs`**
+
+Cover:
+- subreddit normalization (`rust`, `r/rust`, invalid cases)
+- post URL normalization to `old.reddit.com/.../.json?limit=500`
+- feed URL builder
+- search URL builder
+- feed JSON parsing
+- post JSON parsing with top-level comments only
+
+- [ ] **Step 2: Run the targeted tests and verify they fail**
+
+Run:
+`cargo test reddit::tests -- --nocapture`
+
+Expected: FAIL because the module and helpers do not exist yet.
+
+- [ ] **Step 3: Add the adapter implementation**
+
+Implement in `crates/adapter-macos/src/reddit.rs`:
+- public result structs for feed / post / search
+- internal JSON helpers for listing / thing parsing
+- `normalize_subreddit()`
+- `normalize_post_url()`
+- `build_feed_url()`
+- `build_search_url()`
+- `fetch_json()`
+- `feed()`
+- `post()`
+- `search()`
+
+Add `ureq` to `crates/adapter-macos/Cargo.toml`.
+Expose the module with `pub mod reddit;` in `crates/adapter-macos/src/lib.rs`.
+
+- [ ] **Step 4: Run the targeted adapter tests**
+
+Run:
+`cargo test -p cueward-adapter-macos reddit::tests -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-macos/Cargo.toml crates/adapter-macos/src/lib.rs crates/adapter-macos/src/reddit.rs
+git commit -m "feat: add reddit json adapter"
+```
+
+### Task 3: Wire CLI dispatch to adapter and external output
+
+**Files:**
+- Modify: `crates/cli/src/commands/reddit.rs`
+
+- [ ] **Step 1: Replace CLI stubs with real dispatch**
+
+Wire each action to:
+- `cueward_adapter_macos::reddit::feed`
+- `cueward_adapter_macos::reddit::post`
+- `cueward_adapter_macos::reddit::search`
+
+Wrap outputs with `print_external()` using:
+- `reddit/feed`
+- `reddit/post`
+- `reddit/search`
+
+- [ ] **Step 2: Run focused CLI package tests**
+
+Run:
+`cargo test -p cueward-cli reddit_tests -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 3: Run full repo verification**
+
+Run:
+`cargo build --release`
+`cargo test`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/cli/src/commands/reddit.rs
+git commit -m "feat: wire reddit json workflows"
+```
+
+### Task 4: Update user-facing docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `skills/cueward-agent/SKILL.md`
+
+- [ ] **Step 1: Add README usage examples**
+
+Document:
+- `cueward reddit feed`
+- `cueward reddit post`
+- `cueward reddit search`
+
+- [ ] **Step 2: Update skill documentation**
+
+Add Reddit command coverage so the installed skill reflects the new CLI surface.
+
+- [ ] **Step 3: Re-run verification**
+
+Run:
+`cargo test`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md skills/cueward-agent/SKILL.md
+git commit -m "docs: document reddit json commands"
+```

--- a/docs/plans/2026-04-13-safari-bookmarks-crud.md
+++ b/docs/plans/2026-04-13-safari-bookmarks-crud.md
@@ -177,7 +177,7 @@ In `crates/adapter-macos/src/bookmarks.rs`:
 - recursively walk `Children`
 - implement folder lookup from root and `list` / `search` helpers
 - keep URL values opaque strings; do not add canonicalization logic
-- support `--profile` as a root-folder prefix, so `--profile Ryugu --folder "Work/AI Tools"` resolves to `Ryugu/Work/AI Tools`
+- support `--profile` as a root-folder prefix, so `--profile Work --folder "Projects/AI Tools"` resolves to `Work/Projects/AI Tools`
 
 Prefer a small read model:
 

--- a/docs/plans/2026-04-13-smart-polling-state-layer.md
+++ b/docs/plans/2026-04-13-smart-polling-state-layer.md
@@ -1,0 +1,221 @@
+# Smart Polling State Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent scan state layer with backoff, 2-strike delete detection, and content pre-filtering for Reddit and X targets.
+
+**Architecture:** Extend `cueward_core::State` with generic `scan_targets` metadata, then implement a small shared scan-state helper in `adapter-macos` that provider modules can use. Reddit and X will build canonical target URLs, apply provider-specific filters, compute fingerprints, and return scan-aware envelopes such as `fresh`, `unchanged`, `skipped`, `warning`, or `deleted`.
+
+**Tech Stack:** Rust, chrono, serde, serde_json, cargo test
+
+---
+
+### Task 1: Extend persistent core state schema
+
+**Files:**
+- Modify: `crates/core/src/state.rs`
+- Modify: `crates/core/src/lib.rs`
+
+- [ ] **Step 1: Write failing state round-trip tests**
+
+Add tests for:
+- loading legacy state without `scan_targets`
+- saving/loading `scan_targets`
+- updating a stored scan target entry
+
+- [ ] **Step 2: Run the targeted tests and verify they fail**
+
+Run:
+`cargo test -p cueward-core state -- --nocapture`
+
+Expected: FAIL because `scan_targets` and helper accessors do not exist yet.
+
+- [ ] **Step 3: Add the minimal schema**
+
+Implement:
+- `ScanTargetState`
+- `#[serde(default)] scan_targets: HashMap<String, ScanTargetState>`
+- helper methods for get/set of scan target entries
+- export `ScanTargetState` from `cueward_core`
+
+- [ ] **Step 4: Re-run the targeted tests**
+
+Run:
+`cargo test -p cueward-core state -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/state.rs crates/core/src/lib.rs
+git commit -m "feat: add persistent scan target state"
+```
+
+### Task 2: Add shared scan-state helper module in adapter-macos
+
+**Files:**
+- Modify: `crates/adapter-macos/src/lib.rs`
+- Create: `crates/adapter-macos/src/scan_state.rs`
+
+- [ ] **Step 1: Write failing pure tests in `scan_state.rs`**
+
+Cover:
+- scan key building from `provider + target_url`
+- skip/backoff decisions
+- 2-strike delete transitions
+- fingerprint stability
+- bot/deleted author filtering
+- age cutoff filtering
+
+- [ ] **Step 2: Run the targeted tests and verify they fail**
+
+Run:
+`cargo test -p cueward-adapter-macos scan_state::tests -- --nocapture`
+
+Expected: FAIL because the module does not exist yet.
+
+- [ ] **Step 3: Add the shared helper implementation**
+
+Implement:
+- `ScanStatus`
+- `ScanEnvelope<T>`
+- `build_scan_key()`
+- `should_skip_scan()`
+- `record_success()`
+- `record_not_found()`
+- `fingerprint_json()`
+- small pre-filter helpers
+- state load/save wrapper that does not fail the provider result on save errors
+
+- [ ] **Step 4: Re-run targeted scan-state tests**
+
+Run:
+`cargo test -p cueward-adapter-macos scan_state::tests -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-macos/src/lib.rs crates/adapter-macos/src/scan_state.rs
+git commit -m "feat: add shared scan state helpers"
+```
+
+### Task 3: Apply scan state to Reddit provider
+
+**Files:**
+- Modify: `crates/adapter-macos/src/reddit.rs`
+- Modify: `crates/adapter-macos/src/reddit/tests.rs`
+- Modify: `crates/cli/src/commands/reddit.rs`
+
+- [ ] **Step 1: Add failing tests for scan-aware Reddit behavior**
+
+Cover:
+- repeated identical feed/search results become `unchanged`
+- stale target can become `skipped`
+- single 404 on `post` becomes `warning`
+- second consecutive 404 on the same post becomes `deleted`
+- comment pre-filter removes deleted/bot/too-old/too-short comments
+
+- [ ] **Step 2: Run targeted tests and verify they fail**
+
+Run:
+`cargo test -p cueward-adapter-macos reddit::tests -- --nocapture`
+
+Expected: FAIL because Reddit still returns raw provider results.
+
+- [ ] **Step 3: Implement Reddit scan integration**
+
+Make Reddit commands:
+- load/update persistent scan state
+- use canonical `old.reddit.com` target URLs
+- fingerprint feed/search post lists
+- fingerprint filtered top-level comments for `post`
+- return `ScanEnvelope<...>` instead of raw provider data
+
+Update CLI dispatch to print the scan envelope cleanly.
+
+- [ ] **Step 4: Re-run targeted verification**
+
+Run:
+`cargo test -p cueward-adapter-macos reddit::tests -- --nocapture`
+`cargo test -p cueward-cli reddit_tests -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-macos/src/reddit.rs crates/adapter-macos/src/reddit/tests.rs crates/cli/src/commands/reddit.rs
+git commit -m "feat: add reddit scan state tracking"
+```
+
+### Task 4: Apply scan state to X provider
+
+**Files:**
+- Modify: `crates/adapter-macos/src/safari/social/x.rs`
+- Modify: `crates/cli/src/commands/safari_ai/x.rs`
+
+- [ ] **Step 1: Write failing X-focused tests**
+
+Cover:
+- X post filtering removes deleted/bot/too-old/too-short items
+- canonical target URL selection for feed/search/read
+- repeated identical results become `unchanged`
+- `x read` empty result uses 2-strike deleted flow
+
+- [ ] **Step 2: Run targeted tests and verify they fail**
+
+Run:
+`cargo test -p cueward-adapter-macos x_ -- --nocapture`
+
+Expected: FAIL because X still returns raw `Vec<SocialFeedPost>`.
+
+- [ ] **Step 3: Integrate scan state into X**
+
+Implement:
+- canonical URLs for feed/home, search, and read targets
+- provider-specific pre-filter for `SocialFeedPost`
+- fingerprinting after filtering
+- not-found handling for `x read` when the targeted post returns no parsed items
+- scan envelope output for X CLI commands
+
+- [ ] **Step 4: Re-run targeted verification**
+
+Run:
+`cargo test -p cueward-adapter-macos x_ -- --nocapture`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/adapter-macos/src/safari/social/x.rs crates/cli/src/commands/safari_ai/x.rs
+git commit -m "feat: add x scan state tracking"
+```
+
+### Task 5: Full verification and docs touch-up
+
+**Files:**
+- Modify: `docs/specs/2026-04-13-smart-polling-state-layer.md` (only if implementation drifted)
+- Modify: `README.md` (only if command output semantics need a note)
+
+- [ ] **Step 1: Run full verification**
+
+Run:
+`cargo build --release`
+`cargo test`
+
+Expected: PASS
+
+- [ ] **Step 2: Review docs for semantic drift**
+
+If output/status semantics changed in a user-visible way, add a short note to the README.
+
+- [ ] **Step 3: Commit any docs alignment**
+
+```bash
+git add README.md docs/specs/2026-04-13-smart-polling-state-layer.md
+git commit -m "docs: align smart polling docs"
+```

--- a/docs/specs/2026-04-11-calendar-screenshot-clipboard.md
+++ b/docs/specs/2026-04-11-calendar-screenshot-clipboard.md
@@ -2,7 +2,7 @@
 
 **Goal:** 為 cueward 新增三個 macOS 整合功能：日曆讀寫、螢幕截圖（含可選 OCR）、剪貼簿讀寫。
 
-**動機:** Ryugu（AI 助手）需要這三個能力來更好地輔助老闆 — 知道行程判斷何時打擾、主動看螢幕狀態、存取剪貼簿省去手動貼上。
+**動機:** 上層 AI 助手需要這三個能力來更好地輔助使用者 — 知道行程判斷何時打擾、主動看螢幕狀態、存取剪貼簿省去手動貼上。
 
 ---
 
@@ -171,4 +171,4 @@ Calendar 和 Screenshot 加了以備未來需要（calendar events 可能進 cap
 
 ### daemon 側更新
 
-完成後需要在 Ryugu daemon 的 `tools/cueward.ts` 加對應的 action handler（calendar、screenshot、clipboard），以及更新 `buildCuewardCmd` 的 switch/case。
+完成後需要在 host app 的 `tools/cueward.ts` 加對應的 action handler（calendar、screenshot、clipboard），以及更新 `buildCuewardCmd` 的 switch/case。

--- a/docs/specs/2026-04-13-reddit-json-api.md
+++ b/docs/specs/2026-04-13-reddit-json-api.md
@@ -1,0 +1,242 @@
+# Reddit JSON API
+
+## Goal
+
+處理 issue #58，為 `cueward` 新增獨立的 Reddit read-only provider，優先使用公開 JSON endpoint，而不是 Safari DOM automation。
+
+第一版範圍：
+
+- 新增頂層 CLI：`cueward reddit`
+- 只做讀取，不做發文、投票、留言互動
+- 底層統一走 `old.reddit.com/*.json`
+- 不需要 OAuth，只帶固定 `User-Agent`
+- CLI 輸出用 `print_external()` 包裝
+
+不納入第一版：
+
+- nested reply tree
+- comment 搜尋
+- Safari 整合
+- generic HTTP provider framework
+
+## CLI
+
+新增 `reddit` 頂層命令：
+
+```bash
+cueward reddit feed <subreddit> [--limit 20]
+cueward reddit post <url>
+cueward reddit search <query> [--subreddit r/rust] [--limit 10]
+```
+
+語意：
+
+- `feed`
+  - 讀取 subreddit feed
+  - 預設 `--limit 20`
+  - `subreddit` 允許輸入 `rust` 或 `r/rust`
+- `post`
+  - 讀取單篇貼文
+  - 回傳文章本體 + top-level comments 扁平列表
+  - 支援一般 Reddit post URL；內部轉成 `old.reddit.com/.../.json`
+- `search`
+  - 搜尋只回貼文，不回留言
+  - 若有 `--subreddit`，限制在指定 subreddit 內搜尋
+  - 預設 `--limit 10`
+
+## 輸入正規化
+
+### subreddit
+
+- `rust` → `rust`
+- `r/rust` → `rust`
+- `R/rust`、前後空白 → trim 後轉成 `rust`
+- 若輸入為空、只有 `r/`、或含 `/` 深層路徑，回傳使用者錯誤
+
+### post URL
+
+接受常見 Reddit 貼文 URL，例如：
+
+- `https://www.reddit.com/r/rust/comments/abc123/example_title/`
+- `https://old.reddit.com/r/rust/comments/abc123/example_title/`
+- `https://reddit.com/r/rust/comments/abc123/example_title`
+
+內部統一轉成：
+
+- `https://old.reddit.com/r/rust/comments/abc123/example_title/.json?limit=500`
+
+若 URL 不是 Reddit 貼文，回傳使用者錯誤。
+
+## HTTP 策略
+
+使用 `ureq` 做同步 HTTP 請求。
+
+原因：
+
+- CLI 本身是同步流程，不需要引入 async runtime
+- 需求是小型 read-only API client
+- 比起自己直做 `TcpStream`，`ureq` 已處理 redirect、header、錯誤狀態與 response body
+
+所有 request 都帶固定 `User-Agent`，例如：
+
+- `cueward/0.2.x (+https://github.com/HCYT/cueward)`
+
+endpoint：
+
+- feed  
+  `https://old.reddit.com/r/{subreddit}.json?limit={limit}`
+- post  
+  `https://old.reddit.com/r/{subreddit}/comments/{id}/{slug}.json?limit=500`
+- search（全站）  
+  `https://old.reddit.com/search.json?q={query}&limit={limit}&sort=relevance`
+- search（subreddit 內）  
+  `https://old.reddit.com/r/{subreddit}/search.json?q={query}&restrict_sr=on&limit={limit}&sort=relevance`
+
+## 輸出模型
+
+### Feed
+
+回傳：
+
+- `subreddit`: metadata
+- `posts`: 貼文列表
+
+建議 JSON 結構：
+
+```json
+{
+  "subreddit": {
+    "name": "rust",
+    "display_name": "r/rust",
+    "title": "The Rust Programming Language",
+    "description": "A language empowering everyone...",
+    "subscribers": 123456
+  },
+  "posts": [
+    {
+      "id": "abc123",
+      "title": "Rust 1.90 released",
+      "author": "example_user",
+      "subreddit": "rust",
+      "url": "https://www.rust-lang.org/",
+      "permalink": "https://reddit.com/r/rust/comments/abc123/...",
+      "score": 420,
+      "num_comments": 37,
+      "created_utc": 1760000000,
+      "selftext": ""
+    }
+  ]
+}
+```
+
+### Post
+
+回傳：
+
+- `post`: 單篇文章
+- `comments`: top-level comments 扁平列表
+
+建議 JSON 結構：
+
+```json
+{
+  "post": {
+    "id": "abc123",
+    "title": "Rust 1.90 released",
+    "author": "example_user",
+    "subreddit": "rust",
+    "url": "https://www.rust-lang.org/",
+    "permalink": "https://reddit.com/r/rust/comments/abc123/...",
+    "score": 420,
+    "num_comments": 37,
+    "created_utc": 1760000000,
+    "selftext": "release notes..."
+  },
+  "comments": [
+    {
+      "id": "c1",
+      "author": "commenter1",
+      "body": "great release",
+      "score": 12,
+      "created_utc": 1760000100,
+      "permalink": "https://reddit.com/r/rust/comments/abc123/.../c1"
+    }
+  ]
+}
+```
+
+### Search
+
+回傳：
+
+- `query`
+- `subreddit`（可為 null）
+- `limit`
+- `posts`
+
+只回貼文，不回留言。
+
+## 架構決策
+
+這個功能不放在 `safari ai provider` 底下，原因是：
+
+- issue #58 的核心就是「有公開 JSON API 時，優先用 API」
+- Reddit 第一版完全不需要 Safari session、DOM selector、或前景/背景 tab 控制
+- 硬塞進 `safari ai` 只會混淆 transport 與 provider 邊界
+
+實作位置：
+
+- `crates/adapter-macos/src/reddit.rs`
+- `crates/adapter-macos/src/lib.rs`
+- `crates/cli/src/commands/reddit.rs`
+- `crates/cli/src/commands/mod.rs`
+
+外部介面：
+
+- `cueward_adapter_macos::reddit::*`
+- `cueward reddit ...`
+
+## 錯誤處理
+
+第一版至少要明確區分：
+
+- invalid subreddit
+- invalid Reddit post URL
+- request failed
+- Reddit returned unexpected status
+- invalid Reddit JSON payload
+- post payload missing article section
+
+所有錯誤都轉成清楚的 CLI 錯誤訊息，不把 raw parser panic 暴露給使用者。
+
+## 測試
+
+### CLI
+
+至少覆蓋：
+
+- `cueward reddit feed rust`
+- `cueward reddit feed r/rust --limit 50`
+- `cueward reddit post https://www.reddit.com/r/rust/comments/abc123/example_title/`
+- `cueward reddit search "async rust"`
+- `cueward reddit search "async rust" --subreddit r/rust --limit 25`
+
+### Adapter 純函式
+
+至少覆蓋：
+
+- subreddit 正規化
+- post URL 正規化
+- feed/search URL builder
+- feed JSON parser
+- post + top-level comments parser
+- 忽略 nested replies
+
+### 網路測試
+
+第一版不做真網路測試。用 fixture JSON 或內嵌字串做 deterministic parser tests。
+
+## 與現有 issue 的關係
+
+- `#58`：直接處理
+- `#43`：這次實作會提供 Reddit read-only provider 的主要骨架，但 `#43` 是否一併關閉，要看實際 CLI 與 README 是否完整達到該 issue 的範圍

--- a/docs/specs/2026-04-13-safari-bookmarks-crud.md
+++ b/docs/specs/2026-04-13-safari-bookmarks-crud.md
@@ -16,10 +16,10 @@
 新增 `safari bookmarks` 子命令：
 
 ```bash
-cueward safari bookmarks list [--profile "Ryugu"] [--folder "Work/AI Tools"]
-cueward safari bookmarks search "claude" [--profile "Ryugu"] [--folder "Work/AI Tools"]
-cueward safari bookmarks add --title "Claude" --url "https://claude.ai" [--profile "Ryugu"] [--folder "Work/AI Tools"]
-cueward safari bookmarks delete --title "Claude" --url "https://claude.ai" [--profile "Ryugu"] [--folder "Work/AI Tools"]
+cueward safari bookmarks list [--profile "Work"] [--folder "Projects/AI Tools"]
+cueward safari bookmarks search "claude" [--profile "Work"] [--folder "Projects/AI Tools"]
+cueward safari bookmarks add --title "Claude" --url "https://claude.ai" [--profile "Work"] [--folder "Projects/AI Tools"]
+cueward safari bookmarks delete --title "Claude" --url "https://claude.ai" [--profile "Work"] [--folder "Projects/AI Tools"]
 ```
 
 語意：
@@ -41,9 +41,9 @@ cueward safari bookmarks delete --title "Claude" --url "https://claude.ai" [--pr
 
 ## Folder Path 規則
 
-- `--profile Ryugu --folder "Work/AI Tools"` 代表沿著 `Ryugu -> Work -> AI Tools` 往下走
-- 若只有 `--profile Ryugu`，等同操作 `Ryugu` root folder
-- `--folder "Work/AI Tools"` 代表沿著 `Work -> AI Tools` 往下走
+- `--profile Work --folder "Projects/AI Tools"` 代表沿著 `Work -> Projects -> AI Tools` 往下走
+- 若只有 `--profile Work`，等同操作 `Work` root folder
+- `--folder "Projects/AI Tools"` 代表沿著 `Projects -> AI Tools` 往下走
 - 路徑分隔符固定為 `/`
 - 第一期不支援 folder title 本身包含 `/`
 - 空 segment 不允許，例如 `Work//AI`

--- a/docs/specs/2026-04-13-smart-polling-state-layer.md
+++ b/docs/specs/2026-04-13-smart-polling-state-layer.md
@@ -1,0 +1,270 @@
+# Smart Polling State Layer
+
+## Goal
+
+處理 issue #59，為 read-oriented provider 新增跨執行的 scan state / cache 層，支援：
+
+- scan backoff
+- 2-strike delete detection
+- content pre-filter
+
+第一版範圍只接：
+
+- Reddit
+- X
+
+不在第一版：
+
+- Threads（另開 #72）
+- Safari generic read pipeline
+- 持久化全文內容 cache
+
+## 核心概念
+
+對重複掃描的 target（feed、post、search），以：
+
+- `provider + canonical target URL`
+
+作為唯一 key，持久化追蹤其最近掃描狀態。
+
+scan state 用來決定：
+
+- 這次要不要掃
+- 掃完後算不算有變化
+- 遇到 not-found / parse miss 是否應標 deleted
+- 哪些內容要先在 provider 層過濾掉，不丟到上層
+
+## State 存放
+
+沿用 `~/.cueward/state.json`，不要再發明第二個 state 檔。
+
+在既有 `State` 結構裡新增一塊 scan 狀態，例如：
+
+- `scan_targets: HashMap<String, ScanTargetState>`
+
+key 格式：
+
+- `reddit:https://old.reddit.com/r/rust.json?limit=20`
+- `reddit:https://old.reddit.com/r/rust/comments/abc123/example_title.json?limit=500`
+- `x:https://x.com/search?q=rust&src=typed_query&f=live`
+
+## State 模型
+
+每個 target 至少追蹤：
+
+- `provider`
+- `target_url`
+- `last_checked_at`
+- `last_changed_at`
+- `last_fingerprint`
+- `no_change_count`
+- `consecutive_not_found_count`
+- `deleted`
+
+語意：
+
+- `last_checked_at`
+  - 最後一次實際發 request 的時間
+- `last_changed_at`
+  - 最後一次偵測到內容有變化的時間
+- `last_fingerprint`
+  - 上次成功掃描內容的摘要指紋
+- `no_change_count`
+  - 連續幾次掃描都沒有變化
+- `consecutive_not_found_count`
+  - 連續幾次遇到 not-found / 等價 deleted 訊號
+- `deleted`
+  - 已確定視為 deleted，後續預設不再掃
+
+## Scan Backoff 規則
+
+第一版採簡單規則，不做過度最佳化：
+
+- `no_change_count == 0`
+  - 正常頻率
+- `no_change_count >= 2`
+  - 提高最小掃描間隔
+- `last_changed_at` 距今超過一段時間（例如 3 天）
+  - 可直接 skip
+
+第一版建議：
+
+- 正常最小間隔：30 分鐘
+- 2 次以上沒變：6 小時
+- 3 天以上沒變：skip
+
+這些值先做成常數，不先做使用者配置。
+
+## 2-Strike Delete Detection
+
+對可能代表 deleted 的結果，不要單次就宣告刪除。
+
+第一版規則：
+
+- 單次 404 / provider-specific not-found
+  - `consecutive_not_found_count += 1`
+  - 回傳 warning 狀態
+- 連續 2 次
+  - `deleted = true`
+  - 後續預設 skip
+
+對暫時性錯誤（網路錯、5xx、429）：
+
+- 不增加 `consecutive_not_found_count`
+- 只回傳 fetch error
+
+## Content Pre-filter
+
+抓回 provider 內容後、回給上層前先過濾：
+
+- 太短內容 skip
+  - 例如 `< 5` 個詞或 `< 20` 個可見字元
+- bot / deleted-like author skip
+  - `AutoModerator`
+  - `[deleted]`
+  - `[removed]`
+- 太舊內容 skip
+  - 超過固定天數，例如 30 天
+
+第一版先作用在：
+
+- Reddit comments
+- X posts
+
+不先作用在：
+
+- Reddit post 本體
+- subreddit metadata
+
+## Fingerprint 策略
+
+fingerprint 只需要夠穩定，不需要可逆。
+
+第一版用：
+
+- provider-specific filtered item 清單
+- 取每個 item 的 stable fields（id / content / score / comment count / timestamp）
+- 序列化成 JSON 後算 SHA-256
+
+重點：
+
+- 先過 pre-filter，再算 fingerprint
+- 避免因為被過濾掉的 bot / deleted / 太舊內容造成雜訊
+
+## Provider 接法
+
+### Reddit
+
+作用在：
+
+- `feed`
+- `post`
+- `search`
+
+canonical URL：
+
+- 直接用 adapter 已經建好的 `old.reddit.com/*.json` URL
+
+變化判斷：
+
+- `feed/search`
+  - 基於 post list fingerprint
+- `post`
+  - 基於 top-level comments fingerprint
+
+### X
+
+作用在：
+
+- `x list`
+- `x read`
+- `x prompt`（search）
+
+canonical target：
+
+- feed：`https://x.com/home`
+- read：正規化 post URL
+- prompt/search：實際 search URL
+
+變化判斷：
+
+- 基於 `SocialFeedPost` 經 pre-filter 後的 fingerprint
+
+## CLI 形狀
+
+第一版不新增新命令。
+
+做法是把這層 state 邏輯藏在 provider 內部，讓既有命令：
+
+- `cueward reddit ...`
+- `cueward safari ai --provider x ...`
+
+在重複掃描時自動受益。
+
+若需要 debug，再後續補：
+
+- `cueward debug scan-state`
+
+但不放在第一版。
+
+## 架構位置
+
+新增跨 provider 的小模組，而不是把邏輯直接塞進每個 provider：
+
+- `crates/core/src/state.rs`
+  - 擴充 state schema
+- `crates/adapter-macos/src/scan_state.rs`
+  - scan state policy
+  - key builder
+  - fingerprint helper
+  - backoff decision
+  - delete tracking update
+
+provider 只做：
+
+- 組 canonical target key
+- 提供 raw items
+- 定義 provider-specific pre-filter
+
+## 錯誤處理
+
+不要讓 scan state 層把 request error 吃掉。
+
+規則：
+
+- state read 失敗
+  - fallback 到預設空 state
+- state write 失敗
+  - 回 warning / log，但不要讓 fetch 結果整個失敗
+- provider fetch 失敗
+  - 原樣回傳錯誤
+- deleted target
+  - 回傳明確狀態，而不是靜默空結果
+
+## 測試
+
+### 純函式測試
+
+至少覆蓋：
+
+- canonical key 穩定
+- backoff 決策
+- 2-strike delete 狀態轉移
+- pre-filter 規則
+- fingerprint 對無變化內容穩定
+- fingerprint 對有變化內容改變
+
+### state round-trip
+
+- `State` 新 schema 可 load/save
+- 舊版沒有 `scan_targets` 的 `state.json` 仍可正常 load
+
+### provider 測試
+
+- Reddit feed/search/post 使用 scan state 後仍通過既有 parser tests
+- X list/search/read 需要新增 focused tests，至少鎖住 fingerprint input 與 pre-filter
+
+## 與現有 issue 的關係
+
+- `#59`：直接處理
+- `#72`：Threads follow-up，後續把同一套 scan state 套進 Threads provider

--- a/skills/cueward-agent/SKILL.md
+++ b/skills/cueward-agent/SKILL.md
@@ -94,14 +94,14 @@ Read live Safari state and automate the current page or a matched tab.
 cueward safari tabs
 
 # Filter to a Safari profile
-cueward safari tabs --profile Ryugu
+cueward safari tabs --profile Work
 
 # Read the active page or a specific selector
 cueward safari read
 cueward safari read --selector ".article-body"
 
 # Read a specific tab by URL/title match
-cueward safari read --tab "ChatGPT" --profile Ryugu
+cueward safari read --tab "ChatGPT" --profile Work
 
 # Run JavaScript in the current tab
 cueward safari exec "document.title"
@@ -118,17 +118,17 @@ Inspect and manage Safari bookmarks, including nested folders and profile roots.
 ```bash
 # List root bookmarks or a profile root
 cueward safari bookmarks list
-cueward safari bookmarks list --profile Ryugu
+cueward safari bookmarks list --profile Work
 
 # Traverse nested folders inside a profile
-cueward safari bookmarks list --profile Ryugu --folder "Work/AI Tools"
+cueward safari bookmarks list --profile Work --folder "Projects/AI Tools"
 
 # Recursive search
-cueward safari bookmarks search "claude" --profile Ryugu --folder "Work"
+cueward safari bookmarks search "claude" --profile Work --folder "Projects"
 
 # Add or delete by exact title + URL fingerprint inside a folder
-cueward safari bookmarks add --title "Claude" --url "https://claude.ai" --profile Ryugu --folder "Work/AI Tools"
-cueward safari bookmarks delete --title "Claude" --url "https://claude.ai" --profile Ryugu --folder "Work/AI Tools"
+cueward safari bookmarks add --title "Claude" --url "https://claude.ai" --profile Work --folder "Projects/AI Tools"
+cueward safari bookmarks delete --title "Claude" --url "https://claude.ai" --profile Work --folder "Projects/AI Tools"
 ```
 
 - Folder paths use `/` as the separator
@@ -144,7 +144,7 @@ Drive Safari-based AI providers such as Gemini and ChatGPT through the CLI.
 cueward safari ai --provider gemini prompt --prompt "台灣 AI 產業分析"
 
 # Use a provider with a specific Safari profile
-cueward safari ai --provider gemini --profile Ryugu list
+cueward safari ai --provider gemini --profile Work list
 
 # Read a saved conversation
 cueward safari ai --provider gemini read https://gemini.google.com/app/abc123

--- a/skills/cueward-agent/SKILL.md
+++ b/skills/cueward-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cueward-agent
-description: Use Cueward CLI to capture, triage, search, and manage the user's scattered knowledge from Safari, Apple Notes, and iMessage. Also supports Safari tabs/bookmarks/AI automation, OCR (images/PDFs), creating Notes and Reminders, reading Reminders, managing notes (update/delete/move), and Quick Notes (快速備忘錄) operations including archive-to-folder cleanup. Trigger when the user asks about their browsing history, recent notes, messages, Quick Notes, Safari tabs/bookmarks, wants to organize knowledge, create a digest, set reminders from captured content, inspect Safari AI conversations, extract text from images/PDFs, or manage Apple Notes. Also use when the user says things like "what did I read today", "find that article I saw", "summarize my knowledge intake", "help me organize what I've been looking at", "create a reminder for this", "write a summary note", "OCR this screenshot", "list my quick notes", "what's in my quick notes", "show my Safari tabs", or "search my bookmarks".
+description: Use Cueward CLI to capture, triage, search, and manage the user's scattered knowledge from Safari, Apple Notes, iMessage, and Reddit. Also supports Safari tabs/bookmarks/AI automation, OCR (images/PDFs), creating Notes and Reminders, reading Reminders, managing notes (update/delete/move), and Quick Notes (快速備忘錄) operations including archive-to-folder cleanup. Trigger when the user asks about their browsing history, recent notes, messages, Quick Notes, Safari tabs/bookmarks, Reddit feeds/posts, wants to organize knowledge, create a digest, set reminders from captured content, inspect Safari AI conversations, extract text from images/PDFs, or manage Apple Notes. Also use when the user says things like "what did I read today", "find that article I saw", "summarize my knowledge intake", "help me organize what I've been looking at", "create a reminder for this", "write a summary note", "OCR this screenshot", "list my quick notes", "what's in my quick notes", "show my Safari tabs", "search my bookmarks", or "check this subreddit".
 ---
 
 # Cueward Agent Skill
@@ -157,7 +157,28 @@ cueward safari ai --provider chatgpt save-images https://chatgpt.com/c/abc123 --
 - Prefer `list` then `read` when the user asks about prior AI conversations
 - Gemini supports extra workflow commands such as `mode`, `poll`, and `save-media`
 
-### 8. Plan
+### 8. Reddit
+
+Read Reddit through the public JSON API without Safari automation.
+
+```bash
+# Read a subreddit feed
+cueward reddit feed rust
+
+# Read a post plus top-level comments
+cueward reddit post https://www.reddit.com/r/rust/comments/abc123/example_title/
+
+# Search posts globally or inside a subreddit
+cueward reddit search "async rust"
+cueward reddit search "async rust" --subreddit r/rust --limit 25
+```
+
+- Use this when the user wants subreddit or Reddit thread data and browser automation is unnecessary
+- `feed` returns subreddit metadata plus post summaries
+- `post` returns the article plus top-level comments only
+- `search` returns post matches only, not comment matches
+
+### 9. Plan
 
 Create a reminder in Apple Reminders.
 
@@ -167,7 +188,7 @@ cueward plan --title "Review PR" --notes "Check bot comments" --list Cueward
 
 - `--list`: Reminders list (auto-created if missing). Default: `Cueward`
 
-### 9. Reminders
+### 10. Reminders
 
 Read existing Apple Reminders.
 
@@ -179,7 +200,7 @@ cueward reminders today
 
 - Use this when the user asks what they planned already, what is due today, or wants a reminder digest
 
-### 10. OCR
+### 11. OCR
 
 Extract text from images or PDFs using Apple Vision Framework.
 
@@ -192,7 +213,7 @@ cueward ocr <path_to_image_or_pdf>
 - Languages: zh-Hant, zh-Hans, en-US, ja
 - Outputs standard Cue JSON (source: "ocr")
 
-### 11. Notes Management
+### 12. Notes Management
 
 Update, delete, or move Apple Notes.
 
@@ -209,7 +230,7 @@ cueward notes move --title "Note Title" --from Cueward --to Archive
 
 These commands find notes by exact title match within the specified folder.
 
-### 12. Quick Notes
+### 13. Quick Notes
 
 List, update, archive, and delete system Quick Notes (快速備忘錄). Quick Notes are notes created via the macOS Quick Note gesture and tagged with a system flag — they may reside in any folder.
 


### PR DESCRIPTION
## Summary
- promote the latest `dev` branch into `main`
- bring in the new Reddit JSON provider from #71
- bring in the smart polling state layer for Reddit + X from #73

## Included work
- `cueward reddit feed/post/search`
- standalone Reddit adapter using `old.reddit.com/*.json`
- request throttling and retry handling for Reddit API reads
- persistent `scan_targets` state in `~/.cueward/state.json`
- shared scan-state helpers for skip/backoff/fingerprint/delete tracking
- scan-aware Reddit and X commands with statuses such as `fresh`, `unchanged`, `skipped`, `warning`, and `deleted`

## Why
`dev` now contains the completed work for:
- #58 prefer JSON API over DOM scraping where available
- #59 smart polling — backoff + content pre-filter

This PR promotes those stabilized integrations back to `main`.

## Validation
- `cargo build --release`
- `cargo test`
- real smoke tests on Reddit feed/post/search
- real smoke test on X search, including repeat-run `skipped` behavior

## Notes
- `main` is currently at `0.2.1`
- `dev` is ahead by the Reddit provider and scan-state integration work only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
