### PR TITLE
feat: prefer EventKit for calendar reads

### DIFF
--- a/crates/adapter-macos/Cargo.toml
+++ b/crates/adapter-macos/Cargo.toml
@@ -25,4 +25,4 @@ ureq = "2"
 objc2 = "0.6"
 block2 = "0.6"
 objc2-foundation = { version = "0.3.2", features = ["NSArray", "NSCalendar", "NSDate", "NSString", "NSTimeZone", "NSEnumerator"] }
-objc2-event-kit = { version = "0.3.2", default-features = false, features = ["std", "block2", "EKCalendar", "EKCalendarItem", "EKEventStore", "EKReminder", "EKObject", "EKTypes"] }
+objc2-event-kit = { version = "0.3.2", default-features = false, features = ["std", "block2", "EKCalendar", "EKCalendarItem", "EKEvent", "EKEventStore", "EKReminder", "EKObject", "EKTypes"] }

--- a/crates/adapter-macos/src/calendar.rs
+++ b/crates/adapter-macos/src/calendar.rs
@@ -4,6 +4,9 @@ use serde::Serialize;
 use crate::MacosError;
 use crate::applescript::{applescript_date_block, escape, escape_body, run, run_capture};
 
+#[path = "calendar_eventkit.rs"]
+mod eventkit;
+
 const EVENT_SEPARATOR: &str = "---EVENT_SEP---";
 
 #[derive(Serialize)]
@@ -77,6 +80,10 @@ pub fn list_events(
     to: DateTime<Local>,
     calendar_filter: Option<&str>,
 ) -> Result<Vec<CalendarEvent>, MacosError> {
+    if let Some(events) = eventkit::list_events(from, to, calendar_filter)? {
+        return Ok(events);
+    }
+
     let from_block = applescript_date_block("fromDate", &from);
     let to_block = applescript_date_block("toDate", &to);
 
@@ -256,7 +263,10 @@ fn build_update_script(
 
     let mut actions = Vec::new();
     if let Some(new_title) = new_title {
-        actions.push(format!(r#"set summary of targetEvt to "{}""#, escape(new_title)));
+        actions.push(format!(
+            r#"set summary of targetEvt to "{}""#,
+            escape(new_title)
+        ));
     }
     match (new_start.is_some(), new_end.is_some()) {
         (true, true) => {
@@ -264,9 +274,13 @@ fn build_update_script(
             actions.push("set end date of targetEvt to newEndDate".to_string());
         }
         (true, false) => {
-            actions.push("set originalDuration to (end date of targetEvt) - (start date of targetEvt)".to_string());
+            actions.push(
+                "set originalDuration to (end date of targetEvt) - (start date of targetEvt)"
+                    .to_string(),
+            );
             actions.push("set start date of targetEvt to newStartDate".to_string());
-            actions.push("set end date of targetEvt to newStartDate + originalDuration".to_string());
+            actions
+                .push("set end date of targetEvt to newStartDate + originalDuration".to_string());
         }
         (false, true) => {
             actions.push("set end date of targetEvt to newEndDate".to_string());
@@ -274,10 +288,16 @@ fn build_update_script(
         (false, false) => {}
     }
     if let Some(notes) = notes {
-        actions.push(format!("set description of targetEvt to {}", escape_body(notes)));
+        actions.push(format!(
+            "set description of targetEvt to {}",
+            escape_body(notes)
+        ));
     }
     if let Some(location) = location {
-        actions.push(format!("set location of targetEvt to {}", escape_body(location)));
+        actions.push(format!(
+            "set location of targetEvt to {}",
+            escape_body(location)
+        ));
     }
 
     format!(
@@ -395,8 +415,12 @@ mod tests {
         );
 
         assert!(script.contains(r#"set targetCals to (calendars whose name is "Work")"#));
-        assert!(script.contains(r#"repeat with evt in (events of aCal whose summary is "顧問會議")"#));
-        assert!(script.contains("set originalDuration to (end date of targetEvt) - (start date of targetEvt)"));
+        assert!(
+            script.contains(r#"repeat with evt in (events of aCal whose summary is "顧問會議")"#)
+        );
+        assert!(script.contains(
+            "set originalDuration to (end date of targetEvt) - (start date of targetEvt)"
+        ));
         assert!(script.contains("set start date of targetEvt to newStartDate"));
         assert!(script.contains("set end date of targetEvt to newStartDate + originalDuration"));
         assert!(script.contains(r#"set summary of targetEvt to "顧問會議（改期）""#));

--- a/crates/adapter-macos/src/calendar_eventkit.rs
+++ b/crates/adapter-macos/src/calendar_eventkit.rs
@@ -1,0 +1,117 @@
+use chrono::{DateTime, Local, TimeZone};
+use objc2::rc::Retained;
+use objc2_event_kit::{EKAuthorizationStatus, EKCalendar, EKEntityType, EKEvent, EKEventStore};
+use objc2_foundation::NSArray;
+
+use crate::MacosError;
+
+use super::CalendarEvent;
+
+pub(super) fn list_events(
+    from: DateTime<Local>,
+    to: DateTime<Local>,
+    calendar_filter: Option<&str>,
+) -> Result<Option<Vec<CalendarEvent>>, MacosError> {
+    if !authorization_allows_event_reads() {
+        return Ok(None);
+    }
+
+    let store = unsafe { EKEventStore::new() };
+    let calendars = filtered_calendars(&store, calendar_filter)?;
+    let from_date =
+        objc2_foundation::NSDate::dateWithTimeIntervalSince1970(from.timestamp() as f64);
+    let to_date = objc2_foundation::NSDate::dateWithTimeIntervalSince1970(to.timestamp() as f64);
+    let predicate = unsafe {
+        store.predicateForEventsWithStartDate_endDate_calendars(
+            &from_date,
+            &to_date,
+            calendars.as_deref(),
+        )
+    };
+    let events = unsafe { store.eventsMatchingPredicate(&predicate) };
+    let items = events
+        .to_vec()
+        .into_iter()
+        .map(|event| event_to_item(&event))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Some(items))
+}
+
+fn authorization_allows_event_reads() -> bool {
+    let status = unsafe { EKEventStore::authorizationStatusForEntityType(EKEntityType::Event) };
+    status == EKAuthorizationStatus::FullAccess
+}
+
+fn filtered_calendars(
+    store: &EKEventStore,
+    calendar_filter: Option<&str>,
+) -> Result<Option<Retained<NSArray<EKCalendar>>>, MacosError> {
+    let Some(filter) = calendar_filter else {
+        return Ok(None);
+    };
+
+    let calendars = unsafe { store.calendarsForEntityType(EKEntityType::Event) };
+    let matching = calendars
+        .to_vec()
+        .into_iter()
+        .filter(|calendar| unsafe { calendar.title() }.to_string() == filter)
+        .collect::<Vec<_>>();
+
+    Ok(Some(NSArray::from_retained_slice(&matching)))
+}
+
+fn event_to_item(event: &EKEvent) -> Result<CalendarEvent, MacosError> {
+    let title = unsafe { event.title() }.to_string();
+    let start = nsdate_to_calendar_string(unsafe { event.startDate() }.as_ref())?;
+    let end = nsdate_to_calendar_string(unsafe { event.endDate() }.as_ref())?;
+    let calendar = unsafe { event.calendar() }
+        .map(|calendar| unsafe { calendar.title() }.to_string())
+        .unwrap_or_default();
+    let location = unsafe { event.location() }
+        .map(|value| value.to_string())
+        .unwrap_or_default();
+    let notes = unsafe { event.notes() }
+        .map(|value| value.to_string())
+        .unwrap_or_default();
+    let all_day = unsafe { event.isAllDay() };
+
+    Ok(CalendarEvent {
+        title,
+        start,
+        end,
+        calendar,
+        location,
+        notes,
+        all_day,
+    })
+}
+
+fn nsdate_to_calendar_string(date: &objc2_foundation::NSDate) -> Result<String, MacosError> {
+    let timestamp = date.timeIntervalSince1970();
+    let local = Local
+        .timestamp_opt(timestamp as i64, 0)
+        .single()
+        .ok_or_else(|| MacosError::Other(format!("invalid EventKit date: {timestamp}")))?;
+    Ok(local.format("%Y-%m-%dT%H:%M:%S").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Local, TimeZone};
+
+    use super::nsdate_to_calendar_string;
+
+    #[test]
+    fn eventkit_dates_format_like_calendar_output() {
+        let local = Local
+            .with_ymd_and_hms(2026, 4, 21, 16, 30, 45)
+            .single()
+            .expect("local datetime");
+        let date =
+            objc2_foundation::NSDate::dateWithTimeIntervalSince1970(local.timestamp() as f64);
+
+        let formatted = nsdate_to_calendar_string(&date).expect("formatted date");
+
+        assert_eq!(formatted, "2026-04-21T16:30:45");
+    }
+}


### PR DESCRIPTION
## Summary
- prefer EventKit for `calendar list` / `calendar today` read paths
- keep AppleScript as fallback when Calendar only has `writeOnly` EventKit access
- document the `#115` investigation findings in the implementation shape

## What Changed
- add `calendar_eventkit.rs` to read `EKEvent` fields needed by current CLI output
- switch `calendar::list_events` to `EventKit -> AppleScript fallback`
- enable the `EKEvent` feature in `objc2-event-kit`

## Investigation Notes
- AppleScript Calendar reads are not uniformly slow; the pathological path is date-range event queries like:
  - `events of calendar X whose (start date < toDate) and (end date > fromDate)`
- On this machine, several calendars time out or take multiple seconds on that path even when unfiltered event counts are fast
- EventKit is the correct read path, but this machine currently reports `EKEventStore.authorizationStatus(for: .event) == writeOnly`, so read access is not yet available locally
- Because of that, this PR intentionally keeps AppleScript fallback instead of forcing an EventKit-only migration

## Verification
- `cargo test -p cueward-adapter-macos calendar -- --nocapture`
- `cargo test`
- `cargo build --release`
- live smoke:
  - create temporary event in `家庭`
  - `cueward calendar list --calendar 家庭`
  - delete temporary event

Closes #115

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hcyt/cueward/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
