### PR TITLE
fix: speed up reminders reads with EventKit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,8 +328,12 @@ name = "cueward-adapter-macos"
 version = "0.2.1"
 dependencies = [
  "base64",
+ "block2",
  "chrono",
  "cueward-core",
+ "objc2",
+ "objc2-event-kit",
+ "objc2-foundation",
  "plist",
  "rusqlite",
  "serde",
@@ -383,6 +396,16 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -937,6 +960,57 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-event-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bc9ad7325642172110196bacd6af64027ec5549ded7fc6589ea03e0f792bf8"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]

--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -22,3 +22,7 @@ base64 = "0.22"
 urlencoding = "2"
 uuid = { version = "1", features = ["v4"] }
 ureq = "2"
+objc2 = "0.6"
+block2 = "0.6"
+objc2-foundation = { version = "0.3.2", features = ["NSArray", "NSCalendar", "NSDate", "NSString", "NSTimeZone", "NSEnumerator"] }
+objc2-event-kit = { version = "0.3.2", default-features = false, features = ["std", "block2", "EKCalendar", "EKCalendarItem", "EKEventStore", "EKReminder", "EKObject", "EKTypes"] }

--- a/crates/adapter-macos/src/reminders.rs
+++ b/crates/adapter-macos/src/reminders.rs
@@ -5,6 +5,7 @@ use crate::MacosError;
 use crate::applescript::{escape, run_capture};
 
 mod crud;
+mod eventkit;
 
 pub use crud::{
     ReminderSelector, complete_reminder, create_reminder, delete_reminder, update_reminder,
@@ -210,6 +211,10 @@ fn build_list_script(list_filter: Option<&str>) -> String {
 }
 
 pub fn list(list_filter: Option<&str>) -> Result<Vec<ReminderItem>, MacosError> {
+    if let Some(reminders) = eventkit::list(list_filter)? {
+        return Ok(reminders);
+    }
+
     let stdout = run_capture(&build_list_script(list_filter), "list_reminders")?;
     Ok(parse_reminders_output(&stdout))
 }
@@ -296,6 +301,15 @@ pub fn list_due_between(
     to: DateTime<Local>,
     list_filter: Option<&str>,
 ) -> Result<Vec<ReminderItem>, MacosError> {
+    if let Some(reminders) = eventkit::list(list_filter)? {
+        return Ok(
+            reminders
+                .into_iter()
+                .filter(|reminder| reminder_due_in_range(reminder, from, to))
+                .collect(),
+        );
+    }
+
     let stdout = run_capture(
         &build_due_range_script(&from.to_rfc3339(), &to.to_rfc3339(), list_filter),
         "list_reminders_due_between",
@@ -325,6 +339,24 @@ pub fn today() -> Result<Vec<ReminderItem>, MacosError> {
         MacosError::Other(message) => MacosError::Other(format!("today_reminders: {message}")),
         other => other,
     })
+}
+
+fn reminder_due_in_range(reminder: &ReminderItem, from: DateTime<Local>, to: DateTime<Local>) -> bool {
+    reminder
+        .due_date
+        .as_deref()
+        .and_then(parse_due_date)
+        .map(|due| due >= from && due <= to)
+        .unwrap_or(false)
+}
+
+fn parse_due_date(value: &str) -> Option<DateTime<Local>> {
+    let naive = chrono::NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S").ok()?;
+    Local
+        .from_local_datetime(&naive)
+        .single()
+        .or_else(|| Local.from_local_datetime(&naive).earliest())
+        .or_else(|| Local.from_local_datetime(&naive).latest())
 }
 
 #[cfg(test)]

--- a/crates/adapter-macos/src/reminders.rs
+++ b/crates/adapter-macos/src/reminders.rs
@@ -139,8 +139,8 @@ fn reminders_script_prelude() -> String {
     )
 }
 
-fn build_list_script(list_filter: Option<&str>) -> String {
-    let list_filter_block = match list_filter {
+fn build_target_lists_block(list_filter: Option<&str>) -> String {
+    match list_filter {
         Some(name) => {
             let escaped = escape(name);
             format!(
@@ -151,7 +151,45 @@ fn build_list_script(list_filter: Option<&str>) -> String {
             )
         }
         None => "set targetLists to lists".to_string(),
-    };
+    }
+}
+
+fn reminder_rows_block(filter_clause: Option<&str>) -> String {
+    let filter_clause = filter_clause.unwrap_or("set shouldInclude to true");
+    format!(
+        r#"
+                set reminderProps to properties of reminders of aList
+                repeat with reminderInfo in reminderProps
+                    set reminderDueValue to due date of reminderInfo
+                    {filter_clause}
+                    if shouldInclude then
+                        set reminderId to my encode_field(id of reminderInfo)
+                        set reminderTitle to my encode_field(name of reminderInfo)
+                        if body of reminderInfo is missing value then
+                            set reminderNotes to ""
+                        else
+                            set reminderNotes to my encode_field(body of reminderInfo)
+                        end if
+                        if reminderDueValue is missing value then
+                            set reminderDue to ""
+                        else
+                            set reminderDue to my format_reminder_date(reminderDueValue)
+                        end if
+                        if completed of reminderInfo then
+                            set reminderCompleted to "true"
+                        else
+                            set reminderCompleted to "false"
+                        end if
+                        set output to output & reminderId & tab & reminderTitle & tab & reminderNotes & tab & reminderDue & tab & reminderCompleted & tab & listName & "{REMINDER_SEPARATOR}"
+                    end if
+                end repeat
+        "#,
+    )
+}
+
+fn build_list_script(list_filter: Option<&str>) -> String {
+    let list_filter_block = build_target_lists_block(list_filter);
+    let reminder_rows = reminder_rows_block(None);
 
     format!(
         r#"
@@ -161,31 +199,13 @@ fn build_list_script(list_filter: Option<&str>) -> String {
             {list_filter_block}
             repeat with aList in targetLists
                 set listName to my encode_field(name of aList)
-                repeat with aReminder in reminders of aList
-                    set reminderId to my encode_field(id of aReminder)
-                    set reminderTitle to my encode_field(name of aReminder)
-                    if body of aReminder is missing value then
-                        set reminderNotes to ""
-                    else
-                        set reminderNotes to my encode_field(body of aReminder)
-                    end if
-                    if due date of aReminder is missing value then
-                        set reminderDue to ""
-                    else
-                        set reminderDue to my format_reminder_date(due date of aReminder)
-                    end if
-                    if completed of aReminder then
-                        set reminderCompleted to "true"
-                    else
-                        set reminderCompleted to "false"
-                    end if
-                    set output to output & reminderId & tab & reminderTitle & tab & reminderNotes & tab & reminderDue & tab & reminderCompleted & tab & listName & "{REMINDER_SEPARATOR}"
-                end repeat
+                {reminder_rows}
             end repeat
             return output
         end tell
         "#,
         prelude = reminders_script_prelude(),
+        reminder_rows = reminder_rows,
     )
 }
 
@@ -194,7 +214,7 @@ pub fn list(list_filter: Option<&str>) -> Result<Vec<ReminderItem>, MacosError> 
     Ok(parse_reminders_output(&stdout))
 }
 
-fn build_today_script(from: &str, to: &str) -> String {
+fn build_due_range_script(from: &str, to: &str, list_filter: Option<&str>) -> String {
     let from_dt = DateTime::parse_from_rfc3339(from)
         .ok()
         .map(|dt| dt.with_timezone(&Local))
@@ -205,6 +225,18 @@ fn build_today_script(from: &str, to: &str) -> String {
         .unwrap_or_else(Local::now);
     let (from_year, from_month, from_day, from_seconds) = local_datetime_components(&from_dt);
     let (to_year, to_month, to_day, to_seconds) = local_datetime_components(&to_dt);
+    let list_filter_block = build_target_lists_block(list_filter);
+    let reminder_rows = reminder_rows_block(Some(
+        r#"if reminderDueValue is not missing value then
+                        if reminderDueValue is greater than or equal to fromDate and reminderDueValue is less than or equal to toDate then
+                            set shouldInclude to true
+                        else
+                            set shouldInclude to false
+                        end if
+                    else
+                        set shouldInclude to false
+                    end if"#,
+    ));
 
     format!(
         r#"
@@ -221,25 +253,10 @@ fn build_today_script(from: &str, to: &str) -> String {
             set day of toDate to {to_day}
             set time of toDate to {to_seconds}
             set output to ""
-            repeat with aList in lists
+            {list_filter_block}
+            repeat with aList in targetLists
                 set listName to my encode_field(name of aList)
-                set matchingReminders to (reminders of aList whose due date is not missing value and due date is greater than or equal to fromDate and due date is less than or equal to toDate)
-                repeat with aReminder in matchingReminders
-                    set reminderId to my encode_field(id of aReminder)
-                    set reminderTitle to my encode_field(name of aReminder)
-                    if body of aReminder is missing value then
-                        set reminderNotes to ""
-                    else
-                        set reminderNotes to my encode_field(body of aReminder)
-                    end if
-                    set reminderDue to my format_reminder_date(due date of aReminder)
-                    if completed of aReminder then
-                        set reminderCompleted to "true"
-                    else
-                        set reminderCompleted to "false"
-                    end if
-                    set output to output & reminderId & tab & reminderTitle & tab & reminderNotes & tab & reminderDue & tab & reminderCompleted & tab & listName & "{REMINDER_SEPARATOR}"
-                end repeat
+                {reminder_rows}
             end repeat
             return output
         end tell
@@ -253,7 +270,26 @@ fn build_today_script(from: &str, to: &str) -> String {
         to_month = to_month,
         to_day = to_day,
         to_seconds = to_seconds,
+        list_filter_block = list_filter_block,
+        reminder_rows = reminder_rows,
     )
+}
+
+pub fn list_due_between(
+    from: DateTime<Local>,
+    to: DateTime<Local>,
+    list_filter: Option<&str>,
+) -> Result<Vec<ReminderItem>, MacosError> {
+    let stdout = run_capture(
+        &build_due_range_script(&from.to_rfc3339(), &to.to_rfc3339(), list_filter),
+        "list_reminders_due_between",
+    )?;
+    Ok(parse_reminders_output(&stdout))
+}
+
+#[cfg(test)]
+fn build_today_script(from: &str, to: &str) -> String {
+    build_due_range_script(from, to, None)
 }
 
 pub fn today() -> Result<Vec<ReminderItem>, MacosError> {
@@ -269,18 +305,20 @@ pub fn today() -> Result<Vec<ReminderItem>, MacosError> {
         .and_then(|dt| Local.from_local_datetime(&dt).single())
         .ok_or_else(|| MacosError::Other("failed to determine end of today".into()))?;
 
-    let stdout = run_capture(
-        &build_today_script(&from.to_rfc3339(), &to.to_rfc3339()),
-        "today_reminders",
-    )?;
-    Ok(parse_reminders_output(&stdout))
+    list_due_between(from, to, None).map_err(|err| match err {
+        MacosError::Other(message) => MacosError::Other(format!("today_reminders: {message}")),
+        other => other,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use chrono::{Local, TimeZone};
 
-    use super::{REMINDER_SEPARATOR, build_list_script, build_today_script, parse_reminder_line, parse_reminders_output};
+    use super::{
+        REMINDER_SEPARATOR, build_list_script, build_today_script, parse_reminder_line,
+        parse_reminders_output,
+    };
 
     #[test]
     fn parse_reminder_line_unescapes_fields() {
@@ -331,9 +369,37 @@ mod tests {
         assert!(!today_script.contains("class isot"));
         assert!(list_script.contains("format_reminder_date"));
         assert!(today_script.contains("format_reminder_date"));
-        assert!(list_script.contains("set reminderId to my encode_field(id of aReminder)"));
+        assert!(list_script.contains("set reminderId to my encode_field(id of reminderInfo)"));
         assert!(list_script.contains("set reminderCompleted to \"true\""));
-        assert!(today_script.contains("set matchingReminders to"));
+        assert!(today_script.contains("set reminderProps to properties of reminders of aList"));
+    }
+
+    #[test]
+    fn list_script_uses_bulk_properties_lookup() {
+        let script = build_list_script(None);
+
+        assert!(script.contains("set reminderProps to properties of reminders of aList"));
+        assert!(!script.contains("repeat with aReminder in reminders of aList"));
+        assert!(!script.contains("id of aReminder"));
+        assert!(!script.contains("name of aReminder"));
+    }
+
+    #[test]
+    fn today_script_filters_due_dates_without_whose_clause() {
+        let from = Local
+            .with_ymd_and_hms(2026, 4, 11, 0, 0, 0)
+            .single()
+            .expect("from");
+        let to = Local
+            .with_ymd_and_hms(2026, 4, 11, 23, 59, 59)
+            .single()
+            .expect("to");
+        let script = build_today_script(&from.to_rfc3339(), &to.to_rfc3339());
+
+        assert!(script.contains("if reminderDueValue is not missing value then"));
+        assert!(script.contains("if reminderDueValue is greater than or equal to fromDate and reminderDueValue is less than or equal to toDate then"));
+        assert!(!script.contains("set matchingReminders to"));
+        assert!(!script.contains("whose due date is not missing value"));
     }
 
     #[test]

--- a/crates/adapter-macos/src/reminders.rs
+++ b/crates/adapter-macos/src/reminders.rs
@@ -231,7 +231,8 @@ fn build_due_range_script(from: &str, to: &str, list_filter: Option<&str>) -> St
     let (from_year, from_month, from_day, from_seconds) = local_datetime_components(&from_dt);
     let (to_year, to_month, to_day, to_seconds) = local_datetime_components(&to_dt);
     let list_filter_block = build_target_lists_block(list_filter);
-    let reminder_rows = r#"
+    let reminder_rows = format!(
+        r#"
                 set reminderRefs to reminders of aList
                 set reminderDueValues to due date of every reminder of aList
                 set reminderCount to count of reminderDueValues
@@ -257,7 +258,8 @@ fn build_due_range_script(from: &str, to: &str, list_filter: Option<&str>) -> St
                         end if
                     end if
                 end repeat
-    "#;
+    "#,
+    );
 
     format!(
         r#"
@@ -453,6 +455,8 @@ mod tests {
         assert!(!script.contains("set matchingReminders to"));
         assert!(!script.contains("set reminderProps to properties of reminders of aList"));
         assert!(!script.contains("whose due date is not missing value"));
+        assert!(script.contains(REMINDER_SEPARATOR));
+        assert!(!script.contains("{REMINDER_SEPARATOR}"));
     }
 
     #[test]

--- a/crates/adapter-macos/src/reminders.rs
+++ b/crates/adapter-macos/src/reminders.rs
@@ -226,17 +226,33 @@ fn build_due_range_script(from: &str, to: &str, list_filter: Option<&str>) -> St
     let (from_year, from_month, from_day, from_seconds) = local_datetime_components(&from_dt);
     let (to_year, to_month, to_day, to_seconds) = local_datetime_components(&to_dt);
     let list_filter_block = build_target_lists_block(list_filter);
-    let reminder_rows = reminder_rows_block(Some(
-        r#"if reminderDueValue is not missing value then
+    let reminder_rows = r#"
+                set reminderRefs to reminders of aList
+                set reminderDueValues to due date of every reminder of aList
+                set reminderCount to count of reminderDueValues
+                repeat with idx from 1 to reminderCount
+                    set reminderDueValue to item idx of reminderDueValues
+                    if reminderDueValue is not missing value then
                         if reminderDueValue is greater than or equal to fromDate and reminderDueValue is less than or equal to toDate then
-                            set shouldInclude to true
-                        else
-                            set shouldInclude to false
+                            set reminderRef to item idx of reminderRefs
+                            set reminderId to my encode_field(id of reminderRef)
+                            set reminderTitle to my encode_field(name of reminderRef)
+                            if body of reminderRef is missing value then
+                                set reminderNotes to ""
+                            else
+                                set reminderNotes to my encode_field(body of reminderRef)
+                            end if
+                            set reminderDue to my format_reminder_date(reminderDueValue)
+                            if completed of reminderRef then
+                                set reminderCompleted to "true"
+                            else
+                                set reminderCompleted to "false"
+                            end if
+                            set output to output & reminderId & tab & reminderTitle & tab & reminderNotes & tab & reminderDue & tab & reminderCompleted & tab & listName & "{REMINDER_SEPARATOR}"
                         end if
-                    else
-                        set shouldInclude to false
-                    end if"#,
-    ));
+                    end if
+                end repeat
+    "#;
 
     format!(
         r#"
@@ -371,7 +387,8 @@ mod tests {
         assert!(today_script.contains("format_reminder_date"));
         assert!(list_script.contains("set reminderId to my encode_field(id of reminderInfo)"));
         assert!(list_script.contains("set reminderCompleted to \"true\""));
-        assert!(today_script.contains("set reminderProps to properties of reminders of aList"));
+        assert!(today_script.contains("set reminderRefs to reminders of aList"));
+        assert!(today_script.contains("set reminderDueValues to due date of every reminder of aList"));
     }
 
     #[test]
@@ -396,9 +413,13 @@ mod tests {
             .expect("to");
         let script = build_today_script(&from.to_rfc3339(), &to.to_rfc3339());
 
+        assert!(script.contains("set reminderRefs to reminders of aList"));
+        assert!(script.contains("set reminderDueValues to due date of every reminder of aList"));
         assert!(script.contains("if reminderDueValue is not missing value then"));
         assert!(script.contains("if reminderDueValue is greater than or equal to fromDate and reminderDueValue is less than or equal to toDate then"));
+        assert!(script.contains("set reminderRef to item idx of reminderRefs"));
         assert!(!script.contains("set matchingReminders to"));
+        assert!(!script.contains("set reminderProps to properties of reminders of aList"));
         assert!(!script.contains("whose due date is not missing value"));
     }
 

--- a/crates/adapter-macos/src/reminders/eventkit.rs
+++ b/crates/adapter-macos/src/reminders/eventkit.rs
@@ -1,0 +1,126 @@
+use std::sync::mpsc;
+use std::time::Duration as StdDuration;
+
+use block2::RcBlock;
+use objc2::rc::Retained;
+use objc2_event_kit::{
+    EKAuthorizationStatus, EKCalendar, EKEntityType, EKEventStore, EKReminder,
+};
+use objc2_foundation::{NSArray, NSDateComponentUndefined};
+
+use crate::MacosError;
+
+use super::ReminderItem;
+
+pub(super) fn list(list_filter: Option<&str>) -> Result<Option<Vec<ReminderItem>>, MacosError> {
+    if !authorization_allows_reminder_reads() {
+        return Ok(None);
+    }
+
+    let store = unsafe { EKEventStore::new() };
+    let calendars = filtered_calendars(&store, list_filter)?;
+    let predicate = unsafe { store.predicateForRemindersInCalendars(calendars.as_deref()) };
+    let reminders = fetch_reminders(&store, &predicate)?;
+    let items = reminders
+        .iter()
+        .map(|reminder| reminder_to_item(reminder))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Some(items))
+}
+
+fn authorization_allows_reminder_reads() -> bool {
+    let status = unsafe { EKEventStore::authorizationStatusForEntityType(EKEntityType::Reminder) };
+    status == EKAuthorizationStatus::FullAccess
+}
+
+fn filtered_calendars(
+    store: &EKEventStore,
+    list_filter: Option<&str>,
+) -> Result<Option<Retained<NSArray<EKCalendar>>>, MacosError> {
+    let Some(filter) = list_filter else {
+        return Ok(None);
+    };
+
+    let calendars = unsafe { store.calendarsForEntityType(EKEntityType::Reminder) };
+    let matching = calendars
+        .to_vec()
+        .into_iter()
+        .filter(|calendar| unsafe { calendar.title() }.to_string() == filter)
+        .collect::<Vec<_>>();
+
+    Ok(Some(NSArray::from_retained_slice(&matching)))
+}
+
+fn fetch_reminders(
+    store: &EKEventStore,
+    predicate: &objc2_foundation::NSPredicate,
+) -> Result<Vec<Retained<EKReminder>>, MacosError> {
+    let (sender, receiver) = mpsc::sync_channel(1);
+    let completion = RcBlock::new(move |reminders_ptr: *mut NSArray<EKReminder>| {
+        let reminders = unsafe { reminders_ptr.as_ref() }
+            .map(|array| array.to_vec())
+            .unwrap_or_default();
+        let _ = sender.send(reminders);
+    });
+
+    let _fetch_id = unsafe {
+        store.fetchRemindersMatchingPredicate_completion(predicate, &completion)
+    };
+
+    receiver
+        .recv_timeout(StdDuration::from_secs(10))
+        .map_err(|_| MacosError::Other("eventkit reminders fetch timed out".into()))
+}
+
+fn reminder_to_item(reminder: &EKReminder) -> Result<ReminderItem, MacosError> {
+    let id = unsafe { reminder.calendarItemIdentifier() }.to_string();
+    let title = unsafe { reminder.title() }.to_string();
+    let notes = unsafe { reminder.notes() }
+        .map(|notes| notes.to_string())
+        .unwrap_or_default();
+    let due_date = unsafe { reminder.dueDateComponents() }
+        .as_deref()
+        .and_then(date_components_to_string);
+    let completed = unsafe { reminder.isCompleted() };
+    let list_name = unsafe { reminder.calendar() }
+        .map(|calendar| unsafe { calendar.title() }.to_string())
+        .unwrap_or_default();
+
+    Ok(ReminderItem {
+        id: format!("x-apple-reminder://{id}"),
+        title,
+        notes,
+        due_date,
+        completed,
+        list_name,
+    })
+}
+
+fn date_components_to_string(components: &objc2_foundation::NSDateComponents) -> Option<String> {
+    let year = components.year();
+    let month = components.month();
+    let day = components.day();
+
+    if year == NSDateComponentUndefined
+        || month == NSDateComponentUndefined
+        || day == NSDateComponentUndefined
+    {
+        return None;
+    }
+
+    let hour = zero_if_undefined(components.hour());
+    let minute = zero_if_undefined(components.minute());
+    let second = zero_if_undefined(components.second());
+
+    Some(format!(
+        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}"
+    ))
+}
+
+fn zero_if_undefined(value: isize) -> isize {
+    if value == NSDateComponentUndefined {
+        0
+    } else {
+        value
+    }
+}

--- a/crates/cli/src/commands/reminders.rs
+++ b/crates/cli/src/commands/reminders.rs
@@ -172,31 +172,54 @@ pub(crate) fn dispatch(action: RemindersAction) {
             due_before,
             due_tomorrow,
         } => {
-            match cueward_adapter_macos::reminders::list(list.as_deref()) {
-                Ok(reminders) => {
-                    let due_before_dt = match due_before.as_deref() {
-                        Some(value) => match normalize_due_before_cutoff(value) {
-                            Ok(dt) => Some(dt),
-                            Err(err) => {
-                                eprintln!("{err}");
-                                process::exit(1);
-                            }
-                        },
-                        None => None,
-                    };
-                    let tomorrow_bounds = if due_tomorrow {
-                        let tomorrow = Local::now() + Duration::days(1);
-                        match local_day_bounds(tomorrow) {
-                            Ok(bounds) => Some(bounds),
-                            Err(err) => {
-                                eprintln!("{err}");
-                                process::exit(1);
-                            }
-                        }
+            let due_before_dt = match due_before.as_deref() {
+                Some(value) => match normalize_due_before_cutoff(value) {
+                    Ok(dt) => Some(dt),
+                    Err(err) => {
+                        eprintln!("{err}");
+                        process::exit(1);
+                    }
+                },
+                None => None,
+            };
+            let tomorrow_bounds = if due_tomorrow {
+                let tomorrow = Local::now() + Duration::days(1);
+                match local_day_bounds(tomorrow) {
+                    Ok(bounds) => Some(bounds),
+                    Err(err) => {
+                        eprintln!("{err}");
+                        process::exit(1);
+                    }
+                }
+            } else {
+                None
+            };
+
+            let reminders_result = match tomorrow_bounds {
+                Some((from, to)) => {
+                    let effective_to = due_before_dt
+                        .map(|cutoff| if cutoff < to { cutoff } else { to })
+                        .unwrap_or(to);
+                    if effective_to < from {
+                        Ok(Vec::new())
                     } else {
-                        None
+                        cueward_adapter_macos::reminders::list_due_between(
+                            from,
+                            effective_to,
+                            list.as_deref(),
+                        )
+                    }
+                }
+                None => cueward_adapter_macos::reminders::list(list.as_deref()),
+            };
+
+            match reminders_result {
+                Ok(reminders) => {
+                    let reminders = if due_tomorrow {
+                        reminders
+                    } else {
+                        filter_reminders(reminders, due_before_dt, tomorrow_bounds)
                     };
-                    let reminders = filter_reminders(reminders, due_before_dt, tomorrow_bounds);
                     println!("{}", serde_json::to_string_pretty(&reminders).unwrap());
                     eprintln!("{} reminder(s)", reminders.len());
                 }


### PR DESCRIPTION
## Summary
- switch reminders read paths to EventKit with AppleScript fallback
- keep create/update/delete on the existing AppleScript path for now
- preserve reminders CLI behavior while removing the AppleScript performance bottleneck

## Test Plan
- [x] cargo test
- [x] cargo build --release
- [x] local benchmark: `reminders list`, `reminders list --due-tomorrow`, `reminders today`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
